### PR TITLE
FM-15: Cron actor interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,12 +1381,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fendermint_vm_actor_interface"
+version = "0.1.0"
+dependencies = [
+ "fvm_shared 3.0.0-alpha.17",
+]
+
+[[package]]
 name = "fendermint_vm_interpreter"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "cid",
+ "fendermint_vm_actor_interface",
  "fendermint_vm_message",
  "fvm",
  "fvm_ipld_blockstore",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,6 +1385,7 @@ name = "fendermint_vm_actor_interface"
 version = "0.1.0"
 dependencies = [
  "fvm_shared 3.0.0-alpha.17",
+ "paste",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,15 @@ anyhow = "1"
 async-trait = "0.1"
 async-stm = "0.1.2"
 futures = "0.3"
+paste = "1"
+serde = { version = "1", features = ["derive"] }
+serde_tuple = "0.5"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 tempfile = "3.3"
 thiserror = "1"
-serde = { version = "1", features = ["derive"] }
-serde_tuple = "0.5"
-cid = { version = "0.8", default-features = false, features = ["serde-codec", "std", "arb"] }
 
 # Stable FVM dependencies from crates.io
+cid = { version = "0.8", default-features = false, features = ["serde-codec", "std", "arb"] }
 fvm_ipld_blockstore = "0.1"
 fvm_ipld_encoding = "0.3"
 fvm_ipld_car = "0.6"

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -302,7 +302,5 @@ fn to_events(_stamped_events: Vec<StampedEvent>) -> Vec<Event> {
     // I changed that in https://github.com/filecoin-project/ref-fvm/pull/1507 but it's still in review.
     // A possible workaround would be to retrieve the events by their CID, and use a custom type to parse.
     // It will be part of https://github.com/filecoin-project/ref-fvm/pull/1635 :)
-    let events = Vec::new();
-
-    events
+    Vec::new()
 }

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -14,8 +14,9 @@ use fendermint_vm_interpreter::signed::SignedMesssageApplyRet;
 use fendermint_vm_interpreter::{Interpreter, Timestamp};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::econ::TokenAmount;
+use fvm_shared::event::StampedEvent;
 use fvm_shared::version::NetworkVersion;
-use tendermint::abci::{request, response, Code};
+use tendermint::abci::{request, response, Code, Event};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -114,7 +115,7 @@ where
     I: Interpreter<
         State = FvmState<DB>,
         Message = Vec<u8>,
-        BeginOutput = (),
+        BeginOutput = FvmApplyRet,
         DeliverOutput = BytesMessageApplyRet,
         EndOutput = (),
     >,
@@ -262,12 +263,7 @@ fn to_deliver_tx(ret: FvmApplyRet) -> response::DeliverTx {
     let gas_used = receipt.gas_used;
 
     let data = receipt.return_data.to_vec().into();
-
-    // TODO: Convert events. This is currently not possible because the event fields are private.
-    // I changed that in https://github.com/filecoin-project/ref-fvm/pull/1507 but it's still in review.
-    // A possible workaround would be to retrieve the events by their CID, and use a custom type to parse.
-    // It will be part of https://github.com/filecoin-project/ref-fvm/pull/1635 :)
-    let events = Vec::new();
+    let events = to_events(ret.apply_ret.events);
 
     response::DeliverTx {
         code,
@@ -295,6 +291,18 @@ fn to_end_block(_ret: ()) -> response::EndBlock {
 /// Map the return values from cron operations.
 ///
 /// (Currently just a placeholder).
-fn to_begin_block(_ret: ()) -> response::BeginBlock {
-    response::BeginBlock { events: Vec::new() }
+fn to_begin_block(ret: FvmApplyRet) -> response::BeginBlock {
+    let events = to_events(ret.apply_ret.events);
+
+    response::BeginBlock { events }
+}
+
+fn to_events(_stamped_events: Vec<StampedEvent>) -> Vec<Event> {
+    // TODO: Convert events. This is currently not possible because the event fields are private.
+    // I changed that in https://github.com/filecoin-project/ref-fvm/pull/1507 but it's still in review.
+    // A possible workaround would be to retrieve the events by their CID, and use a custom type to parse.
+    // It will be part of https://github.com/filecoin-project/ref-fvm/pull/1635 :)
+    let events = Vec::new();
+
+    events
 }

--- a/fendermint/vm/actor_interface/Cargo.toml
+++ b/fendermint/vm/actor_interface/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "fendermint_vm_actor_interface"
+description = "Re-export interfaces of built-in actors, either copyed versions or from direct project reference."
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+fvm_shared = { workspace = true }

--- a/fendermint/vm/actor_interface/Cargo.toml
+++ b/fendermint/vm/actor_interface/Cargo.toml
@@ -9,4 +9,5 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+paste = { workspace = true }
 fvm_shared = { workspace = true }

--- a/fendermint/vm/actor_interface/src/cron.rs
+++ b/fendermint/vm/actor_interface/src/cron.rs
@@ -1,0 +1,11 @@
+use fvm_shared::{ActorID, METHOD_CONSTRUCTOR};
+
+/// Cron actor address.
+pub const CRON_ACTOR_ID: ActorID = 3;
+
+/// Cron actor methods available
+#[repr(u64)]
+pub enum Method {
+    Constructor = METHOD_CONSTRUCTOR,
+    EpochTick = 2,
+}

--- a/fendermint/vm/actor_interface/src/cron.rs
+++ b/fendermint/vm/actor_interface/src/cron.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use fvm_shared::METHOD_CONSTRUCTOR;
 
 define_singleton!(CRON_ACTOR = 3);

--- a/fendermint/vm/actor_interface/src/cron.rs
+++ b/fendermint/vm/actor_interface/src/cron.rs
@@ -1,7 +1,6 @@
-use fvm_shared::{ActorID, METHOD_CONSTRUCTOR};
+use fvm_shared::METHOD_CONSTRUCTOR;
 
-/// Cron actor address.
-pub const CRON_ACTOR_ID: ActorID = 3;
+define_singleton!(CRON_ACTOR = 3);
 
 /// Cron actor methods available
 #[repr(u64)]

--- a/fendermint/vm/actor_interface/src/lib.rs
+++ b/fendermint/vm/actor_interface/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod cron;

--- a/fendermint/vm/actor_interface/src/lib.rs
+++ b/fendermint/vm/actor_interface/src/lib.rs
@@ -1,1 +1,24 @@
+//! The modules in this crate a thin interfaces to builtin-actors,
+//! so that the rest of the system doesn't have to copy-paste things
+//! such as actor IDs, method numbers, method parameter data types.
+//!
+//! This is similar to how the FVM library contains copies for actors
+//! it assumes to be deployed, like the init-actor. There, it's to avoid
+//! circular project dependencies. Here, we have the option to reference
+//! the actor projects directly and re-export what we need, or to copy
+//! the relevant pieces of code. By limiting this choice to this crate,
+//! the rest of the application can avoid ad-hoc magic numbers.
+//!
+//! For reference, the IDs can be found in [singletons](https://github.com/filecoin-project/builtin-actors/blob/master/runtime/src/builtin/singletons.rs).
+
+macro_rules! define_singleton {
+    ($name:ident = $id:literal) => {
+        paste::paste! {
+            pub const [<$name _ID>]: fvm_shared::ActorID = $id;
+            pub const [<$name _ADDR>]: fvm_shared::address::Address = fvm_shared::address::Address::new_id([<$name _ID>]);
+        }
+    };
+}
+
 pub mod cron;
+pub mod system;

--- a/fendermint/vm/actor_interface/src/lib.rs
+++ b/fendermint/vm/actor_interface/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! The modules in this crate a thin interfaces to builtin-actors,
 //! so that the rest of the system doesn't have to copy-paste things
 //! such as actor IDs, method numbers, method parameter data types.

--- a/fendermint/vm/actor_interface/src/system.rs
+++ b/fendermint/vm/actor_interface/src/system.rs
@@ -1,0 +1,1 @@
+define_singleton!(SYSTEM_ACTOR = 0);

--- a/fendermint/vm/actor_interface/src/system.rs
+++ b/fendermint/vm/actor_interface/src/system.rs
@@ -1,1 +1,3 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 define_singleton!(SYSTEM_ACTOR = 0);

--- a/fendermint/vm/interpreter/Cargo.toml
+++ b/fendermint/vm/interpreter/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 
 [dependencies]
 fendermint_vm_message = { path = "../message" }
+fendermint_vm_actor_interface = { path = "../actor_interface" }
 
 async-trait = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
Closes #15 

Created a `fendermint/vm/actor_interface` crate (similar to Forest) with copies of actor IDs and methods (similar to the FVM) as a consolidation point for how to invoke built-in actors.

Calling the `cron` actor in `begin_block`. 

TODO: Which actors the `cron` actor is calling seems to depend entirely on constructor arguments, that is, it's defined in genesis. We identified that we'll only keep actors which probably don't have regular jobs to do at the beginning of the blocks. Things like applying power transitions need to happen at the end of the blocks - maybe we should move the cron to the end, from the beginning? Probably not, nobody used to FVM in Lotus/Forest would expect that. Should we have another general actor to call? Or just call it from the interpreter - that seems to be the most straight forward option, and then the FVM doesn't need actors that exist because of the needs of Tendermint.

