### PR TITLE
CI: Separate caches.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,8 +75,11 @@ jobs:
         continue-on-error: true
         with:
           release-name: v0.3.1
-          cache-key: cargo-${{ matrix.os }}-${{matrix.rust}}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain', 'rust-toolchain.toml') }}
-          cache-update: false # It contains the lock file, should be immutable.
+          # Caching everything separately, in case they don't ask for the same things to be compiled.
+          cache-key: ${{ matrix.make.name }}-${{ matrix.os }}-${{matrix.rust}}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain', 'rust-toolchain.toml') }}
+          # Not sure why we should ever update a cache that has the hash of the lock file in it.
+          # In Forest it only contains the rust-toolchain, so it makes sense to update because dependencies could have changed.
+          cache-update: false
 
       - name: ${{ matrix.make.name }}
         run: make ${{ matrix.make.task }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,9 @@ jobs:
       RUST_BACKTRACE: full
       RUSTFLAGS: -Dwarnings
       CARGO_INCREMENTAL: '0'
-      SCCACHE_CACHE_SIZE: 2G
+      SCCACHE_CACHE_SIZE: 10G
+      CC: "sccache clang"
+      CXX: "sccache clang++"
 
     steps:
       - name: Check out the project

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ all: test build
 build:
 	cargo build --release
 
+# Using --release for testing because wasm can otherwise be slow.
 test:
 	cargo test --release
 
@@ -23,4 +24,4 @@ check-fmt:
 	cargo fmt --all --check
 
 check-clippy:
-	cargo clippy --all --release -- -D warnings
+	cargo clippy --all -- -D warnings


### PR DESCRIPTION
Looking at the `sccache` setup and post logs [before](https://github.com/consensus-shipyard/fendermint/actions/runs/4057626181 and [after](https://github.com/consensus-shipyard/fendermint/actions/runs/4057880432) merging a PR, the cache behaviour is confusing. Before the merge, the logs say the cache is found for `Lint (stable)` and `Test (stable)`, but both have 100% cache misses. `Test (nightly)` works as expected. After the merge, on `master`, no caches are found, even though the restore key is the same. 

I will try to separate the Lint and Test caches, maybe that will at least make them behave like nightly and avoid the cache hits.

Ah, Github isolates caches per branch: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache