### PR TITLE
FM-18: Check transactions

### DIFF
--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -8,13 +8,14 @@ use async_trait::async_trait;
 use cid::Cid;
 use fendermint_abci::Application;
 use fendermint_storage::{Codec, Encode, KVRead, KVReadable, KVStore, KVWritable, KVWrite};
-use fendermint_vm_interpreter::bytes::BytesMessageApplyRet;
-use fendermint_vm_interpreter::chain::ChainMessageApplyRet;
-use fendermint_vm_interpreter::fvm::{FvmApplyRet, FvmState};
-use fendermint_vm_interpreter::signed::SignedMesssageApplyRet;
-use fendermint_vm_interpreter::{Interpreter, Timestamp};
+use fendermint_vm_interpreter::bytes::{BytesMessageApplyRet, BytesMessageCheckRet};
+use fendermint_vm_interpreter::chain::{ChainMessageApplyRet, IllegalMessage};
+use fendermint_vm_interpreter::fvm::{FvmApplyRet, FvmCheckRet, FvmCheckState, FvmState};
+use fendermint_vm_interpreter::signed::InvalidSignature;
+use fendermint_vm_interpreter::{CheckInterpreter, Interpreter, Timestamp};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::econ::TokenAmount;
+use fvm_shared::error::ExitCode;
 use fvm_shared::event::StampedEvent;
 use fvm_shared::version::NetworkVersion;
 use serde::{Deserialize, Serialize};
@@ -35,6 +36,8 @@ enum AppError {
     InvalidEncoding = 51,
     /// Failed to validate the user signature.
     InvalidSignature = 52,
+    /// User sent a message they should not construct.
+    IllegalMessage = 53,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -46,6 +49,15 @@ pub struct AppState {
     circ_supply: TokenAmount,
 }
 
+struct AppStore<DB, S>
+where
+    DB: Blockstore + 'static,
+    S: KVStore,
+{
+    db: DB,
+    namespace: S::Namespace,
+}
+
 /// Handle ABCI requests.
 #[derive(Clone)]
 pub struct App<DB, S, I>
@@ -53,31 +65,32 @@ where
     DB: Blockstore + 'static,
     S: KVStore,
 {
-    db: Arc<DB>,
-    /// Namespace under which to persist application state.
-    namespace: S::Namespace,
+    store: Arc<AppStore<DB, S>>,
     /// Interpreter for block lifecycle events.
     interpreter: Arc<I>,
     /// State accumulating changes during block execution.
     exec_state: Arc<Mutex<Option<FvmState<DB>>>>,
+    /// Projected partial state accumulating during transaction checks.
+    check_state: Arc<tokio::sync::Mutex<Option<FvmCheckState<DB>>>>,
 }
 
 impl<DB, S, I> App<DB, S, I>
 where
-    DB: Blockstore + 'static,
-    S: KVStore,
+    S: KVStore + Codec<AppState> + Encode<AppStoreKey>,
+    DB: Blockstore + KVWritable<S> + KVReadable<S> + Clone + 'static,
 {
     pub fn new(db: DB, namespace: S::Namespace, interpreter: I) -> Self {
+        let store = AppStore { db, namespace };
         Self {
-            db: Arc::new(db),
-            namespace,
+            store: Arc::new(store),
             interpreter: Arc::new(interpreter),
             exec_state: Arc::new(Mutex::new(None)),
+            check_state: Arc::new(tokio::sync::Mutex::new(None)),
         }
     }
 }
 
-impl<DB, S, I> App<DB, S, I>
+impl<DB, S> AppStore<DB, S>
 where
     S: KVStore + Codec<AppState> + Encode<AppStoreKey>,
     DB: Blockstore + KVWritable<S> + KVReadable<S> + 'static,
@@ -96,7 +109,13 @@ where
             .with_write(|tx| tx.put(&self.namespace, &AppStoreKey::State, &state))
             .expect("commit failed");
     }
+}
 
+impl<DB, S, I> App<DB, S, I>
+where
+    DB: Blockstore + 'static,
+    S: KVStore,
+{
     /// Put the execution state during block execution. Has to be empty.
     fn put_exec_state(&self, state: FvmState<DB>) {
         let mut guard = self.exec_state.lock().expect("mutex poisoned");
@@ -132,7 +151,7 @@ where
 impl<DB, S, I> Application for App<DB, S, I>
 where
     S: KVStore + Codec<AppState> + Encode<AppStoreKey>,
-    S::Namespace: Sync,
+    S::Namespace: Sync + Send,
     DB: Blockstore + KVWritable<S> + KVReadable<S> + Clone + Send + Sync + 'static,
     I: Interpreter<
         State = FvmState<DB>,
@@ -141,10 +160,15 @@ where
         DeliverOutput = BytesMessageApplyRet,
         EndOutput = (),
     >,
+    I: CheckInterpreter<
+        State = FvmCheckState<DB>,
+        Message = Vec<u8>,
+        Output = BytesMessageCheckRet,
+    >,
 {
     /// Provide information about the ABCI application.
     async fn info(&self, _request: request::Info) -> response::Info {
-        let state = self.committed_state();
+        let state = self.store.committed_state();
         let height =
             tendermint::block::Height::try_from(state.block_height).expect("height too big");
         let app_hash = tendermint::hash::AppHash::try_from(state.state_root.to_bytes())
@@ -169,13 +193,41 @@ where
     }
 
     /// Check the given transaction before putting it into the local mempool.
-    async fn check_tx(&self, _request: request::CheckTx) -> response::CheckTx {
-        todo!("make an interpreter for checks, on a projected state")
+    async fn check_tx(&self, request: request::CheckTx) -> response::CheckTx {
+        // Keep the guard through the check, so there can be only one at a time.
+        let mut guard = self.check_state.lock().await;
+
+        let state = guard.take().unwrap_or_else(|| {
+            let state = self.store.committed_state();
+            FvmCheckState::new(self.store.db.clone(), state.state_root)
+                .expect("error creating check state")
+        });
+
+        // TODO: We can make use of `request.kind` to skip signature checks on repeated calls.
+        let (state, result) = self
+            .interpreter
+            .check(state, request.tx.to_vec())
+            .await
+            .expect("error running check");
+
+        // Update the check state.
+        *guard = Some(state);
+
+        match result {
+            Err(e) => invalid_check_tx(AppError::InvalidEncoding, e.description),
+            Ok(result) => match result {
+                Err(IllegalMessage) => invalid_check_tx(AppError::IllegalMessage, "".to_owned()),
+                Ok(result) => match result {
+                    Err(InvalidSignature(d)) => invalid_check_tx(AppError::InvalidSignature, d),
+                    Ok(ret) => to_check_tx(ret),
+                },
+            },
+        }
     }
 
     /// Signals the beginning of a new block, prior to any `DeliverTx` calls.
     async fn begin_block(&self, request: request::BeginBlock) -> response::BeginBlock {
-        let state = self.committed_state();
+        let state = self.store.committed_state();
         let height = request.header.height.into();
         let timestamp = Timestamp(
             request
@@ -185,7 +237,7 @@ where
                 .try_into()
                 .expect("negative timestamp"),
         );
-        let db = self.db.as_ref().to_owned();
+        let db = self.store.db.clone();
 
         let state = FvmState::new(
             db,
@@ -219,12 +271,10 @@ where
         match result {
             Err(e) => invalid_deliver_tx(AppError::InvalidEncoding, e.description),
             Ok(ret) => match ret {
-                ChainMessageApplyRet::Signed(SignedMesssageApplyRet::InvalidSignature(d)) => {
+                ChainMessageApplyRet::Signed(Err(InvalidSignature(d))) => {
                     invalid_deliver_tx(AppError::InvalidSignature, d)
                 }
-                ChainMessageApplyRet::Signed(SignedMesssageApplyRet::Applied(ret)) => {
-                    to_deliver_tx(ret)
-                }
+                ChainMessageApplyRet::Signed(Ok(ret)) => to_deliver_tx(ret),
             },
         }
     }
@@ -245,9 +295,13 @@ where
         let exec_state = self.take_exec_state();
         let state_root = exec_state.commit().expect("failed to commit FVM");
 
-        let mut state = self.committed_state();
+        let mut state = self.store.committed_state();
         state.state_root = state_root;
-        self.set_committed_state(state);
+        self.store.set_committed_state(state);
+
+        // Reset check state.
+        let mut guard = self.check_state.lock().await;
+        *guard = None;
 
         response::Commit {
             data: state_root.to_bytes().into(),
@@ -267,15 +321,19 @@ fn invalid_deliver_tx(err: AppError, description: String) -> response::DeliverTx
     }
 }
 
+/// Response to check where the input was blatantly invalid.
+/// This indicates that the user who sent the transaction is either attacking or has a faulty client.
+fn invalid_check_tx(err: AppError, description: String) -> response::CheckTx {
+    response::CheckTx {
+        code: Code::Err(NonZeroU32::try_from(err as u32).expect("error codes are non-zero")),
+        info: description,
+        ..Default::default()
+    }
+}
+
 fn to_deliver_tx(ret: FvmApplyRet) -> response::DeliverTx {
     let receipt = ret.apply_ret.msg_receipt;
-    let code = if receipt.exit_code.is_success() {
-        Code::Ok
-    } else {
-        Code::Err(
-            NonZeroU32::try_from(receipt.exit_code.value()).expect("error codes are non-zero"),
-        )
-    };
+    let code = to_code(receipt.exit_code);
 
     // Based on the sanity check in the `DefaultExecutor`.
     // gas_cost = gas_fee_cap * gas_limit; this is how much the account is charged up front.
@@ -296,6 +354,23 @@ fn to_deliver_tx(ret: FvmApplyRet) -> response::DeliverTx {
         gas_used,
         events,
         codespace: Default::default(),
+    }
+}
+
+fn to_check_tx(ret: FvmCheckRet) -> response::CheckTx {
+    response::CheckTx {
+        code: to_code(ret.exit_code),
+        gas_wanted: ret.gas_limit.try_into().expect("gas wanted not i64"),
+        sender: ret.sender.to_string(),
+        ..Default::default()
+    }
+}
+
+fn to_code(exit_code: ExitCode) -> Code {
+    if exit_code.is_success() {
+        Code::Ok
+    } else {
+        Code::Err(NonZeroU32::try_from(exit_code.value()).expect("error codes are non-zero"))
     }
 }
 

--- a/fendermint/storage/src/testing.rs
+++ b/fendermint/storage/src/testing.rs
@@ -15,7 +15,7 @@ pub type TestNamespace = &'static str;
 
 /// Return all namespaces used by the tests, so they can be pre-allocated, if necessary.
 pub fn test_namespaces() -> &'static [&'static str] {
-    ["foo", "bar", "fizz", "buzz", "spam", "eggs"].as_slice()
+    ["fizz", "buzz", "spam", "eggs"].as_slice()
 }
 
 /// Test operations on some collections with known types,
@@ -45,8 +45,8 @@ impl Arbitrary for TestOpNs {
     fn arbitrary(g: &mut Gen) -> Self {
         use TestOpKV::*;
         use TestOpNs::*;
-        match u8::arbitrary(g) % 10 {
-            i if i < 4 => {
+        match u8::arbitrary(g) % 100 {
+            i if i < 47 => {
                 let ns = g.choose(&["spam", "eggs"]).unwrap();
                 let k = *g.choose(&["foo", "bar"]).unwrap();
                 match u8::arbitrary(g) % 10 {
@@ -55,7 +55,7 @@ impl Arbitrary for TestOpNs {
                     _ => S2I(ns, Del(k.to_owned())),
                 }
             }
-            i if i < 9 => {
+            i if i < 94 => {
                 let ns = g.choose(&["fizz", "buzz"]).unwrap();
                 let k = u8::arbitrary(g) % 2;
                 match u8::arbitrary(g) % 10 {

--- a/fendermint/vm/interpreter/src/bytes.rs
+++ b/fendermint/vm/interpreter/src/bytes.rs
@@ -4,9 +4,13 @@ use async_trait::async_trait;
 
 use fendermint_vm_message::chain::ChainMessage;
 
-use crate::{chain::ChainMessageApplyRet, Interpreter};
+use crate::{
+    chain::{ChainMessageApplyRet, ChainMessageCheckRet},
+    CheckInterpreter, Interpreter,
+};
 
 pub type BytesMessageApplyRet = Result<ChainMessageApplyRet, fvm_ipld_encoding::Error>;
+pub type BytesMessageCheckRet = Result<ChainMessageCheckRet, fvm_ipld_encoding::Error>;
 
 /// Interpreter working on raw bytes.
 #[derive(Clone)]
@@ -40,7 +44,7 @@ where
             Err(e) =>
             // TODO: Punish the validator for including rubbish.
             // There is always the possibility that our codebase is incompatible,
-            // but then we'll have a consensu failure.
+            // but then we'll have a consensus failure later when we don't agree on the ledger.
             {
                 Ok((state, Err(e)))
             }
@@ -57,5 +61,33 @@ where
 
     async fn end(&self, state: Self::State) -> anyhow::Result<(Self::State, Self::EndOutput)> {
         self.inner.end(state).await
+    }
+}
+
+#[async_trait]
+impl<I> CheckInterpreter for BytesMessageInterpreter<I>
+where
+    I: CheckInterpreter<Message = ChainMessage, Output = ChainMessageCheckRet>,
+{
+    type State = I::State;
+    type Message = Vec<u8>;
+    type Output = BytesMessageCheckRet;
+
+    async fn check(
+        &self,
+        state: Self::State,
+        msg: Self::Message,
+    ) -> anyhow::Result<(Self::State, Self::Output)> {
+        match fvm_ipld_encoding::from_slice::<ChainMessage>(&msg) {
+            Err(e) =>
+            // The user sent us an invalid message, all we can do is discard it and block the source.
+            {
+                Ok((state, Err(e)))
+            }
+            Ok(msg) => {
+                let (state, ret) = self.inner.check(state, msg).await?;
+                Ok((state, Ok(ret)))
+            }
+        }
     }
 }

--- a/fendermint/vm/interpreter/src/chain.rs
+++ b/fendermint/vm/interpreter/src/chain.rs
@@ -4,7 +4,21 @@ use async_trait::async_trait;
 
 use fendermint_vm_message::{chain::ChainMessage, signed::SignedMessage};
 
-use crate::{signed::SignedMesssageApplyRet, Interpreter};
+use crate::{
+    signed::{SignedMessageApplyRet, SignedMessageCheckRet},
+    CheckInterpreter, Interpreter,
+};
+
+/// A message a user is not supposed to send.
+pub struct IllegalMessage;
+
+// For now this is the only option, later we can expand.
+pub enum ChainMessageApplyRet {
+    Signed(SignedMessageApplyRet),
+}
+
+/// We only allow signed messages into the mempool.
+pub type ChainMessageCheckRet = Result<SignedMessageCheckRet, IllegalMessage>;
 
 /// Interpreter working on chain messages; in the future it will schedule
 /// CID lookups to turn references into self-contained user or cross messages.
@@ -19,14 +33,10 @@ impl<I> ChainMessageInterpreter<I> {
     }
 }
 
-pub enum ChainMessageApplyRet {
-    Signed(SignedMesssageApplyRet),
-}
-
 #[async_trait]
 impl<I> Interpreter for ChainMessageInterpreter<I>
 where
-    I: Interpreter<Message = SignedMessage, DeliverOutput = SignedMesssageApplyRet>,
+    I: Interpreter<Message = SignedMessage, DeliverOutput = SignedMessageApplyRet>,
 {
     type State = I::State;
     type Message = ChainMessage;
@@ -53,5 +63,29 @@ where
 
     async fn end(&self, state: Self::State) -> anyhow::Result<(Self::State, Self::EndOutput)> {
         self.inner.end(state).await
+    }
+}
+
+#[async_trait]
+impl<I> CheckInterpreter for ChainMessageInterpreter<I>
+where
+    I: CheckInterpreter<Message = SignedMessage, Output = SignedMessageCheckRet>,
+{
+    type State = I::State;
+    type Message = ChainMessage;
+    type Output = ChainMessageCheckRet;
+
+    async fn check(
+        &self,
+        state: Self::State,
+        msg: Self::Message,
+    ) -> anyhow::Result<(Self::State, Self::Output)> {
+        match msg {
+            ChainMessage::Signed(msg) => {
+                let (state, ret) = self.inner.check(state, msg).await?;
+
+                Ok((state, Ok(ret)))
+            }
+        }
     }
 }

--- a/fendermint/vm/interpreter/src/fvm.rs
+++ b/fendermint/vm/interpreter/src/fvm.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use std::marker::PhantomData;
 
+use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 
 use cid::Cid;
@@ -11,12 +12,16 @@ use fvm::{
     engine::{EngineConfig, EnginePool},
     executor::{ApplyRet, DefaultExecutor, Executor},
     machine::{DefaultMachine, Machine, NetworkConfig},
+    state_tree::StateTree,
     DefaultKernel,
 };
 use fvm_ipld_blockstore::Blockstore;
-use fvm_shared::{clock::ChainEpoch, econ::TokenAmount, version::NetworkVersion, BLOCK_GAS_LIMIT};
+use fvm_shared::{
+    address::Address, clock::ChainEpoch, econ::TokenAmount, error::ExitCode,
+    version::NetworkVersion, BLOCK_GAS_LIMIT,
+};
 
-use crate::{externs::FendermintExterns, Interpreter, Timestamp};
+use crate::{externs::FendermintExterns, CheckInterpreter, Interpreter, Timestamp};
 
 pub type FvmMessage = fvm_shared::message::Message;
 
@@ -27,6 +32,14 @@ pub type FvmMessage = fvm_shared::message::Message;
 pub struct FvmApplyRet {
     pub apply_ret: ApplyRet,
     pub gas_limit: u64,
+}
+
+/// Transaction check results are expressed by the exit code, so that hopefully
+/// they would result in the same error code if they were applied.
+pub struct FvmCheckRet {
+    pub sender: Address,
+    pub gas_limit: u64,
+    pub exit_code: ExitCode,
 }
 
 /// A state we create for the execution of all the messages in a block.
@@ -47,7 +60,7 @@ where
         block_height: ChainEpoch,
         block_timestamp: Timestamp,
         network_version: NetworkVersion,
-        initial_state: Cid,
+        initial_state_root: Cid,
         base_fee: TokenAmount,
         circ_supply: TokenAmount,
     ) -> anyhow::Result<Self> {
@@ -56,7 +69,7 @@ where
         // TODO: Configure:
         // * circ_supply; by default it's for Filecoin
         // * base_fee; by default it's zero
-        let mut mc = nc.for_epoch(block_height, block_timestamp.0, initial_state);
+        let mut mc = nc.for_epoch(block_height, block_timestamp.0, initial_state_root);
         mc.set_base_fee(base_fee);
         mc.set_circulating_supply(circ_supply);
 
@@ -177,5 +190,80 @@ where
     async fn end(&self, state: Self::State) -> anyhow::Result<(Self::State, Self::EndOutput)> {
         // TODO: Epoch transitions for checkpointing.
         Ok((state, ()))
+    }
+}
+
+pub struct ReadOnlyBlockstore<DB>(DB);
+
+impl<DB> Blockstore for ReadOnlyBlockstore<DB>
+where
+    DB: Blockstore,
+{
+    fn get(&self, k: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
+        self.0.get(k)
+    }
+
+    fn put_keyed(&self, _k: &Cid, _block: &[u8]) -> anyhow::Result<()> {
+        panic!("never intended to use put on the read-only blockstore")
+    }
+}
+
+/// A state we create for the execution of all the messages in a block.
+pub struct FvmCheckState<DB>
+where
+    DB: Blockstore + 'static,
+{
+    state_tree: StateTree<ReadOnlyBlockstore<DB>>,
+}
+
+impl<DB> FvmCheckState<DB>
+where
+    DB: Blockstore + 'static,
+{
+    pub fn new(blockstore: DB, initial_state_root: Cid) -> anyhow::Result<Self> {
+        // Sanity check that the blockstore contains the supplied state root.
+        if !blockstore
+            .has(&initial_state_root)
+            .context("failed to load initial state-root")?
+        {
+            return Err(anyhow!(
+                "blockstore doesn't have the initial state-root {}",
+                initial_state_root
+            ));
+        }
+
+        // Create a new state tree from the supplied root.
+        let state_tree = {
+            let bstore = ReadOnlyBlockstore(blockstore);
+            StateTree::new_from_root(bstore, &initial_state_root)?
+        };
+
+        let state = FvmCheckState { state_tree };
+
+        Ok(state)
+    }
+}
+
+#[async_trait]
+impl<DB> CheckInterpreter for FvmMessageInterpreter<DB>
+where
+    DB: Blockstore + 'static + Send + Sync,
+{
+    type State = FvmCheckState<DB>;
+
+    type Message = FvmMessage;
+
+    type Output = FvmCheckRet;
+
+    /// Check that:
+    /// * sender exists
+    /// * sender nonce matches the message sequence
+    /// * sender has enough funds to cover the gas cost
+    async fn check(
+        &self,
+        _state: Self::State,
+        _msg: Self::Message,
+    ) -> anyhow::Result<(Self::State, Self::Output)> {
+        todo!()
     }
 }

--- a/fendermint/vm/interpreter/src/lib.rs
+++ b/fendermint/vm/interpreter/src/lib.rs
@@ -77,3 +77,26 @@ pub trait Interpreter: Sync + Send {
     /// requests once every 1000 blocks.
     async fn end(&self, state: Self::State) -> anyhow::Result<(Self::State, Self::EndOutput)>;
 }
+
+/// Check if messages can be added to the mempool by performing certain validation
+/// over a projected version of the state. Does not execute transactions fully,
+/// just does basic validation. The state is updated so that things like nonces
+/// and balances are adjusted as if the transaction was executed. This way an
+/// account can send multiple messages in a row, not just the next that follows
+/// its current nonce.
+#[async_trait]
+pub trait CheckInterpreter: Sync + Send {
+    type State: Send;
+    type Message: Send;
+    type Output;
+
+    /// Called when a new user transaction is being added to the mempool.
+    ///
+    /// Returns the updated state, and the check output, which should be
+    /// able to describe both the success and failure cases.
+    async fn check(
+        &self,
+        state: Self::State,
+        msg: Self::Message,
+    ) -> anyhow::Result<(Self::State, Self::Output)>;
+}

--- a/fendermint/vm/interpreter/src/signed.rs
+++ b/fendermint/vm/interpreter/src/signed.rs
@@ -6,9 +6,15 @@ use async_trait::async_trait;
 use fendermint_vm_message::signed::{SignedMessage, SignedMessageError};
 
 use crate::{
-    fvm::{FvmApplyRet, FvmMessage},
-    Interpreter,
+    fvm::{FvmApplyRet, FvmCheckRet, FvmMessage},
+    CheckInterpreter, Interpreter,
 };
+
+/// Message validation failed due to an invalid signature.
+pub struct InvalidSignature(pub String);
+
+pub type SignedMessageApplyRet = Result<FvmApplyRet, InvalidSignature>;
+pub type SignedMessageCheckRet = Result<FvmCheckRet, InvalidSignature>;
 
 /// Interpreter working on signed messages, validating their signature before sending
 /// the unsigned parts on for execution.
@@ -23,11 +29,6 @@ impl<I> SignedMessageInterpreter<I> {
     }
 }
 
-pub enum SignedMesssageApplyRet {
-    InvalidSignature(String),
-    Applied(FvmApplyRet),
-}
-
 #[async_trait]
 impl<I> Interpreter for SignedMessageInterpreter<I>
 where
@@ -36,7 +37,7 @@ where
     type State = I::State;
     type Message = SignedMessage;
     type BeginOutput = I::BeginOutput;
-    type DeliverOutput = SignedMesssageApplyRet;
+    type DeliverOutput = SignedMessageApplyRet;
     type EndOutput = I::EndOutput;
 
     async fn deliver(
@@ -48,12 +49,11 @@ where
             Err(SignedMessageError::Ipld(e)) => Err(anyhow!(e)),
             Err(SignedMessageError::InvalidSignature(s)) => {
                 // TODO: We can penalize the validator for including an invalid signature.
-                Ok((state, SignedMesssageApplyRet::InvalidSignature(s)))
+                Ok((state, Err(InvalidSignature(s))))
             }
             Ok(()) => {
                 let (state, ret) = self.inner.deliver(state, msg.message).await?;
-
-                Ok((state, SignedMesssageApplyRet::Applied(ret)))
+                Ok((state, Ok(ret)))
             }
         }
     }
@@ -64,5 +64,34 @@ where
 
     async fn end(&self, state: Self::State) -> anyhow::Result<(Self::State, Self::EndOutput)> {
         self.inner.end(state).await
+    }
+}
+
+#[async_trait]
+impl<I> CheckInterpreter for SignedMessageInterpreter<I>
+where
+    I: CheckInterpreter<Message = FvmMessage, Output = FvmCheckRet>,
+{
+    type State = I::State;
+    type Message = SignedMessage;
+    type Output = SignedMessageCheckRet;
+
+    async fn check(
+        &self,
+        state: Self::State,
+        msg: Self::Message,
+    ) -> anyhow::Result<(Self::State, Self::Output)> {
+        match msg.verify() {
+            Err(SignedMessageError::Ipld(e)) => Err(anyhow!(e)),
+            Err(SignedMessageError::InvalidSignature(s)) => {
+                // There is nobody we can punish for this, we can just tell Tendermint to discard this message,
+                // and potentially block the source IP address.
+                Ok((state, Err(InvalidSignature(s))))
+            }
+            Ok(()) => {
+                let (state, ret) = self.inner.check(state, msg.message).await?;
+                Ok((state, Ok(ret)))
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #18 

Implements a new `CheckInterpreter` stack that performs checks on incoming transactions before they are added to the mempool. The successful results update a temporary state, so for examples nonces are incremented, gas is charged.