### PR TITLE
FM-16: RocksDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,12 +109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
-name = "asn1_der"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
-
-[[package]]
 name = "async-stm"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,22 +168,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
-name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64ct"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
 name = "bellperson"
@@ -398,12 +380,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bs58"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
-
-[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,16 +415,6 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
-]
-
-[[package]]
-name = "cached"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4dfac631a8e77b2f327f7852bb6172771f5279c4512efe79fad6067b37be3d"
-dependencies = [
- "hashbrown 0.11.2",
- "once_cell",
 ]
 
 [[package]]
@@ -559,12 +525,6 @@ dependencies = [
  "serde",
  "toml",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
 
 [[package]]
 name = "constant_time_eq"
@@ -905,16 +865,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
- "zeroize",
-]
-
-[[package]]
 name = "derive-getters"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,8 +992,6 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
- "serde",
  "sha2 0.9.9",
  "zeroize",
 ]
@@ -1197,15 +1145,16 @@ dependencies = [
  "async-trait",
  "cid",
  "fendermint_abci",
+ "fendermint_rocksdb",
  "fendermint_storage",
  "fendermint_vm_interpreter",
  "fendermint_vm_message",
- "forest_db",
  "fvm",
  "fvm_ipld_blockstore",
  "fvm_ipld_car",
  "fvm_ipld_encoding",
  "fvm_shared",
+ "serde",
  "tempfile",
  "tendermint",
  "tokio",
@@ -1363,12 +1312,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flex-error"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,25 +1335,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "forest_db"
-version = "0.2.0"
-source = "git+https://github.com/ChainSafe/forest.git?tag=v0.6.0#b36faae76c6104ab20e0b0187cd506b1566ecfbf"
-dependencies = [
- "anyhow",
- "cid",
- "fvm_ipld_blockstore",
- "lazy_static",
- "libipld",
- "libp2p-bitswap",
- "num_cpus",
- "parking_lot",
- "prometheus",
- "rocksdb",
- "serde",
- "thiserror",
-]
 
 [[package]]
 name = "forest_hash_utils"
@@ -1501,7 +1425,6 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
- "num_cpus",
 ]
 
 [[package]]
@@ -1532,12 +1455,6 @@ name = "futures-task"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -1800,12 +1717,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -1831,12 +1742,6 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1926,7 +1831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.3",
+ "hashbrown",
  "serde",
 ]
 
@@ -2042,50 +1947,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
-name = "libipld"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9c3aa309c260aa2f174bac968901eddc546e9d85950c28eae6a7bec402f926"
-dependencies = [
- "async-trait",
- "cached",
- "fnv",
- "libipld-cbor",
- "libipld-cbor-derive",
- "libipld-core",
- "libipld-json",
- "libipld-macro",
- "log",
- "multihash",
- "parking_lot",
- "thiserror",
-]
-
-[[package]]
-name = "libipld-cbor"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd1ab68c9d26f20c7d0dfea6eecbae8c00359875210001b33ca27d4a02f3d09"
-dependencies = [
- "byteorder",
- "libipld-core",
- "thiserror",
-]
-
-[[package]]
-name = "libipld-cbor-derive"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ec2f49393a1347a2d95ebcb248ff75d0d47235919b678036c010a8cd927375"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "libipld-core"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2101,27 +1962,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libipld-json"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18aa481a87f084d98473dd9ece253a9569c762b75f6bbba8217d54e48c9d63b3"
-dependencies = [
- "libipld-core",
- "multihash",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "libipld-macro"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852c011562ae5059b67c3a917f9f5945af5a68df8e39ede4444fff33274d25e2"
-dependencies = [
- "libipld-core",
-]
-
-[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,117 +1969,6 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
-]
-
-[[package]]
-name = "libp2p"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0a0d2f693675f49ded13c5d510c48b78069e23cbd9108d7ccd59f6dc568819"
-dependencies = [
- "bytes",
- "futures",
- "futures-timer",
- "getrandom 0.2.8",
- "instant",
- "libp2p-core",
- "libp2p-request-response",
- "libp2p-swarm",
- "multiaddr",
- "parking_lot",
- "pin-project",
- "smallvec",
-]
-
-[[package]]
-name = "libp2p-bitswap"
-version = "0.24.0"
-source = "git+https://github.com/hanabi1224/libp2p-bitswap?branch=forest-libp2p@0.50#6f14bc98846abb4a7e1ee8739d199a55bcfcb441"
-dependencies = [
- "async-trait",
- "fnv",
- "futures",
- "lazy_static",
- "libipld",
- "libp2p",
- "prometheus",
- "prost",
- "prost-build",
- "thiserror",
- "tracing",
- "unsigned-varint",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a8fcd392ff67af6cc3f03b1426c41f7f26b6b9aff2dc632c1c56dd649e571f"
-dependencies = [
- "asn1_der",
- "bs58",
- "ed25519-dalek",
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "instant",
- "log",
- "multiaddr",
- "multihash",
- "multistream-select",
- "once_cell",
- "parking_lot",
- "pin-project",
- "prost",
- "prost-build",
- "rand 0.8.5",
- "rw-stream-sink",
- "sec1",
- "sha2 0.10.6",
- "smallvec",
- "thiserror",
- "unsigned-varint",
- "void",
- "zeroize",
-]
-
-[[package]]
-name = "libp2p-request-response"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3236168796727bfcf4927f766393415361e2c644b08bedb6a6b13d957c9a4884"
-dependencies = [
- "async-trait",
- "bytes",
- "futures",
- "instant",
- "libp2p-core",
- "libp2p-swarm",
- "log",
- "rand 0.8.5",
- "smallvec",
- "unsigned-varint",
-]
-
-[[package]]
-name = "libp2p-swarm"
-version = "0.41.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a35472fe3276b3855c00f1c032ea8413615e030256429ad5349cdf67c6e1a0"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "instant",
- "libp2p-core",
- "log",
- "pin-project",
- "rand 0.8.5",
- "smallvec",
- "thiserror",
- "void",
 ]
 
 [[package]]
@@ -2474,24 +2203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multiaddr"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aebdb21e90f81d13ed01dc84123320838e53963c2ca94b60b305d3fa64f31e"
-dependencies = [
- "arrayref",
- "byteorder",
- "data-encoding",
- "multibase",
- "multihash",
- "percent-encoding",
- "serde",
- "static_assertions",
- "unsigned-varint",
- "url",
-]
-
-[[package]]
 name = "multibase"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2537,26 +2248,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "multistream-select"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8552ab875c1313b97b8d20cb857b9fd63e2d1d6a0a1b53ce9821e575405f27a"
-dependencies = [
- "bytes",
- "futures",
- "log",
- "pin-project",
- "smallvec",
- "unsigned-varint",
 ]
 
 [[package]]
@@ -2658,7 +2349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
  "crc32fast",
- "hashbrown 0.12.3",
+ "hashbrown",
  "indexmap",
  "memchr",
 ]
@@ -2771,16 +2462,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
-name = "petgraph"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2811,16 +2492,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der",
- "spki",
-]
 
 [[package]]
 name = "pkg-config"
@@ -2855,16 +2526,6 @@ dependencies = [
  "diff",
  "output_vt100",
  "yansi",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]
@@ -2911,21 +2572,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
-dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "memchr",
- "parking_lot",
- "protobuf",
- "thiserror",
-]
-
-[[package]]
 name = "prost"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2933,28 +2579,6 @@ checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
 dependencies = [
  "bytes",
  "prost-derive",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f8ad728fb08fe212df3c05169e940fbb6d9d16a877ddde14644a983ba2012e"
-dependencies = [
- "bytes",
- "heck 0.4.1",
- "itertools 0.10.5",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn",
- "tempfile",
- "which",
 ]
 
 [[package]]
@@ -2979,12 +2603,6 @@ dependencies = [
  "bytes",
  "prost",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "psm"
@@ -3283,17 +2901,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
-name = "rw-stream-sink"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26338f5e09bb721b85b135ea05af7767c90b52f6de4f087d4f4a3a9d64e7dc04"
-dependencies = [
- "futures",
- "pin-project",
- "static_assertions",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3304,19 +2911,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sec1"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "zeroize",
-]
 
 [[package]]
 name = "semver"
@@ -3557,16 +3151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3727,7 +3311,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck 0.3.3",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -4177,10 +3761,6 @@ name = "unsigned-varint"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
-dependencies = [
- "futures-io",
- "futures-util",
-]
 
 [[package]]
 name = "url"
@@ -4216,12 +3796,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -231,6 +231,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -792,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -1973,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.8.0+7.4.4"
+version = "0.8.3+7.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611804e4666a25136fcc5f8cf425ab4d26c7f74ea245ffe92ea23b85b6420b5d"
+checksum = "557b255ff04123fcc176162f56ed0c9cd42d8f357cf55b3fabeb60f7413741b3"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2970,9 +2971,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7434af0dc1cbd59268aa98b4c22c131c0584d2232f6fb166efb993e2832e896a"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -3143,9 +3144,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+checksum = "7dccf47db1b41fa1573ed27ccf5e08e3ca771cb994f776668c5ebda893b248fc"
 dependencies = [
  "lock_api",
 ]
@@ -3581,9 +3582,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "7e267c18a719545b481171952a79f8c25c80361463ba44bc7fa9eba7c742ef4f"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3616,7 +3617,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.5",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4193,9 +4194,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,6 +1197,7 @@ dependencies = [
  "async-trait",
  "cid",
  "fendermint_abci",
+ "fendermint_storage",
  "fendermint_vm_interpreter",
  "fendermint_vm_message",
  "forest_db",
@@ -1208,6 +1209,21 @@ dependencies = [
  "tempfile",
  "tendermint",
  "tokio",
+]
+
+[[package]]
+name = "fendermint_rocksdb"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fendermint_storage",
+ "fvm_ipld_blockstore",
+ "num_cpus",
+ "rocksdb",
+ "serde",
+ "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -2238,6 +2254,7 @@ dependencies = [
  "glob",
  "libc",
  "libz-sys",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -4619,4 +4636,15 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.6+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a3f9792c0c3dc6c165840a75f47ae1f4da402c2d006881129579f6597e801b"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["fendermint/abci", "fendermint/app", "fendermint/storage", "fendermint/testing", "fendermint/vm/*"]
+members = ["fendermint/abci", "fendermint/app", "fendermint/rocksdb", "fendermint/storage", "fendermint/testing", "fendermint/vm/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -37,3 +37,7 @@ fvm_shared = "3.0.0-alpha.18"
 # Tendermint dependencies are forked because we are building against 0.37 release candidates.
 tower-abci = { git = "https://github.com/consensus-shipyard/tower-abci.git", branch = "tendermint-v0.37" }
 tendermint = { git = "https://github.com/aakoshh/tendermint-rs.git", branch = "mikhail/multi-tc-version-support" }
+
+# The current 0.2.0 version of forest_db is not published to crates.io.
+# Using the `tag` of the `forest` repo rather than the `version` of just `forest_db` so we don't get a random commit in `main`.
+forest_db = { git = "https://github.com/ChainSafe/forest.git", tag = "v0.6.0", features = ["rocksdb"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,3 @@ fvm_shared = "3.0.0-alpha.18"
 # Tendermint dependencies are forked because we are building against 0.37 release candidates.
 tower-abci = { git = "https://github.com/consensus-shipyard/tower-abci.git", branch = "tendermint-v0.37" }
 tendermint = { git = "https://github.com/aakoshh/tendermint-rs.git", branch = "mikhail/multi-tc-version-support" }
-
-# The current 0.2.0 version of forest_db is not published to crates.io.
-# Using the `tag` of the `forest` repo rather than the `version` of just `forest_db` so we don't get a random commit in `main`.
-forest_db = { git = "https://github.com/ChainSafe/forest.git", tag = "v0.6.0", features = ["rocksdb"] }

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -11,8 +11,11 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 tokio = { workspace = true }
 tendermint = { workspace = true }
+serde = { workspace = true }
 
 fendermint_abci = { path = "../abci" }
+fendermint_storage = { path = "../storage" }
+fendermint_rocksdb = { path = "../rocksdb" }
 fendermint_vm_interpreter = { path = "../vm/interpreter" }
 fendermint_vm_message = { path = "../vm/message" }
 
@@ -22,10 +25,6 @@ fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_car = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_shared = { workspace = true }
-
-# The current 0.2.0 version of forest_db is not published to crates.io.
-# Using the `tag` of the `forest` repo rather than the `version` of just `forest_db` so we don't get a random commit in `main`.
-forest_db = { git = "https://github.com/ChainSafe/forest.git", tag = "v0.6.0", features = ["rocksdb"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/fendermint/app/src/lib.rs
+++ b/fendermint/app/src/lib.rs
@@ -1,3 +1,4 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 pub mod app;
+pub mod store;

--- a/fendermint/app/src/main.rs
+++ b/fendermint/app/src/main.rs
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use fendermint_abci::ApplicationService;
-use fendermint_app::app;
+use fendermint_app::{app, store::AppStore};
+use fendermint_rocksdb::RocksDb;
 use fendermint_vm_interpreter::{
     bytes::BytesMessageInterpreter, chain::ChainMessageInterpreter, fvm::FvmMessageInterpreter,
     signed::SignedMessageInterpreter,
 };
-use forest_db::rocks::RocksDb;
+
+const APP_NAMESPACE: &'static str = "app";
 
 #[tokio::main]
 async fn main() {
@@ -17,8 +19,7 @@ async fn main() {
     let interpreter = BytesMessageInterpreter::new(interpreter);
 
     let db = open_db();
-
-    let app = app::App::new(db, interpreter);
+    let app = app::App::<_, AppStore<&'static str>, _>::new(db, APP_NAMESPACE, interpreter);
     let _service = ApplicationService(app);
 }
 
@@ -28,8 +29,7 @@ fn open_db() -> RocksDb {
 
 #[cfg(test)]
 mod tests {
-    use forest_db::rocks::RocksDb;
-    use forest_db::rocks_config::RocksDbConfig;
+    use fendermint_rocksdb::{RocksDb, RocksDbConfig};
     use fvm_ipld_car::load_car_unchecked;
 
     #[tokio::test]

--- a/fendermint/app/src/main.rs
+++ b/fendermint/app/src/main.rs
@@ -9,8 +9,6 @@ use fendermint_vm_interpreter::{
     signed::SignedMessageInterpreter,
 };
 
-const APP_NAMESPACE: &'static str = "app";
-
 #[tokio::main]
 async fn main() {
     let interpreter = FvmMessageInterpreter::<RocksDb>::new();
@@ -19,7 +17,8 @@ async fn main() {
     let interpreter = BytesMessageInterpreter::new(interpreter);
 
     let db = open_db();
-    let app = app::App::<_, AppStore<&'static str>, _>::new(db, APP_NAMESPACE, interpreter);
+    let ns = db.new_cf_handle("app").unwrap();
+    let app = app::App::<_, AppStore, _>::new(db, ns, interpreter);
     let _service = ApplicationService(app);
 }
 

--- a/fendermint/app/src/store.rs
+++ b/fendermint/app/src/store.rs
@@ -1,27 +1,21 @@
-use std::{borrow::Cow, hash::Hash, marker::PhantomData};
+use std::borrow::Cow;
 
 use fendermint_storage::{Codec, Decode, Encode, KVError, KVResult, KVStore};
 use fvm_ipld_encoding::{de::DeserializeOwned, serde::Serialize};
 
 #[derive(Clone)]
-pub struct AppStore<NS> {
-    _ns: PhantomData<NS>,
-}
+pub struct AppStore;
 
-impl<NS> KVStore for AppStore<NS>
-where
-    NS: Eq + Hash + Clone,
-{
+impl KVStore for AppStore {
     type Repr = Vec<u8>;
-    type Namespace = NS;
+    type Namespace = &'static str;
 }
 
-impl<NS, T> Codec<T> for AppStore<NS> where AppStore<NS>: Encode<T> + Decode<T> {}
+impl<T> Codec<T> for AppStore where AppStore: Encode<T> + Decode<T> {}
 
 /// CBOR serialization.
-impl<NS, T> Encode<T> for AppStore<NS>
+impl<T> Encode<T> for AppStore
 where
-    NS: Eq + Hash + Clone,
     T: Serialize,
 {
     fn to_repr(value: &T) -> KVResult<Cow<Self::Repr>> {
@@ -32,9 +26,8 @@ where
 }
 
 /// CBOR deserialization.
-impl<NS, T> Decode<T> for AppStore<NS>
+impl<T> Decode<T> for AppStore
 where
-    NS: Eq + Hash + Clone,
     T: DeserializeOwned,
 {
     fn from_repr(repr: &Self::Repr) -> KVResult<T> {

--- a/fendermint/app/src/store.rs
+++ b/fendermint/app/src/store.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use std::borrow::Cow;
 
 use fendermint_storage::{Codec, Decode, Encode, KVError, KVResult, KVStore};

--- a/fendermint/app/src/store.rs
+++ b/fendermint/app/src/store.rs
@@ -1,0 +1,43 @@
+use std::{borrow::Cow, hash::Hash, marker::PhantomData};
+
+use fendermint_storage::{Codec, Decode, Encode, KVError, KVResult, KVStore};
+use fvm_ipld_encoding::{de::DeserializeOwned, serde::Serialize};
+
+#[derive(Clone)]
+pub struct AppStore<NS> {
+    _ns: PhantomData<NS>,
+}
+
+impl<NS> KVStore for AppStore<NS>
+where
+    NS: Eq + Hash + Clone,
+{
+    type Repr = Vec<u8>;
+    type Namespace = NS;
+}
+
+impl<NS, T> Codec<T> for AppStore<NS> where AppStore<NS>: Encode<T> + Decode<T> {}
+
+/// CBOR serialization.
+impl<NS, T> Encode<T> for AppStore<NS>
+where
+    NS: Eq + Hash + Clone,
+    T: Serialize,
+{
+    fn to_repr(value: &T) -> KVResult<Cow<Self::Repr>> {
+        fvm_ipld_encoding::to_vec(value)
+            .map_err(|e| KVError::Codec(Box::new(e)))
+            .map(Cow::Owned)
+    }
+}
+
+/// CBOR deserialization.
+impl<NS, T> Decode<T> for AppStore<NS>
+where
+    NS: Eq + Hash + Clone,
+    T: DeserializeOwned,
+{
+    fn from_repr(repr: &Self::Repr) -> KVResult<T> {
+        fvm_ipld_encoding::from_slice(repr).map_err(|e| KVError::Codec(Box::new(e)))
+    }
+}

--- a/fendermint/rocksdb/Cargo.toml
+++ b/fendermint/rocksdb/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "fendermint_rocksdb"
+description = "Implement the KVStore abstraction for RocksDB"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+num_cpus = "1.14"
+rocksdb = { version = "0.19", features = ["multi-threaded-cf"] }
+anyhow = { workspace = true }
+fendermint_storage = { path = "../storage", optional = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+cid = { workspace = true, optional = true }
+fvm_ipld_blockstore = { workspace = true, optional = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[features]
+default = ["lz4", "blockstore", "kvstore"]
+blockstore = ["fvm_ipld_blockstore", "cid"]
+kvstore = ["fendermint_storage"]
+
+lz4 = ["rocksdb/lz4"]
+# snappy = ["rocksdb/snappy"]
+# zlib = ["rocksdb/zlib"]
+# bzip2 = ["rocksdb/bzip2"]
+# zstd = ["rocksdb/zstd"]

--- a/fendermint/rocksdb/src/blockstore.rs
+++ b/fendermint/rocksdb/src/blockstore.rs
@@ -1,0 +1,33 @@
+use cid::Cid;
+use fvm_ipld_blockstore::Blockstore;
+use rocksdb::WriteBatchWithTransaction;
+
+use crate::RocksDb;
+
+impl Blockstore for RocksDb {
+    fn get(&self, k: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
+        self.read(k.to_bytes()).map_err(Into::into)
+    }
+
+    fn put_keyed(&self, k: &Cid, block: &[u8]) -> anyhow::Result<()> {
+        self.write(k.to_bytes(), block).map_err(Into::into)
+    }
+
+    fn put_many_keyed<D, I>(&self, blocks: I) -> anyhow::Result<()>
+    where
+        Self: Sized,
+        D: AsRef<[u8]>,
+        I: IntoIterator<Item = (Cid, D)>,
+    {
+        let mut batch = WriteBatchWithTransaction::<true>::default();
+        for (cid, v) in blocks.into_iter() {
+            let k = cid.to_bytes();
+            let v = v.as_ref();
+            batch.put(k, v);
+        }
+        // This function is used in `fvm_ipld_car::load_car`
+        // It reduces time cost of loading mainnet snapshot
+        // by ~10% by not writing to WAL(write ahead log).
+        Ok(self.db.write_without_wal(batch)?)
+    }
+}

--- a/fendermint/rocksdb/src/blockstore.rs
+++ b/fendermint/rocksdb/src/blockstore.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use rocksdb::WriteBatchWithTransaction;

--- a/fendermint/rocksdb/src/kvstore.rs
+++ b/fendermint/rocksdb/src/kvstore.rs
@@ -1,0 +1,206 @@
+use anyhow::anyhow;
+use fendermint_storage::Decode;
+use fendermint_storage::Encode;
+use fendermint_storage::KVResult;
+use fendermint_storage::KVTransaction;
+use fendermint_storage::KVTransactionPrepared;
+use fendermint_storage::KVWritable;
+use fendermint_storage::KVWrite;
+use fendermint_storage::{KVError, KVRead, KVReadable, KVStore};
+use rocksdb::BoundColumnFamily;
+use rocksdb::ErrorKind;
+use rocksdb::OptimisticTransactionDB;
+use rocksdb::Transaction;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::marker::PhantomData;
+use std::mem::ManuallyDrop;
+use std::sync::Arc;
+use std::thread;
+
+use crate::RocksDb;
+
+/// Marker for read-only mode.
+pub struct Read;
+/// Marker for read-write mode.
+pub struct Write;
+
+pub struct RocksDbTx<'a, M> {
+    db: &'a OptimisticTransactionDB,
+    tx: ManuallyDrop<Transaction<'a, OptimisticTransactionDB>>,
+    /// Cache column families to avoid further cloning on each access.
+    cfs: RefCell<BTreeMap<String, Arc<BoundColumnFamily<'a>>>>,
+    /// Indicate read-only or read-write mode.
+    _mode: PhantomData<M>,
+    /// Flag to support sanity checking in `Drop`.
+    read_only: bool,
+}
+
+impl<'a, M> RocksDbTx<'a, M> {
+    /// Look up a column family and pass it to a closure.
+    /// Return an error if it doesn't exist.
+    fn with_cf_handle<F, T>(&self, name: &str, f: F) -> KVResult<T>
+    where
+        F: FnOnce(&Arc<BoundColumnFamily<'a>>) -> KVResult<T>,
+    {
+        let mut cfs = self.cfs.borrow_mut();
+        let cf = match cfs.get(name) {
+            Some(cf) => cf,
+            None => match self.db.cf_handle(name) {
+                None => {
+                    return Err(KVError::Unexpected(
+                        anyhow!("column family {name} doesn't exist").into(),
+                    ))
+                }
+                Some(cf) => {
+                    cfs.insert(name.to_owned(), cf);
+                    cfs.get(name).unwrap()
+                }
+            },
+        };
+        f(cf)
+    }
+}
+
+impl<S> KVReadable<S> for RocksDb
+where
+    S: KVStore<Repr = Vec<u8>>,
+    S::Namespace: AsRef<str>,
+{
+    type Tx<'a> = RocksDbTx<'a, Read>
+    where
+        Self: 'a;
+
+    fn read(&self) -> Self::Tx<'_> {
+        let tx = self.db.transaction();
+        RocksDbTx {
+            db: self.db.as_ref(),
+            tx: ManuallyDrop::new(tx),
+            cfs: Default::default(),
+            read_only: true,
+            _mode: PhantomData,
+        }
+    }
+}
+
+impl<S> KVWritable<S> for RocksDb
+where
+    S: KVStore<Repr = Vec<u8>>,
+    S::Namespace: AsRef<str>,
+{
+    type Tx<'a> = RocksDbTx<'a, Write>
+    where
+        Self: 'a;
+
+    fn write(&self) -> Self::Tx<'_> {
+        let tx = self.db.transaction();
+        RocksDbTx {
+            db: self.db.as_ref(),
+            tx: ManuallyDrop::new(tx),
+            cfs: Default::default(),
+            read_only: false,
+            _mode: PhantomData,
+        }
+    }
+}
+
+impl<'a, S, M> KVRead<S> for RocksDbTx<'a, M>
+where
+    S: KVStore<Repr = Vec<u8>>,
+    S::Namespace: AsRef<str>,
+{
+    fn get<K, V>(&self, ns: &S::Namespace, k: &K) -> KVResult<Option<V>>
+    where
+        S: Encode<K> + Decode<V>,
+    {
+        self.with_cf_handle(ns.as_ref(), |cf| {
+            let key = S::to_repr(k)?;
+
+            let res = self.tx.get_cf(cf, key.as_ref()).map_err(unexpected)?;
+
+            match res {
+                Some(bz) => Ok(Some(S::from_repr(&bz)?)),
+                None => Ok(None),
+            }
+        })
+    }
+}
+
+impl<'a, S> KVWrite<S> for RocksDbTx<'a, Write>
+where
+    S: KVStore<Repr = Vec<u8>>,
+    S::Namespace: AsRef<str>,
+{
+    fn put<K, V>(&mut self, ns: &S::Namespace, k: &K, v: &V) -> KVResult<()>
+    where
+        S: Encode<K> + Encode<V>,
+    {
+        self.with_cf_handle(ns.as_ref(), |cf| {
+            let k = S::to_repr(k)?;
+            let v = S::to_repr(v)?;
+
+            self.tx
+                .put_cf(cf, k.as_ref(), v.as_ref())
+                .map_err(unexpected)?;
+
+            Ok(())
+        })
+    }
+
+    fn delete<K>(&mut self, ns: &S::Namespace, k: &K) -> KVResult<()>
+    where
+        S: Encode<K>,
+    {
+        self.with_cf_handle(ns.as_ref(), |cf| {
+            let k = S::to_repr(k)?;
+
+            self.tx.delete_cf(cf, k.as_ref()).map_err(unexpected)?;
+
+            Ok(())
+        })
+    }
+}
+
+impl<'a> KVTransaction for RocksDbTx<'a, Write> {
+    type Prepared = Self;
+
+    fn prepare(self) -> KVResult<Option<Self::Prepared>> {
+        match self.tx.prepare() {
+            Err(e) if e.kind() == ErrorKind::Busy => Ok(None),
+            Err(e) => Err(unexpected(e)),
+            Ok(()) => Ok(Some(self)),
+        }
+    }
+
+    fn rollback(self) -> KVResult<()> {
+        self.tx.rollback().map_err(unexpected)
+    }
+}
+
+impl<'a> KVTransactionPrepared for RocksDbTx<'a, Write> {
+    fn commit(self) -> KVResult<()> {
+        // This method cleans up the transaction without running the panicky destructor.
+        let mut this = ManuallyDrop::new(self);
+        let res = unsafe {
+            let tx = ManuallyDrop::take(&mut this.tx);
+            tx.commit().map_err(unexpected)
+        };
+        res
+    }
+
+    fn rollback(self) -> KVResult<()> {
+        KVTransaction::rollback(self)
+    }
+}
+
+impl<'a, M> Drop for RocksDbTx<'a, M> {
+    fn drop(&mut self) {
+        if !self.read_only && !thread::panicking() {
+            panic!("Transaction prematurely dropped. Must call `.commit()` or `.rollback()`.");
+        }
+    }
+}
+
+fn unexpected(e: rocksdb::Error) -> KVError {
+    KVError::Unexpected(Box::new(e))
+}

--- a/fendermint/rocksdb/src/kvstore.rs
+++ b/fendermint/rocksdb/src/kvstore.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use anyhow::anyhow;
 use fendermint_storage::Decode;
 use fendermint_storage::Encode;

--- a/fendermint/rocksdb/src/kvstore.rs
+++ b/fendermint/rocksdb/src/kvstore.rs
@@ -183,11 +183,8 @@ impl<'a> KVTransactionPrepared for RocksDbTx<'a, Write> {
     fn commit(self) -> KVResult<()> {
         // This method cleans up the transaction without running the panicky destructor.
         let mut this = ManuallyDrop::new(self);
-        let res = unsafe {
-            let tx = ManuallyDrop::take(&mut this.tx);
-            tx.commit().map_err(unexpected)
-        };
-        res
+        let tx = unsafe { ManuallyDrop::take(&mut this.tx) };
+        tx.commit().map_err(unexpected)
     }
 
     fn rollback(self) -> KVResult<()> {

--- a/fendermint/rocksdb/src/lib.rs
+++ b/fendermint/rocksdb/src/lib.rs
@@ -1,0 +1,8 @@
+mod rocks;
+
+#[cfg(feature = "blockstore")]
+mod blockstore;
+#[cfg(feature = "kvstore")]
+mod kvstore;
+
+pub use rocks::{Error as RocksDbError, RocksDb, RocksDbConfig};

--- a/fendermint/rocksdb/src/lib.rs
+++ b/fendermint/rocksdb/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 mod rocks;
 
 #[cfg(feature = "blockstore")]

--- a/fendermint/rocksdb/src/rocks/config.rs
+++ b/fendermint/rocksdb/src/rocks/config.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use anyhow::anyhow;
-use num_cpus;
 use rocksdb::{
     BlockBasedOptions, Cache, DBCompactionStyle, DBCompressionType, DataBlockIndexType, LogLevel,
     Options,
@@ -49,9 +48,8 @@ impl Default for RocksDbConfig {
     }
 }
 
-impl Into<Options> for &RocksDbConfig {
-    fn into(self) -> Options {
-        let config = self;
+impl From<&RocksDbConfig> for Options {
+    fn from(config: &RocksDbConfig) -> Self {
         let mut db_opts = Options::default();
         db_opts.create_if_missing(config.create_if_missing);
         db_opts.increase_parallelism(config.parallelism);

--- a/fendermint/rocksdb/src/rocks/config.rs
+++ b/fendermint/rocksdb/src/rocks/config.rs
@@ -1,3 +1,4 @@
+// Copyright 2022-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/fendermint/rocksdb/src/rocks/config.rs
+++ b/fendermint/rocksdb/src/rocks/config.rs
@@ -1,0 +1,213 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use anyhow::anyhow;
+use num_cpus;
+use rocksdb::{
+    BlockBasedOptions, Cache, DBCompactionStyle, DBCompressionType, DataBlockIndexType, LogLevel,
+    Options,
+};
+use serde::{Deserialize, Serialize};
+
+/// Only subset of possible options is implemented, add missing ones when needed.
+/// For description of different options please refer to the `rocksdb` crate documentation.
+/// <https://docs.rs/rocksdb/latest/rocksdb/>
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RocksDbConfig {
+    pub create_if_missing: bool,
+    pub parallelism: i32,
+    /// This is the `memtable` size in bytes.
+    pub write_buffer_size: usize,
+    pub max_open_files: i32,
+    pub max_background_jobs: Option<i32>,
+    pub compaction_style: String,
+    pub compression_type: String,
+    pub enable_statistics: bool,
+    pub stats_dump_period_sec: u32,
+    pub log_level: String,
+    pub optimize_filters_for_hits: bool,
+    pub optimize_for_point_lookup: i32,
+}
+
+impl Default for RocksDbConfig {
+    fn default() -> Self {
+        Self {
+            create_if_missing: true,
+            parallelism: num_cpus::get() as i32,
+            write_buffer_size: 2usize.pow(30), // 1 GiB
+            max_open_files: -1,
+            max_background_jobs: None,
+            compaction_style: "none".into(),
+            compression_type: "lz4".into(),
+            enable_statistics: false,
+            stats_dump_period_sec: 600,
+            log_level: "warn".into(),
+            optimize_filters_for_hits: true,
+            optimize_for_point_lookup: 8,
+        }
+    }
+}
+
+impl Into<Options> for &RocksDbConfig {
+    fn into(self) -> Options {
+        let config = self;
+        let mut db_opts = Options::default();
+        db_opts.create_if_missing(config.create_if_missing);
+        db_opts.increase_parallelism(config.parallelism);
+        db_opts.set_write_buffer_size(config.write_buffer_size);
+        db_opts.set_max_open_files(config.max_open_files);
+
+        if let Some(max_background_jobs) = config.max_background_jobs {
+            db_opts.set_max_background_jobs(max_background_jobs);
+        }
+        if let Some(compaction_style) = compaction_style_from_str(&config.compaction_style).unwrap()
+        {
+            db_opts.set_compaction_style(compaction_style);
+            db_opts.set_disable_auto_compactions(false);
+        } else {
+            db_opts.set_disable_auto_compactions(true);
+        }
+        db_opts.set_compression_type(compression_type_from_str(&config.compression_type).unwrap());
+        if config.enable_statistics {
+            db_opts.set_stats_dump_period_sec(config.stats_dump_period_sec);
+            db_opts.enable_statistics();
+        };
+        db_opts.set_log_level(log_level_from_str(&config.log_level).unwrap());
+        db_opts.set_optimize_filters_for_hits(config.optimize_filters_for_hits);
+        // Comes from https://github.com/facebook/rocksdb/blob/main/options/options.cc#L606
+        // Only modified to upgrade format to v5
+        if !config.optimize_for_point_lookup.is_negative() {
+            let cache_size = config.optimize_for_point_lookup as usize;
+            let mut opts = BlockBasedOptions::default();
+            opts.set_format_version(5);
+            opts.set_data_block_index_type(DataBlockIndexType::BinaryAndHash);
+            opts.set_data_block_hash_ratio(0.75);
+            opts.set_bloom_filter(10.0, false);
+            let cache = Cache::new_lru_cache(cache_size * 1024 * 1024).unwrap();
+            opts.set_block_cache(&cache);
+            db_opts.set_block_based_table_factory(&opts);
+            db_opts.set_memtable_prefix_bloom_ratio(0.02);
+            db_opts.set_memtable_whole_key_filtering(true);
+        }
+        db_opts
+    }
+}
+
+/// Converts string to a compaction style `RocksDB` variant.
+fn compaction_style_from_str(s: &str) -> anyhow::Result<Option<DBCompactionStyle>> {
+    match s.to_lowercase().as_str() {
+        "level" => Ok(Some(DBCompactionStyle::Level)),
+        "universal" => Ok(Some(DBCompactionStyle::Universal)),
+        "fifo" => Ok(Some(DBCompactionStyle::Fifo)),
+        "none" => Ok(None),
+        _ => Err(anyhow!("invalid compaction option")),
+    }
+}
+
+/// Converts string to a compression type `RocksDB` variant.
+fn compression_type_from_str(s: &str) -> anyhow::Result<DBCompressionType> {
+    let valid_options = [
+        #[cfg(feature = "bzip2")]
+        "bz2",
+        #[cfg(feature = "lz4")]
+        "lz4",
+        #[cfg(feature = "lz4")]
+        "lz4hc",
+        #[cfg(feature = "snappy")]
+        "snappy",
+        #[cfg(feature = "zlib")]
+        "zlib",
+        #[cfg(feature = "zstd")]
+        "zstd",
+        "none",
+    ];
+    match s.to_lowercase().as_str() {
+        #[cfg(feature = "bzip2")]
+        "bz2" => Ok(DBCompressionType::Bz2),
+        #[cfg(feature = "lz4")]
+        "lz4" => Ok(DBCompressionType::Lz4),
+        #[cfg(feature = "lz4")]
+        "lz4hc" => Ok(DBCompressionType::Lz4hc),
+        #[cfg(feature = "snappy")]
+        "snappy" => Ok(DBCompressionType::Snappy),
+        #[cfg(feature = "zlib")]
+        "zlib" => Ok(DBCompressionType::Zlib),
+        #[cfg(feature = "zstd")]
+        "zstd" => Ok(DBCompressionType::Zstd),
+        "none" => Ok(DBCompressionType::None),
+        opt => Err(anyhow!(
+            "invalid compression option: {opt}, valid options: {}",
+            valid_options.join(",")
+        )),
+    }
+}
+
+/// Converts string to a log level `RocksDB` variant.
+fn log_level_from_str(s: &str) -> anyhow::Result<LogLevel> {
+    match s.to_lowercase().as_str() {
+        "debug" => Ok(LogLevel::Debug),
+        "warn" => Ok(LogLevel::Warn),
+        "error" => Ok(LogLevel::Error),
+        "fatal" => Ok(LogLevel::Fatal),
+        "header" => Ok(LogLevel::Header),
+        _ => Err(anyhow!("invalid log level option")),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rocksdb::DBCompactionStyle;
+
+    #[test]
+    fn compaction_style_from_str_test() {
+        let test_cases = vec![
+            ("Level", Ok(Some(DBCompactionStyle::Level))),
+            ("UNIVERSAL", Ok(Some(DBCompactionStyle::Universal))),
+            ("fifo", Ok(Some(DBCompactionStyle::Fifo))),
+            ("none", Ok(None)),
+            ("cthulhu", Err(anyhow!("some error message"))),
+        ];
+        for (input, expected) in test_cases {
+            let actual = compaction_style_from_str(input);
+            if let Ok(compaction_style) = actual {
+                assert_eq!(expected.unwrap(), compaction_style);
+            } else {
+                assert!(expected.is_err());
+            }
+        }
+    }
+
+    #[test]
+    fn compression_style_from_str_test() {
+        let test_cases = vec![
+            #[cfg(feature = "bzip2")]
+            ("bz2", Ok(DBCompressionType::Bz2)),
+            #[cfg(feature = "lz4")]
+            ("lz4", Ok(DBCompressionType::Lz4)),
+            #[cfg(feature = "lz4")]
+            ("lz4HC", Ok(DBCompressionType::Lz4hc)),
+            #[cfg(feature = "snappy")]
+            ("SNAPPY", Ok(DBCompressionType::Snappy)),
+            #[cfg(feature = "zlib")]
+            ("zlib", Ok(DBCompressionType::Zlib)),
+            #[cfg(feature = "zstd")]
+            ("ZSTD", Ok(DBCompressionType::Zstd)),
+            ("none", Ok(DBCompressionType::None)),
+            ("cthulhu", Err(anyhow!("some error message"))),
+        ];
+        for (input, expected) in test_cases {
+            let actual = compression_type_from_str(input);
+            if let Ok(compression_type) = actual {
+                assert_eq!(expected.unwrap(), compression_type);
+                let dir = tempfile::tempdir().unwrap();
+                let mut opt = rocksdb::Options::default();
+                opt.create_if_missing(true);
+                opt.set_compression_type(compression_type);
+                rocksdb::DB::open(&opt, dir.path()).unwrap();
+            } else {
+                assert!(expected.is_err());
+            }
+        }
+    }
+}

--- a/fendermint/rocksdb/src/rocks/error.rs
+++ b/fendermint/rocksdb/src/rocks/error.rs
@@ -1,0 +1,13 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use thiserror::Error;
+
+/// Database error
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    Database(#[from] rocksdb::Error),
+    #[error("{0}")]
+    Other(String),
+}

--- a/fendermint/rocksdb/src/rocks/error.rs
+++ b/fendermint/rocksdb/src/rocks/error.rs
@@ -1,3 +1,4 @@
+// Copyright 2022-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/fendermint/rocksdb/src/rocks/mod.rs
+++ b/fendermint/rocksdb/src/rocks/mod.rs
@@ -1,0 +1,92 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use rocksdb::{OptimisticTransactionDB, Options, WriteBatchWithTransaction};
+use std::{path::Path, sync::Arc};
+
+mod config;
+mod error;
+
+pub use config::RocksDbConfig;
+pub use error::Error;
+
+#[derive(Clone)]
+pub struct RocksDb {
+    pub db: Arc<OptimisticTransactionDB>,
+    options: Options,
+}
+
+/// `RocksDb` is used as the KV store. Unlike the implementation in Forest
+/// which is using the `DB` type, this one is using `OptimisticTransactionDB`
+/// so that we can make use of transactions that can be rolled back.
+///
+/// Usage:
+/// ```no_run
+/// use fendermint_rocksdb::{RocksDb, RocksDbConfig};
+///
+/// let mut db = RocksDb::open("test_db", &RocksDbConfig::default()).unwrap();
+/// ```
+impl RocksDb {
+    pub fn open<P>(path: P, config: &RocksDbConfig) -> Result<Self, Error>
+    where
+        P: AsRef<Path>,
+    {
+        let db_opts = config.into();
+        Ok(Self {
+            db: Arc::new(OptimisticTransactionDB::open(&db_opts, path)?),
+            options: db_opts,
+        })
+    }
+
+    pub fn get_statistics(&self) -> Option<String> {
+        self.options.get_statistics()
+    }
+
+    pub fn read<K>(&self, key: K) -> Result<Option<Vec<u8>>, Error>
+    where
+        K: AsRef<[u8]>,
+    {
+        self.db.get(key).map_err(Error::from)
+    }
+
+    pub fn write<K, V>(&self, key: K, value: V) -> Result<(), Error>
+    where
+        K: AsRef<[u8]>,
+        V: AsRef<[u8]>,
+    {
+        Ok(self.db.put(key, value)?)
+    }
+
+    pub fn delete<K>(&self, key: K) -> Result<(), Error>
+    where
+        K: AsRef<[u8]>,
+    {
+        Ok(self.db.delete(key)?)
+    }
+
+    pub fn exists<K>(&self, key: K) -> Result<bool, Error>
+    where
+        K: AsRef<[u8]>,
+    {
+        self.db
+            .get_pinned(key)
+            .map(|v| v.is_some())
+            .map_err(Error::from)
+    }
+
+    pub fn bulk_write<K, V>(&self, values: &[(K, V)]) -> Result<(), Error>
+    where
+        K: AsRef<[u8]>,
+        V: AsRef<[u8]>,
+    {
+        let mut batch = WriteBatchWithTransaction::<true>::default();
+        for (k, v) in values {
+            batch.put(k, v);
+        }
+        Ok(self.db.write_without_wal(batch)?)
+    }
+
+    pub fn flush(&self) -> Result<(), Error> {
+        self.db.flush().map_err(|e| Error::Other(e.to_string()))
+    }
+}

--- a/fendermint/rocksdb/src/rocks/mod.rs
+++ b/fendermint/rocksdb/src/rocks/mod.rs
@@ -89,4 +89,17 @@ impl RocksDb {
     pub fn flush(&self) -> Result<(), Error> {
         self.db.flush().map_err(|e| Error::Other(e.to_string()))
     }
+
+    /// Create a new column family, using the default options.
+    ///
+    /// Returns error if it already exists.
+    pub fn new_cf_handle<'a>(&self, name: &'a str) -> Result<&'a str, Error> {
+        if self.db.cf_handle(name).is_some() {
+            return Err(Error::Other(format!(
+                "column family '{name}' already exists"
+            )));
+        }
+        self.db.create_cf(name, &self.options)?;
+        Ok(name)
+    }
 }

--- a/fendermint/rocksdb/src/rocks/mod.rs
+++ b/fendermint/rocksdb/src/rocks/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2022-2023 Protocol Labs
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/fendermint/storage/src/lib.rs
+++ b/fendermint/storage/src/lib.rs
@@ -12,6 +12,8 @@ pub mod im;
 /// Possible errors during key-value operations.
 #[derive(Debug)]
 pub enum KVError {
+    /// The operation failed because there was a write conflict.
+    Conflict,
     /// KV transaction was aborted due to some business rule violation.
     Abort(Box<dyn Error + Send + Sync>),
     /// An error occurred during serializing or deserializing the data.


### PR DESCRIPTION
Related to #16 

Implements `KVStore` for RocksDB. Unfortunately I could not use the Forest RocksDB library any more, because even if I specified the `multi-threaded-cf` feature which is required for `.transaction()`, I had to create an `OptimisticTransactionDB`, not a `DB`, so I ended up copying a lot of the Forest code. 
 
The PR changes `App` to use `KVStore`. 

In this instance, after so much work, it doesn't make a difference because we don't modify the app state concurrently, nor do we perform multiple steps during writes/reads. Still, it felt right to put the data into a different column family, and at least this way we can use the same abstraction elsewhere in the application, like for relayers. Another area is where it can help is supporting queries by maintaining a list of the past N state roots. If it's slow, we can always go back. 

I will add tests in a follow up PR.