### PR TITLE
FM-25: Remove KVPreparedTransaction

### DIFF
--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -7,9 +7,7 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use cid::Cid;
 use fendermint_abci::Application;
-use fendermint_storage::{
-    Codec, Encode, KVRead, KVReadable, KVStore, KVTransaction, KVWritable, KVWrite,
-};
+use fendermint_storage::{Codec, Encode, KVRead, KVReadable, KVStore, KVWritable, KVWrite};
 use fendermint_vm_interpreter::bytes::BytesMessageApplyRet;
 use fendermint_vm_interpreter::chain::ChainMessageApplyRet;
 use fendermint_vm_interpreter::fvm::{FvmApplyRet, FvmState};
@@ -94,11 +92,9 @@ where
 
     /// Set the last committed state.
     fn set_committed_state(&self, state: AppState) {
-        let mut tx = self.db.write();
-        tx.put(&self.namespace, &AppStoreKey::State, &state)
-            .expect("put failed");
-        let committed = tx.prepare_and_commit().expect("commit failed");
-        assert!(committed, "not committed")
+        self.db
+            .with_write(|tx| tx.put(&self.namespace, &AppStoreKey::State, &state))
+            .expect("commit failed");
     }
 
     /// Put the execution state during block execution. Has to be empty.

--- a/fendermint/storage/src/lib.rs
+++ b/fendermint/storage/src/lib.rs
@@ -108,6 +108,17 @@ pub trait KVWritable<S: KVStore> {
 
     /// Start a read-write tranasction.
     fn write(&self) -> Self::Tx<'_>;
+
+    /// Start a read-write transaction, use it, then commit.
+    fn with_write<F, T>(&self, f: F) -> KVResult<T>
+    where
+        F: FnOnce(&mut Self::Tx<'_>) -> KVResult<T>,
+    {
+        let mut tx = self.write();
+        let res = f(&mut tx)?;
+        tx.commit()?;
+        Ok(res)
+    }
 }
 
 /// A collection of homogenous objects under the same namespace.

--- a/fendermint/storage/src/tests.rs
+++ b/fendermint/storage/src/tests.rs
@@ -240,7 +240,7 @@ where
                 _ => (),
             }
         }
-        tx.prepare_and_commit().unwrap();
+        tx.commit().unwrap();
     };
 
     let sutc = sut.clone();
@@ -335,7 +335,7 @@ where
     }
 
     // Commit the writes, but they should still not be visible to the reads that started earlier.
-    txw.prepare_and_commit().unwrap();
+    txw.commit().unwrap();
 
     for (ns, op) in &gets {
         let coll = colls.s2i(ns);


### PR DESCRIPTION
Closes #25

The PR removes the `prepare()` method because it works differently in RocksDB than I imagined. Unlike `put`, `delete` and `commit`, the docs do not mention that it could return `Busy`, so I imagine that it does not check for conflicts. It might do, but it doesn't say, just that it prepares for two phase commit by writing changes to the WAL. 

I got rid of it in favor of allowing `commit` to return `KVResult::Conflict` to signal that it failed. I will update STM to expect this workflow.