### PR TITLE
FM-11: Message model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e90af4de65aa7b293ef2d09daff88501eb254f58edde2e1ac02c82d873eadad"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,9 +624,12 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ed9c8b2d17acb8110c46f1da5bf4a696d745e1474a16db0cd2b49cd0249bf2"
 dependencies = [
+ "arbitrary",
  "core2",
  "multibase",
  "multihash",
+ "quickcheck",
+ "rand 0.7.3",
  "serde",
  "serde_bytes",
  "unsigned-varint",
@@ -1219,6 +1228,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1350,6 +1369,18 @@ dependencies = [
  "fvm_ipld_car",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "fendermint_vm_message"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_shared 3.0.0-alpha.17",
+ "serde",
+ "serde_tuple",
 ]
 
 [[package]]
@@ -3223,12 +3254,15 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
 dependencies = [
+ "arbitrary",
  "blake2b_simd",
  "blake2s_simd 1.0.0",
  "blake3",
  "core2",
  "digest 0.10.6",
  "multihash-derive",
+ "quickcheck",
+ "rand 0.7.3",
  "ripemd",
  "serde",
  "serde-big-array",
@@ -3790,6 +3824,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "quickcheck"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["fendermint/*"]
+members = ["fendermint/abci", "fendermint/app", "fendermint/vm/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -11,11 +11,14 @@ license-file = "LICENSE-APACHE"
 
 
 [workspace.dependencies]
-async-trait = "0.1.61"
+async-trait = "0.1"
 futures = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 tempfile = "3.3"
-
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_tuple = "0.5"
+cid = { version = "0.8", default-features = false, features = ["serde-codec", "std", "arb"] }
 
 # Stable FVM dependencies from crates.io
 fvm_ipld_blockstore = "0.1"

--- a/fendermint/vm/message/Cargo.toml
+++ b/fendermint/vm/message/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fendermint_vm_message"
+description = "Messages (transactions) received on chain and passed on to the FVM"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+cid = { workspace = true }
+serde = { workspace = true }
+serde_tuple = { workspace = true }
+fvm_shared = { workspace = true }
+fvm_ipld_encoding = { workspace = true }

--- a/fendermint/vm/message/src/chain_message.rs
+++ b/fendermint/vm/message/src/chain_message.rs
@@ -1,0 +1,32 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+use serde::{Deserialize, Serialize};
+
+use crate::signed_message::SignedMessage;
+
+/// The different kinds of messages that can appear in blocks, ie. the transactions
+/// we can receive from Tendermint through the ABCI.
+///
+/// Unlike Filecoin, we don't have `Unsigned` messages here. In Filecoin, the messages
+/// signed by BLS signatures are aggregated to the block level, and their original
+/// signatures are stripped from the messages, to save space. Tendermint Core will
+/// not do this for us (perhaps with ABCI++ Vote Extensions we could do it), though.
+#[derive(Clone, Debug, Serialize, Deserialize, Hash)]
+#[serde(untagged)]
+pub enum ChainMessage {
+    /// A message that can be passed on to the FVM as-is.
+    SelfContained(SignedMessage),
+    // TODO: ForResolution - A message CID proposed for async resolution.
+    // This will not need a signature, it is proposed by the validator who made the block.
+    // We might want to add a `from` and a signature anyway if we want to reward relayers.
+    // Or the validator itself can be rewarded for inclusion, since a message like this
+    // will be a top-down or bottom-up message, and this incentivises them to do the relaying.
+
+    // TODO: ForExecution - A message CID proposed for execution in the containing block, assumed to be resolvable.
+    // This will again not need a signature, it is proposed by the validator who made the block.
+    // The reward for this should have two parts:
+    // (1) go to the validator who originally proposed the resolution of this CID, and
+    // (2) go to the validator who proposed the execution.
+    // This should ensure that even if low-power validator poposed a CID, the others aren't neglecting it.
+    // To remember after a restart who the original proposer was, the proposed CIDs have to go onto the ledger.
+}

--- a/fendermint/vm/message/src/lib.rs
+++ b/fendermint/vm/message/src/lib.rs
@@ -1,0 +1,17 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+use cid::{multihash, multihash::MultihashDigest, Cid};
+use fvm_ipld_encoding::{to_vec, Error as IpldError, DAG_CBOR};
+use serde::Serialize;
+
+pub mod signed_message;
+
+/// Calculate the CID using Blake2b256 digest and DAG_CBOR.
+///
+/// This used to be part of the `Cbor` trait, which is deprecated.
+fn cid<T: Serialize>(value: &T) -> Result<Cid, IpldError> {
+    let bz = to_vec(value)?;
+    let digest = multihash::Code::Blake2b256.digest(&bz);
+    let cid = Cid::new_v1(DAG_CBOR, digest);
+    Ok(cid)
+}

--- a/fendermint/vm/message/src/lib.rs
+++ b/fendermint/vm/message/src/lib.rs
@@ -4,6 +4,7 @@ use cid::{multihash, multihash::MultihashDigest, Cid};
 use fvm_ipld_encoding::{to_vec, Error as IpldError, DAG_CBOR};
 use serde::Serialize;
 
+pub mod chain_message;
 pub mod signed_message;
 
 /// Calculate the CID using Blake2b256 digest and DAG_CBOR.

--- a/fendermint/vm/message/src/signed_message.rs
+++ b/fendermint/vm/message/src/signed_message.rs
@@ -1,0 +1,71 @@
+// Copyright 2022-2023 Protocol Labs
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
+use fvm_shared::crypto::signature::{Signature, SignatureType};
+use fvm_shared::message::Message;
+
+/// Represents a wrapped message with signature bytes.
+///
+/// This is the message
+#[derive(PartialEq, Clone, Debug, Serialize_tuple, Deserialize_tuple, Hash, Eq)]
+pub struct SignedMessage {
+    pub message: Message,
+    pub signature: Signature,
+}
+
+impl SignedMessage {
+    /// Generate a new signed message from fields.
+    ///
+    /// The signature will not be verified.
+    pub fn new_unchecked(message: Message, signature: Signature) -> SignedMessage {
+        SignedMessage { message, signature }
+    }
+
+    /// Generate a new signed message from fields.
+    ///
+    /// The signature will be verified.
+    pub fn new_checked(message: Message, signature: Signature) -> anyhow::Result<SignedMessage> {
+        Self::verify_signature(&message, &signature)?;
+        Ok(SignedMessage { message, signature })
+    }
+
+    /// Verify that the message CID was signed by the `from` address.
+    pub fn verify_signature(message: &Message, signature: &Signature) -> anyhow::Result<()> {
+        let cid = crate::cid(&message)?.to_bytes();
+        signature
+            .verify(&cid, &message.from)
+            .map_err(anyhow::Error::msg)
+    }
+
+    /// Verifies that the from address of the message generated the signature.
+    pub fn verify(&self) -> anyhow::Result<()> {
+        Self::verify_signature(&self.message, &self.signature)
+    }
+
+    /// Returns reference to the unsigned message.
+    pub fn message(&self) -> &Message {
+        &self.message
+    }
+
+    /// Returns signature of the signed message.
+    pub fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    /// Consumes self and returns it's unsigned message.
+    pub fn into_message(self) -> Message {
+        self.message
+    }
+
+    /// Checks if the signed message is a BLS message.
+    pub fn is_bls(&self) -> bool {
+        self.signature.signature_type() == SignatureType::BLS
+    }
+
+    /// Checks if the signed message is a SECP message.
+    pub fn is_secp256k1(&self) -> bool {
+        self.signature.signature_type() == SignatureType::Secp256k1
+    }
+}


### PR DESCRIPTION
Closes #11 

The PR brings over parts of the [message](https://github.com/ChainSafe/forest/tree/main/vm/message) crate from Forest. Only the `SignedMessage` was copied more or less as-is; the `ChainMessage` also got an equivalent, but its contents are different.

The location mirrors the `vm` directory in Forest, which I thought might provide some familiar structure, with the eventual `interpreter` dealing with the FVM. But, those Forest modules are not something which I can reuse: they are built against FVM v2 (as opposed to v3 which we are targeting here) and already reflect some parts of Expected Consensus.

NB the `Cbor` trait has been removed from the `builtin-actors` and `ref-fvm`.