### PR TITLE
FM-16: Storage abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
  "core2",
  "multibase",
  "multihash",
- "quickcheck",
+ "quickcheck 0.9.2",
  "rand 0.7.3",
  "serde",
  "serde_bytes",
@@ -1065,6 +1065,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,7 +1214,11 @@ dependencies = [
 name = "fendermint_storage"
 version = "0.1.0"
 dependencies = [
+ "fvm_ipld_encoding",
  "im",
+ "quickcheck 1.0.3",
+ "quickcheck_macros",
+ "serde",
 ]
 
 [[package]]
@@ -2484,7 +2498,7 @@ dependencies = [
  "core2",
  "digest 0.10.6",
  "multihash-derive",
- "quickcheck",
+ "quickcheck 0.9.2",
  "rand 0.7.3",
  "ripemd",
  "serde",
@@ -2970,10 +2984,32 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
 dependencies = [
- "env_logger",
+ "env_logger 0.7.1",
  "log",
  "rand 0.7.3",
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger 0.8.4",
+ "log",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,6 +1201,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "fendermint_storage"
+version = "0.1.0"
+dependencies = [
+ "im",
+]
+
+[[package]]
 name = "fendermint_testing"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["fendermint/abci", "fendermint/app", "fendermint/testing", "fendermint/vm/*"]
+members = ["fendermint/abci", "fendermint/app", "fendermint/storage", "fendermint/testing", "fendermint/vm/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ serde_tuple = "0.5"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 tempfile = "3.3"
 thiserror = "1"
+quickcheck = "1"
+quickcheck_macros = "1"
 
 # Stable FVM dependencies from crates.io
 cid = { version = "0.8", default-features = false, features = ["serde-codec", "std", "arb"] }

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -54,9 +54,9 @@ impl<DB, I> App<DB, I>
 where
     DB: Blockstore + 'static,
 {
-    pub fn new(db: Arc<DB>, interpreter: I) -> Self {
+    pub fn new(db: DB, interpreter: I) -> Self {
         Self {
-            db,
+            db: Arc::new(db),
             interpreter: Arc::new(interpreter),
             exec_state: Arc::new(Mutex::new(None)),
         }

--- a/fendermint/app/src/main.rs
+++ b/fendermint/app/src/main.rs
@@ -1,8 +1,6 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::sync::Arc;
-
 use fendermint_abci::ApplicationService;
 use fendermint_app::app;
 use fendermint_vm_interpreter::{
@@ -19,11 +17,12 @@ async fn main() {
     let interpreter = BytesMessageInterpreter::new(interpreter);
 
     let db = open_db();
+
     let app = app::App::new(db, interpreter);
     let _service = ApplicationService(app);
 }
 
-fn open_db() -> Arc<RocksDb> {
+fn open_db() -> RocksDb {
     todo!()
 }
 

--- a/fendermint/storage/Cargo.toml
+++ b/fendermint/storage/Cargo.toml
@@ -11,6 +11,12 @@ license.workspace = true
 [dependencies]
 im = { version = "15.1.0", optional = true }
 
+[dev-dependencies]
+quickcheck = { workspace = true }
+quickcheck_macros = { workspace = true }
+serde = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+
 [features]
 default = ["inmem"]
 inmem = ["im"]

--- a/fendermint/storage/Cargo.toml
+++ b/fendermint/storage/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "fendermint_storage"
+description = "KV store abstraction for non-blockstore use."
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+im = { version = "15.1.0", optional = true }
+
+[features]
+default = ["inmem"]
+inmem = ["im"]

--- a/fendermint/storage/src/im.rs
+++ b/fendermint/storage/src/im.rs
@@ -189,7 +189,7 @@ where
         let mut m = self.data.get(ns).cloned().unwrap_or_default();
         let kr = S::to_repr(k)?;
         let vr = S::to_repr(v)?;
-        m.insert(kr, Arc::new(vr));
+        m.insert(kr.into_owned(), Arc::new(vr.into_owned()));
         self.data.insert(ns.clone(), m);
         Ok(())
     }

--- a/fendermint/storage/src/im.rs
+++ b/fendermint/storage/src/im.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::{
     hash::Hash,
     mem,

--- a/fendermint/storage/src/im.rs
+++ b/fendermint/storage/src/im.rs
@@ -1,0 +1,206 @@
+use std::{
+    hash::Hash,
+    mem,
+    sync::{Arc, Mutex, MutexGuard},
+    thread,
+};
+
+use crate::{
+    Decode, Encode, KVRead, KVReadable, KVResult, KVStore, KVTransaction, KVTransactionPrepared,
+    KVWritable, KVWrite,
+};
+
+/// Read-only mode.
+pub struct Read;
+/// Read-write mode.
+pub struct Write;
+
+type IDataMap<S> = im::HashMap<
+    <S as KVStore>::Namespace,
+    im::HashMap<<S as KVStore>::Repr, Arc<<S as KVStore>::Repr>>,
+>;
+
+/// Given some `KVStore` type, the `InMemoryBackend` can be used to
+/// emulate the same interface, but keep all the data in memory.
+/// This can facilitate unit tests, but can be used for transient
+/// storage as well, although STM has more granular access, and
+/// the performance of this thing is likely to be terrible.
+///
+/// By default it serializes write transactions, which is required
+/// for its correctness, but it can be disabled for the sake of
+/// testing, or if writes only happen from the same task and
+/// never concurrently.
+///
+/// Alternatively we could change the transaction implementation
+/// to track individual puts/deletes and apply them in batch
+/// at commit time. In that case if puts are commutative then
+/// we could do multiple writes at the same time.
+#[derive(Clone)]
+pub struct InMemoryBackend<S: KVStore> {
+    data: Arc<Mutex<IDataMap<S>>>,
+    write_token: Arc<Mutex<()>>,
+    lock_writes: bool,
+}
+
+impl<S: KVStore> InMemoryBackend<S> {
+    pub fn new(lock_writes: bool) -> Self {
+        Self {
+            data: Arc::new(Mutex::new(Default::default())),
+            write_token: Arc::new(Mutex::new(())),
+            lock_writes,
+        }
+    }
+}
+
+impl<S: KVStore> Default for InMemoryBackend<S> {
+    fn default() -> Self {
+        // Locking is the only safe way to use writes from multiple threads.
+        Self::new(true)
+    }
+}
+
+impl<S: KVStore> KVReadable<S> for InMemoryBackend<S>
+where
+    S::Repr: Hash + Eq,
+{
+    type Tx<'a> = Transaction<'a, S, Read> where Self: 'a;
+
+    /// Take a fresh snapshot, to isolate the effects of any further writes
+    /// to the datastore from this read transaction.
+    fn read(&self) -> Transaction<S, Read> {
+        Transaction {
+            backend: self,
+            data: self.data.lock().unwrap().clone(),
+            token: None,
+            _mode: Read,
+        }
+    }
+}
+
+impl<S: KVStore> KVWritable<S> for InMemoryBackend<S>
+where
+    S::Repr: Hash + Eq,
+{
+    type Tx<'a>
+    = Transaction<'a, S, Write>
+    where
+        Self: 'a;
+
+    /// Take a snapshot to accumulate writes until they are committed.
+    /// Take a write-lock on the data if necessary, but beware it doesn't work well with STM.
+    fn write(&self) -> Transaction<S, Write> {
+        // Take this lock first, otherwise we might be blocking `data` from anyone being able to commit.
+        let token = if self.lock_writes {
+            Some(self.write_token.lock().unwrap())
+        } else {
+            None
+        };
+        Transaction {
+            backend: self,
+            data: self.data.lock().unwrap().clone(),
+            token,
+            _mode: Write,
+        }
+    }
+}
+
+/// A transaction that can be read-only with no write lock taken,
+/// or read-write, releasing the lock when it goes out of scope.
+pub struct Transaction<'a, S: KVStore, M> {
+    backend: &'a InMemoryBackend<S>,
+    data: IDataMap<S>,
+    token: Option<MutexGuard<'a, ()>>,
+    _mode: M,
+}
+
+impl<'a, S: KVStore> KVTransaction for Transaction<'a, S, Write> {
+    // An exclusive lock has already been taken.
+    type Prepared = Self;
+
+    fn prepare(self) -> Option<Self> {
+        Some(self)
+    }
+
+    fn rollback(mut self) {
+        mem::take(&mut self.token);
+    }
+}
+
+impl<'a, S: KVStore> KVTransactionPrepared for Transaction<'a, S, Write> {
+    fn commit(mut self) {
+        let mut guard = self.backend.data.lock().unwrap();
+        *guard = mem::take(&mut self.data);
+        mem::take(&mut self.token);
+    }
+
+    fn rollback(self) {
+        KVTransaction::rollback(self)
+    }
+}
+
+impl<'a, S: KVStore> KVTransaction for Transaction<'a, S, Read> {
+    type Prepared = Self;
+    fn prepare(self) -> Option<Self> {
+        Some(self)
+    }
+    fn rollback(self) {}
+}
+
+impl<'a, S: KVStore> KVTransactionPrepared for Transaction<'a, S, Read> {
+    fn commit(self) {}
+    fn rollback(self) {}
+}
+
+impl<'a, S: KVStore, M> Drop for Transaction<'a, S, M> {
+    fn drop(&mut self) {
+        if self.token.is_some() && !thread::panicking() {
+            panic!("Transaction prematurely dropped. Must call `.commit()` or `.rollback()`.");
+        }
+    }
+}
+
+impl<'a, S: KVStore, M> KVRead<S> for Transaction<'a, S, M>
+where
+    S::Repr: Hash + Eq,
+{
+    fn get<K, V>(&self, ns: &S::Namespace, k: &K) -> KVResult<Option<V>>
+    where
+        S: Encode<K> + Decode<V>,
+    {
+        if let Some(m) = self.data.get(ns) {
+            let kr = S::to_repr(k)?;
+            let v = m.get(&kr).map(|v| S::from_repr(v));
+            return v.transpose();
+        }
+        Ok(None)
+    }
+}
+
+impl<'a, S: KVStore> KVWrite<S> for Transaction<'a, S, Write>
+where
+    S::Repr: Hash + Eq,
+{
+    fn put<K, V>(&mut self, ns: &S::Namespace, k: &K, v: &V) -> KVResult<()>
+    where
+        S: Encode<K> + Encode<V>,
+    {
+        let mut m = self.data.get(ns).cloned().unwrap_or_default();
+        let kr = S::to_repr(k)?;
+        let vr = S::to_repr(v)?;
+        m.insert(kr, Arc::new(vr));
+        self.data.insert(ns.clone(), m);
+        Ok(())
+    }
+
+    fn delete<K>(&mut self, ns: &S::Namespace, k: &K) -> KVResult<()>
+    where
+        S: Encode<K>,
+    {
+        if let Some(mut m) = self.data.get(ns).cloned() {
+            let kr = S::to_repr(k)?;
+            m.remove(&kr);
+            self.data.insert(ns.clone(), m);
+        }
+        Ok(())
+    }
+}

--- a/fendermint/storage/src/lib.rs
+++ b/fendermint/storage/src/lib.rs
@@ -1,7 +1,6 @@
 // For benchmarks.
 use std::error::Error;
 use std::hash::Hash;
-use std::io::Error as IoError;
 use std::marker::PhantomData;
 
 /// In-memory KV store backend.
@@ -14,7 +13,7 @@ pub enum KVError {
     /// KV transaction was aborted due to some business rule violation.
     Abort(Box<dyn Error + Send + Sync>),
     /// An error occurred during serializing or deserializing the data.
-    Codec(IoError),
+    Codec(Box<dyn Error + Send + Sync>),
     /// Some unexpected error occurred in the underlying implementation,
     /// e.g. some IO error with a database.
     Unexpected(Box<dyn Error + Send + Sync>),
@@ -48,6 +47,11 @@ where
 {
     fn from_repr(repr: &Self::Repr) -> KVResult<T>;
 }
+
+/// Encode and decode data.
+///
+/// Ideally this would be just a trait alias, but that's an unstable feature.
+pub trait Codec<T>: Encode<T> + Decode<T> {}
 
 /// Operations available on a read transaction.
 pub trait KVRead<S: KVStore> {
@@ -148,5 +152,5 @@ where
     }
 }
 
-// #[cfg(test)]
-// mod test;
+#[cfg(test)]
+mod tests;

--- a/fendermint/storage/src/lib.rs
+++ b/fendermint/storage/src/lib.rs
@@ -102,8 +102,10 @@ pub trait KVTransactionPrepared {
 }
 
 /// Interface for stores that support read-only transactions.
+///
+/// Any resources held by the read transaction should be released when it's dropped.
 pub trait KVReadable<S: KVStore> {
-    type Tx<'a>: KVRead<S> + KVTransaction
+    type Tx<'a>: KVRead<S>
     where
         Self: 'a;
 

--- a/fendermint/storage/src/lib.rs
+++ b/fendermint/storage/src/lib.rs
@@ -4,9 +4,9 @@ use std::hash::Hash;
 use std::io::Error as IoError;
 use std::marker::PhantomData;
 
-// /// In-memory KV store backend.
-// #[cfg(feature = "inmem")]
-// pub mod im;
+/// In-memory KV store backend.
+#[cfg(feature = "inmem")]
+pub mod im;
 
 /// Possible errors during key-value operations.
 #[derive(Debug)]

--- a/fendermint/storage/src/lib.rs
+++ b/fendermint/storage/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 // For benchmarks.
 use std::error::Error;
 use std::hash::Hash;

--- a/fendermint/storage/src/lib.rs
+++ b/fendermint/storage/src/lib.rs
@@ -1,0 +1,152 @@
+// For benchmarks.
+use std::error::Error;
+use std::hash::Hash;
+use std::io::Error as IoError;
+use std::marker::PhantomData;
+
+// /// In-memory KV store backend.
+// #[cfg(feature = "inmem")]
+// pub mod im;
+
+/// Possible errors during key-value operations.
+#[derive(Debug)]
+pub enum KVError {
+    /// KV transaction was aborted due to some business rule violation.
+    Abort(Box<dyn Error + Send + Sync>),
+    /// An error occurred during serializing or deserializing the data.
+    Codec(IoError),
+    /// Some unexpected error occurred in the underlying implementation,
+    /// e.g. some IO error with a database.
+    Unexpected(Box<dyn Error + Send + Sync>),
+}
+
+pub type KVResult<T> = Result<T, KVError>;
+
+/// Helper trait to reduce the number of generic parameters that infect anything
+/// that has to use a KV store. It's a type family of all customizable types
+/// that can vary by KV store implementation.
+pub trait KVStore {
+    /// Type specifying in which collection to store some homogenous data set.
+    type Namespace: Clone + Hash + Eq;
+
+    /// The type used for storing data at rest, e.g. in binary format or JSON.
+    type Repr: Clone;
+}
+
+/// Encode data as binary with a serialization scheme.
+pub trait Encode<T>
+where
+    Self: KVStore,
+{
+    fn to_repr(value: &T) -> KVResult<Self::Repr>;
+}
+
+/// Decode data from binary with a serialization scheme.
+pub trait Decode<T>
+where
+    Self: KVStore,
+{
+    fn from_repr(repr: &Self::Repr) -> KVResult<T>;
+}
+
+/// Operations available on a read transaction.
+pub trait KVRead<S: KVStore> {
+    fn get<K, V>(&self, ns: &S::Namespace, k: &K) -> KVResult<Option<V>>
+    where
+        S: Encode<K> + Decode<V>;
+}
+
+/// Operations available on a write transaction.
+pub trait KVWrite<S: KVStore>: KVRead<S> {
+    fn put<K, V>(&mut self, ns: &S::Namespace, k: &K, v: &V) -> KVResult<()>
+    where
+        S: Encode<K> + Encode<V>;
+
+    fn delete<K>(&mut self, ns: &S::Namespace, k: &K) -> KVResult<()>
+    where
+        S: Encode<K>;
+}
+
+/// Transaction running on a KV store, ending with a commit or a rollback.
+/// This mimics the `Aux` interface in the STM module.
+pub trait KVTransaction {
+    type Prepared: KVTransactionPrepared;
+    /// Prepare to commit the transaction. This gives us a chance to do
+    /// Optimistic Concurrency Control, to only take out locks during commit.
+    fn prepare(self) -> Option<Self::Prepared>;
+
+    /// Abandon the changes of the transaction.
+    fn rollback(self);
+
+    /// Convenience method to prepare and commit.
+    ///
+    /// Returns a flag indicating whether the commit successful.
+    fn prepare_and_commit(self) -> bool
+    where
+        Self: Sized,
+    {
+        self.prepare().map(|tx| tx.commit()).is_some()
+    }
+}
+
+/// Transaction in a state when it's ready to be committed.
+pub trait KVTransactionPrepared {
+    fn commit(self);
+    fn rollback(self);
+}
+
+/// Interface for stores that support read-only transactions.
+pub trait KVReadable<S: KVStore> {
+    type Tx<'a>: KVRead<S> + KVTransaction
+    where
+        Self: 'a;
+
+    /// Start a read-only transaction.
+    fn read(&self) -> Self::Tx<'_>;
+}
+
+/// Interface for stores that support read-write transactions.
+pub trait KVWritable<S: KVStore> {
+    type Tx<'a>: KVWrite<S> + KVTransaction
+    where
+        Self: 'a;
+
+    /// Start a read-write tranasction.
+    fn write(&self) -> Self::Tx<'_>;
+}
+
+/// A collection of homogenous objects under the same namespace.
+#[derive(Clone)]
+pub struct KVCollection<S: KVStore, K, V> {
+    ns: S::Namespace,
+    phantom_k: PhantomData<K>,
+    phantom_v: PhantomData<V>,
+}
+
+impl<S: KVStore, K, V> KVCollection<S, K, V>
+where
+    S: Encode<K> + Encode<V> + Decode<V>,
+{
+    pub fn new(ns: S::Namespace) -> Self {
+        Self {
+            ns,
+            phantom_k: PhantomData,
+            phantom_v: PhantomData,
+        }
+    }
+
+    pub fn get(&self, kv: &impl KVRead<S>, k: &K) -> KVResult<Option<V>> {
+        kv.get(&self.ns, k)
+    }
+
+    pub fn put(&self, kv: &mut impl KVWrite<S>, k: &K, v: &V) -> KVResult<()> {
+        kv.put(&self.ns, k, v)
+    }
+
+    pub fn delete(&self, kv: &mut impl KVWrite<S>, k: &K) -> KVResult<()> {
+        kv.delete(&self.ns, k)
+    }
+}
+
+// #[cfg(test)]
+// mod test;

--- a/fendermint/storage/src/lib.rs
+++ b/fendermint/storage/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-// For benchmarks.
+use std::borrow::Cow;
 use std::error::Error;
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -39,7 +39,7 @@ pub trait Encode<T>
 where
     Self: KVStore,
 {
-    fn to_repr(value: &T) -> KVResult<Self::Repr>;
+    fn to_repr(value: &T) -> KVResult<Cow<Self::Repr>>;
 }
 
 /// Decode data from binary with a serialization scheme.

--- a/fendermint/storage/src/tests.rs
+++ b/fendermint/storage/src/tests.rs
@@ -409,6 +409,8 @@ where
 
 #[cfg(feature = "inmem")]
 mod im {
+    use std::borrow::Cow;
+
     use crate::{im::InMemoryBackend, Codec, Decode, Encode, KVError, KVResult, KVStore};
     use quickcheck_macros::quickcheck;
     use serde::{de::DeserializeOwned, Serialize};
@@ -424,8 +426,10 @@ mod im {
     }
 
     impl<T: Serialize> Encode<T> for TestKVStore {
-        fn to_repr(value: &T) -> KVResult<Self::Repr> {
-            fvm_ipld_encoding::to_vec(value).map_err(|e| KVError::Codec(Box::new(e)))
+        fn to_repr(value: &T) -> KVResult<Cow<Self::Repr>> {
+            fvm_ipld_encoding::to_vec(value)
+                .map_err(|e| KVError::Codec(Box::new(e)))
+                .map(Cow::Owned)
         }
     }
     impl<T: DeserializeOwned> Decode<T> for TestKVStore {

--- a/fendermint/storage/src/tests.rs
+++ b/fendermint/storage/src/tests.rs
@@ -295,7 +295,7 @@ where
     };
 
     let ok = apply_model(&data1, &data2) || apply_model(&data2, &data1);
-    tx.prepare_and_commit();
+    drop(tx);
     ok
 }
 
@@ -351,7 +351,7 @@ where
     }
 
     // Finish the reads and start another read transaction. Now the writes should be visible.
-    txr.prepare_and_commit();
+    drop(txr);
     txr = sut.read();
 
     for (ns, op) in &gets {

--- a/fendermint/storage/src/tests.rs
+++ b/fendermint/storage/src/tests.rs
@@ -1,0 +1,468 @@
+use crate::{Codec, KVCollection, KVRead, KVReadable, KVStore, KVTransaction, KVWritable, KVWrite};
+use quickcheck::{Arbitrary, Gen};
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::thread;
+
+/// We'll see how this works out. We would have to wrap any KVStore
+/// with something that can handle strings as namespaces.
+type TestNamespace = &'static str;
+
+/// Test operations on some collections with known types,
+/// so we can have the simplest possible model implementation.
+#[derive(Clone, Debug)]
+enum TestOpKV<K, V> {
+    Get(K),
+    Put(K, V),
+    Del(K),
+}
+
+#[derive(Clone, Debug)]
+enum TestOpNs {
+    S2I(TestNamespace, TestOpKV<String, u8>),
+    I2S(TestNamespace, TestOpKV<u8, String>),
+    Rollback,
+}
+
+#[derive(Clone, Debug)]
+pub struct TestData {
+    ops: Vec<TestOpNs>,
+}
+
+/// Generate commands from a limited set of keys so there's a
+/// high probability that we get/delete what we put earlier.
+impl Arbitrary for TestOpNs {
+    fn arbitrary(g: &mut Gen) -> Self {
+        use TestOpKV::*;
+        use TestOpNs::*;
+        match u8::arbitrary(g) % 100 {
+            i if i < 49 => {
+                let ns = g.choose(&["spam", "eggs"]).unwrap();
+                let k = *g.choose(&["foo", "bar"]).unwrap();
+                match u8::arbitrary(g) % 10 {
+                    i if i < 3 => S2I(ns, Get(k.to_owned())),
+                    i if i < 9 => S2I(ns, Put(k.to_owned(), Arbitrary::arbitrary(g))),
+                    _ => S2I(ns, Del(k.to_owned())),
+                }
+            }
+            i if i < 98 => {
+                let ns = g.choose(&["fizz", "buzz"]).unwrap();
+                let k = u8::arbitrary(g) % 2;
+                match u8::arbitrary(g) % 10 {
+                    i if i < 3 => I2S(ns, Get(k)),
+                    i if i < 9 => {
+                        let sz = u8::arbitrary(g) % 5;
+                        let s = (0..sz).map(|_| char::arbitrary(g)).collect();
+                        I2S(ns, Put(k, s))
+                    }
+                    _ => I2S(ns, Del(k)),
+                }
+            }
+            _ => Rollback,
+        }
+    }
+}
+
+impl Arbitrary for TestData {
+    fn arbitrary(g: &mut Gen) -> Self {
+        TestData {
+            ops: Arbitrary::arbitrary(g),
+        }
+    }
+}
+
+/// Test data for multiple transactions, interspersed.
+#[derive(Clone, Debug)]
+pub struct TestDataMulti<const N: usize> {
+    ops: Vec<(usize, TestOpNs)>,
+}
+
+impl<const N: usize> Arbitrary for TestDataMulti<N> {
+    fn arbitrary(g: &mut Gen) -> Self {
+        let mut ops = Vec::new();
+        for i in 0..N {
+            let data = TestData::arbitrary(g);
+            ops.extend(data.ops.into_iter().map(|op| (i32::arbitrary(g), i, op)));
+        }
+        ops.sort_by_key(|(r, _, _)| *r);
+
+        TestDataMulti {
+            ops: ops.into_iter().map(|(_, i, op)| (i, op)).collect(),
+        }
+    }
+}
+
+struct TestDataStore;
+
+impl KVStore for TestDataStore {
+    type Namespace = TestNamespace;
+    type Repr = Vec<u8>;
+}
+
+#[derive(Default)]
+struct Model {
+    s2i: HashMap<TestNamespace, HashMap<String, u8>>,
+    i2s: HashMap<TestNamespace, HashMap<u8, String>>,
+}
+
+struct Collections<S: KVStore> {
+    s2i: HashMap<TestNamespace, KVCollection<S, String, u8>>,
+    i2s: HashMap<TestNamespace, KVCollection<S, u8, String>>,
+}
+
+impl<S: KVStore> Default for Collections<S> {
+    fn default() -> Self {
+        Self {
+            s2i: HashMap::new(),
+            i2s: HashMap::new(),
+        }
+    }
+}
+
+impl<S> Collections<S>
+where
+    S: KVStore<Namespace = TestNamespace> + Clone + Codec<String> + Codec<u8>,
+{
+    fn s2i(&mut self, ns: TestNamespace) -> &KVCollection<S, String, u8> {
+        self.s2i.entry(ns).or_insert_with(|| KVCollection::new(ns))
+    }
+
+    fn i2s(&mut self, ns: TestNamespace) -> &KVCollection<S, u8, String> {
+        self.i2s.entry(ns).or_insert_with(|| KVCollection::new(ns))
+    }
+}
+
+/// State machine test for an implementation of a `KVWritable` using a sequence of random ops.
+pub fn check_writable<S>(sut: &impl KVWritable<S>, data: TestData) -> bool
+where
+    S: KVStore<Namespace = TestNamespace> + Clone + Codec<String> + Codec<u8>,
+{
+    let mut model = Model::default();
+    // Creating a collection doesn't add much to the test but at least we exercise this path.
+    let mut colls = Collections::<S>::default();
+    // Start the transaction.
+    let mut tx = sut.write();
+    let mut ok = true;
+    for d in data.ops {
+        match d {
+            TestOpNs::S2I(ns, op) => {
+                let coll = colls.s2i(ns);
+                if !apply_both(&mut tx, &mut model.s2i, coll, ns, op) {
+                    ok = false;
+                }
+            }
+            TestOpNs::I2S(ns, op) => {
+                let coll = colls.i2s(ns);
+                if !apply_both(&mut tx, &mut model.i2s, coll, ns, op) {
+                    ok = false;
+                }
+            }
+            TestOpNs::Rollback => {
+                //println!("ROLLBACK");
+                model = Model::default();
+                tx.rollback();
+                tx = sut.write();
+            }
+        }
+    }
+    tx.rollback();
+    ok
+}
+
+/// Check that two write transactions don't see each others' changes.
+///
+/// This test assumes that write transactions can be executed concurrently, that
+/// they don't block each other. If that's not the case don't call this test.
+pub fn check_write_isolation<S>(sut: &impl KVWritable<S>, data: TestDataMulti<2>) -> bool
+where
+    S: KVStore<Namespace = TestNamespace> + Clone + Codec<String> + Codec<u8>,
+{
+    let mut colls = Collections::<S>::default();
+    let mut model1 = Model::default();
+    let mut model2 = Model::default();
+    let mut tx1 = sut.write();
+    let mut tx2 = sut.write();
+    let mut ok = true;
+    for (i, op) in data.ops {
+        let tx = if i == 0 { &mut tx1 } else { &mut tx2 };
+        let model = if i == 0 { &mut model1 } else { &mut model2 };
+        match op {
+            TestOpNs::S2I(ns, op) => {
+                let coll = colls.s2i(ns);
+                if !apply_both(tx, &mut model.s2i, coll, ns, op) {
+                    ok = false;
+                }
+            }
+            TestOpNs::I2S(ns, op) => {
+                let coll = colls.i2s(ns);
+                if !apply_both(tx, &mut model.i2s, coll, ns, op) {
+                    ok = false;
+                }
+            }
+            TestOpNs::Rollback => {}
+        }
+    }
+    tx1.rollback();
+    tx2.rollback();
+    ok
+}
+
+/// Check that two write transactions don't see each others' changes when executed on different threads.
+pub fn check_write_isolation_concurrent<S, B>(sut: &B, data1: TestData, data2: TestData) -> bool
+where
+    S: KVStore<Namespace = TestNamespace> + Clone + Codec<String> + Codec<u8>,
+    B: KVWritable<S> + Clone + Send + 'static,
+{
+    let sut2 = sut.clone();
+    let t = thread::spawn(move || check_writable(&sut2, data2));
+    let c1 = check_writable(sut, data1);
+    let c2 = t.join().unwrap();
+    c1 && c2
+}
+
+/// Check that two write transactions are serializable, their effects don't get lost and aren't interspersed.
+pub fn check_write_serialization_concurrent<S, B>(sut: &B, data1: TestData, data2: TestData) -> bool
+where
+    S: KVStore<Namespace = TestNamespace> + Clone + Codec<String> + Codec<u8>,
+    B: KVWritable<S> + KVReadable<S> + Clone + Send + 'static,
+{
+    let apply_sut = |sut: &B, data: &TestData| {
+        let mut tx = sut.write();
+        for op in data.ops.iter() {
+            match op {
+                TestOpNs::S2I(ns, TestOpKV::Put(k, v)) => tx.put(ns, k, v).unwrap(),
+                TestOpNs::S2I(ns, TestOpKV::Del(k)) => tx.delete(ns, k).unwrap(),
+                TestOpNs::I2S(ns, TestOpKV::Put(k, v)) => tx.put(ns, k, v).unwrap(),
+                TestOpNs::I2S(ns, TestOpKV::Del(k)) => tx.delete(ns, k).unwrap(),
+                _ => (),
+            }
+        }
+        tx.prepare_and_commit();
+    };
+
+    let sutc = sut.clone();
+    let data2c = data2.clone();
+    let t = thread::spawn(move || apply_sut(&sutc, &data2c));
+    apply_sut(sut, &data1);
+    t.join().unwrap();
+
+    // The changes were applied in one order or the other.
+    let tx = sut.read();
+    let apply_model = |a: &TestData, b: &TestData| -> bool {
+        let mut model = Model::default();
+        // First apply all the writes
+        for op in a.ops.iter().chain(b.ops.iter()).map(|op| op.clone()) {
+            match op {
+                TestOpNs::S2I(ns, TestOpKV::Put(k, v)) => {
+                    model.s2i.entry(ns).or_default().insert(k, v);
+                }
+                TestOpNs::S2I(ns, TestOpKV::Del(k)) => {
+                    model.s2i.entry(ns).or_default().remove(&k);
+                }
+                TestOpNs::I2S(ns, TestOpKV::Put(k, v)) => {
+                    model.i2s.entry(ns).or_default().insert(k, v);
+                }
+                TestOpNs::I2S(ns, TestOpKV::Del(k)) => {
+                    model.i2s.entry(ns).or_default().remove(&k);
+                }
+                _ => (),
+            }
+        }
+        // Then just the reads on the final state.
+        for op in a.ops.iter().chain(b.ops.iter()) {
+            match op {
+                TestOpNs::S2I(ns, TestOpKV::Get(k)) => {
+                    let expected = tx.get::<String, u8>(&ns, k).unwrap();
+                    let found = model.s2i.get(ns).and_then(|m| m.get(k)).cloned();
+                    if found != expected {
+                        return false;
+                    }
+                }
+                TestOpNs::I2S(ns, TestOpKV::Get(k)) => {
+                    let expected = tx.get::<u8, String>(&ns, k).unwrap();
+                    let found = model.i2s.get(ns).and_then(|m| m.get(k)).cloned();
+                    if found != expected {
+                        return false;
+                    }
+                }
+                _ => (),
+            }
+        }
+        true
+    };
+
+    let ok = apply_model(&data1, &data2) || apply_model(&data2, &data1);
+    tx.prepare_and_commit();
+    ok
+}
+
+/// Check that read transactions don't see changes from write transactions.
+///
+/// This test assumes that read and write transactions can be executed concurrently,
+/// that they don't block each other. If that's not the case don't call this test.
+pub fn check_read_isolation<S, B>(sut: &B, data: TestData) -> bool
+where
+    S: KVStore<Namespace = TestNamespace> + Clone + Codec<String> + Codec<u8>,
+    B: KVWritable<S> + KVReadable<S>,
+{
+    let mut model = Model::default();
+    let mut colls = Collections::<S>::default();
+    let mut txw = sut.write();
+    let mut txr = sut.read();
+    let mut gets = Vec::new();
+    let mut ok = true;
+
+    for op in data.ops.clone() {
+        match op {
+            TestOpNs::S2I(ns, op) => {
+                let coll = colls.s2i(ns);
+                apply_both(&mut txw, &mut model.s2i, coll, ns, op.clone());
+                match &op {
+                    TestOpKV::Get(k) => {
+                        if coll.get(&txr, &k).unwrap().is_some() {
+                            ok = false;
+                        }
+                        gets.push((ns, op));
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Commit the writes, but they should still not be visible to the reads that started earlier.
+    txw.prepare_and_commit();
+
+    for (ns, op) in &gets {
+        let coll = colls.s2i(ns);
+        match op {
+            TestOpKV::Get(k) => {
+                let found = coll.get(&txr, &k).unwrap();
+                if found.is_some() {
+                    ok = false;
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    // Finish the reads and start another read transaction. Now the writes should be visible.
+    txr.prepare_and_commit();
+    txr = sut.read();
+
+    for (ns, op) in &gets {
+        let coll = colls.s2i(ns);
+        match op {
+            TestOpKV::Get(k) => {
+                let found = coll.get(&txr, &k).unwrap();
+                let expected = model.s2i.get(ns).and_then(|m| m.get(k)).cloned();
+                if found != expected {
+                    ok = false;
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    ok
+}
+
+/// Apply an operation on the model and the KV store, checking that the results are the same where possible.
+fn apply_both<S, K, V>(
+    tx: &mut impl KVWrite<S>,
+    model: &mut HashMap<TestNamespace, HashMap<K, V>>,
+    coll: &KVCollection<S, K, V>,
+    ns: TestNamespace,
+    op: TestOpKV<K, V>,
+) -> bool
+where
+    S: KVStore<Namespace = TestNamespace> + Clone + Codec<K> + Codec<V>,
+    K: Hash + Eq,
+    V: Clone + PartialEq,
+{
+    match op {
+        TestOpKV::Get(k) => {
+            let found = coll.get(tx, &k).unwrap();
+            let expected = model.get(ns).and_then(|m| m.get(&k)).cloned();
+            //println!("GET {:?}/{:?}: {:?} ?= {:?}", ns, k, found, expected);
+            if found != expected {
+                return false;
+            }
+        }
+        TestOpKV::Put(k, v) => {
+            //println!("PUT {:?}/{:?}: {:?}", ns, k, v);
+            coll.put(tx, &k, &v).unwrap();
+            model.entry(ns).or_default().insert(k, v);
+        }
+        TestOpKV::Del(k) => {
+            //println!("DEL {:?}/{:?}", ns, k);
+            coll.delete(tx, &k).unwrap();
+            model.entry(ns).or_default().remove(&k);
+        }
+    }
+    true
+}
+
+#[cfg(feature = "inmem")]
+mod im {
+    use crate::{im::InMemoryBackend, Codec, Decode, Encode, KVError, KVResult, KVStore};
+    use quickcheck_macros::quickcheck;
+    use serde::{de::DeserializeOwned, Serialize};
+
+    use super::{TestData, TestDataMulti, TestNamespace};
+
+    #[derive(Clone)]
+    struct TestKVStore;
+
+    impl KVStore for TestKVStore {
+        type Namespace = TestNamespace;
+        type Repr = Vec<u8>;
+    }
+
+    impl<T: Serialize> Encode<T> for TestKVStore {
+        fn to_repr(value: &T) -> KVResult<Self::Repr> {
+            fvm_ipld_encoding::to_vec(value).map_err(|e| KVError::Codec(Box::new(e)))
+        }
+    }
+    impl<T: DeserializeOwned> Decode<T> for TestKVStore {
+        fn from_repr(repr: &Self::Repr) -> KVResult<T> {
+            fvm_ipld_encoding::from_slice(repr).map_err(|e| KVError::Codec(Box::new(e)))
+        }
+    }
+
+    impl<T> Codec<T> for TestKVStore where TestKVStore: Encode<T> + Decode<T> {}
+
+    #[quickcheck]
+    fn writable(data: TestData) -> bool {
+        let backend = InMemoryBackend::<TestKVStore>::default();
+        super::check_writable(&backend, data)
+    }
+
+    #[quickcheck]
+    fn write_isolation(data: TestDataMulti<2>) -> bool {
+        // XXX: It isn't safe to use this backend without locking writes if writes are concurrent.
+        // It's just here to try the test on something.
+        let backend = InMemoryBackend::<TestKVStore>::new(false);
+        super::check_write_isolation(&backend, data)
+    }
+
+    #[quickcheck]
+    fn write_isolation_concurrent(data1: TestData, data2: TestData) -> bool {
+        let backend = InMemoryBackend::<TestKVStore>::default();
+        super::check_write_isolation_concurrent(&backend, data1, data2)
+    }
+
+    #[quickcheck]
+    fn write_serialization_concurrent(data1: TestData, data2: TestData) -> bool {
+        let backend = InMemoryBackend::<TestKVStore>::default();
+        super::check_write_serialization_concurrent(&backend, data1, data2)
+    }
+
+    #[quickcheck]
+    fn read_isolation(data: TestData) -> bool {
+        let backend = InMemoryBackend::<TestKVStore>::default();
+        super::check_read_isolation(&backend, data)
+    }
+}

--- a/fendermint/storage/src/tests.rs
+++ b/fendermint/storage/src/tests.rs
@@ -163,12 +163,12 @@ where
             TestOpNs::Rollback => {
                 //println!("ROLLBACK");
                 model = Model::default();
-                tx.rollback();
+                tx.rollback().unwrap();
                 tx = sut.write();
             }
         }
     }
-    tx.rollback();
+    tx.rollback().unwrap();
     ok
 }
 
@@ -205,8 +205,8 @@ where
             TestOpNs::Rollback => {}
         }
     }
-    tx1.rollback();
-    tx2.rollback();
+    tx1.rollback().unwrap();
+    tx2.rollback().unwrap();
     ok
 }
 
@@ -240,7 +240,7 @@ where
                 _ => (),
             }
         }
-        tx.prepare_and_commit();
+        tx.prepare_and_commit().unwrap();
     };
 
     let sutc = sut.clone();
@@ -335,7 +335,7 @@ where
     }
 
     // Commit the writes, but they should still not be visible to the reads that started earlier.
-    txw.prepare_and_commit();
+    txw.prepare_and_commit().unwrap();
 
     for (ns, op) in &gets {
         let coll = colls.s2i(ns);

--- a/fendermint/storage/src/tests.rs
+++ b/fendermint/storage/src/tests.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use crate::{Codec, KVCollection, KVRead, KVReadable, KVStore, KVTransaction, KVWritable, KVWrite};
 use quickcheck::{Arbitrary, Gen};
 use std::collections::HashMap;


### PR DESCRIPTION
Related to #16 

This PR brings over some code I developed a while ago when I wanted to use RocksDB with transactions, and column families. It creates a `KVStore` abstraction that we can implement, with `KVReadable` and `KVWriteable` traits to show whether something requires read-only or read-write access. Further to that, it defines `Encode`, `Decode` and `Codec` traits to do the actual serialization. 

Currently in Forest they use a `DB: Blockstore + Store` generic parameter to access IPLD data under the default namespace and also to store arbitrary key-value pairs as bytes, for example [here](https://github.com/ChainSafe/forest/blob/v0.6.0/blockchain/chain/src/store/chain_store.rs#L704). 

```rust
pub fn set_genesis<DB>(db: &DB, header: &BlockHeader) -> Result<Cid, Error>
where
    DB: Blockstore + Store,
{
    db.write(GENESIS_KEY, header.marshal_cbor()?)?;
    db.put_obj(&header, Blake2b256)
        .map_err(|e| Error::Other(e.to_string()))
}
```

I wanted to achieve the following things with this PR:
* Be able to store things like this genesis header, or the tip of the chain, or the application state, separately from the IPLD data, in a different column family. It seems cleaner and the IPLD store can grow arbitrarily large.
* Be able to use transactions, when overwriting multiple entries. This is not an issue with the IPLD part because it's content addressed and append-only, but in other cases, if the application crashed midway, it might be left in an inconsistent state. 
* Provide a strongly typed interface to the data store using the `KVCollection` type, to avoid having to serialize data from bytes in the call site. 

The idea is that a function like `set_genesis` would look something like this:

```rust
pub fn set_genesis<DB>(db: &DB, header: &BlockHeader) -> Result<Cid, Error>
where
    DB: Blockstore + KVStore<S, Namespace=&str> + KVWriteable<DB> + Encode<BlockHeader> + Encode<&str>,
{
    let mut tx = db.write();
    tx.put("genesis", "header", header)?;
    let cid = db.put_obj(&header, Blake2b256)
        .map_err(|e| Error::Other(e.to_string()))?;
    tx.prepare_and_commit();
   Ok(cid)
}
```

It is more cumbersome in this small context; the boilerplate would be manageable by using `KVCollection` and starting transactions further out further out, which allows multiple operations to be chained together into an atomic isolated execution.