### PR TITLE
FM-30: Binary format tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
  "once_cell",
  "version_check",
 ]
@@ -198,7 +198,7 @@ dependencies = [
  "memmap",
  "num_cpus",
  "pairing",
- "rand",
+ "rand 0.8.5",
  "rand_core 0.6.4",
  "rayon",
  "rustversion",
@@ -469,25 +469,12 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ed9c8b2d17acb8110c46f1da5bf4a696d745e1474a16db0cd2b49cd0249bf2"
 dependencies = [
- "core2",
- "multibase",
- "multihash 0.16.3",
- "serde",
- "serde_bytes",
- "unsigned-varint",
-]
-
-[[package]]
-name = "cid"
-version = "0.9.0"
-source = "git+https://github.com/multiformats/rust-cid.git?tag=v0.9.0#8e964478de91df1cc887ade8a4f9606b3c4b391e"
-dependencies = [
  "arbitrary",
  "core2",
  "multibase",
- "multihash 0.17.0",
- "quickcheck",
- "rand",
+ "multihash",
+ "quickcheck 0.9.2",
+ "rand 0.7.3",
  "serde",
  "serde_bytes",
  "unsigned-varint",
@@ -1032,6 +1019,16 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
@@ -1161,7 +1158,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "cid 0.9.0",
+ "cid",
  "fendermint_abci",
  "fendermint_rocksdb",
  "fendermint_storage",
@@ -1183,12 +1180,12 @@ name = "fendermint_rocksdb"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cid 0.9.0",
+ "cid",
  "fendermint_storage",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "num_cpus",
- "quickcheck",
+ "quickcheck 1.0.3",
  "rocksdb",
  "serde",
  "tempfile",
@@ -1201,7 +1198,7 @@ version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding",
  "im",
- "quickcheck",
+ "quickcheck 1.0.3",
  "quickcheck_macros",
  "serde",
 ]
@@ -1228,7 +1225,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "cid 0.9.0",
+ "cid",
  "fendermint_vm_actor_interface",
  "fendermint_vm_message",
  "fvm",
@@ -1242,12 +1239,13 @@ name = "fendermint_vm_message"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "cid 0.9.0",
+ "cid",
  "fendermint_vm_message",
  "fvm_ipld_encoding",
  "fvm_shared",
- "quickcheck",
+ "quickcheck 1.0.3",
  "quickcheck_macros",
+ "rand 0.8.5",
  "serde",
  "serde_tuple",
  "thiserror",
@@ -1279,7 +1277,7 @@ dependencies = [
  "lazy_static",
  "merkletree",
  "neptune",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.10.6",
 ]
@@ -1304,7 +1302,7 @@ dependencies = [
  "memmap",
  "merkletree",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "serde",
  "serde_json",
@@ -1507,7 +1505,7 @@ dependencies = [
  "anyhow",
  "blake2b_simd",
  "byteorder",
- "cid 0.8.6",
+ "cid",
  "derive-getters",
  "derive_builder",
  "derive_more",
@@ -1521,12 +1519,12 @@ dependencies = [
  "lazy_static",
  "log",
  "minstant",
- "multihash 0.16.3",
+ "multihash",
  "num-derive",
  "num-traits",
  "num_cpus",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "replace_with",
  "serde",
@@ -1558,7 +1556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e84f16d6927ce342ef86bd20fcc2d5bd498ed33ae6d7a22fea7a1b453488ec88"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "itertools 0.10.5",
@@ -1574,8 +1572,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688239a96199577f6705a3f9689abfd795f867f91f5847bc7e236017cc672df7"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
- "multihash 0.16.3",
+ "cid",
+ "multihash",
 ]
 
 [[package]]
@@ -1584,7 +1582,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c60423568393a284de6d7c342cd664690611f27d223eb78629fa568ddd4e7951"
 dependencies = [
- "cid 0.8.6",
+ "cid",
  "futures",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
@@ -1600,9 +1598,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0816a2a6df4853de08a723d261110d56a121aa313bc570fe9d248f0a4bc5288"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "fvm_ipld_blockstore",
- "multihash 0.16.3",
+ "multihash",
  "serde",
  "serde_ipld_dagcbor",
  "serde_repr",
@@ -1618,12 +1616,12 @@ checksum = "0c942494dde990aeac314311bde34c787be99cab7d0836397a75556cbaa2c3e7"
 dependencies = [
  "anyhow",
  "byteorder",
- "cid 0.8.6",
+ "cid",
  "forest_hash_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "libipld-core",
- "multihash 0.16.3",
+ "multihash",
  "once_cell",
  "serde",
  "sha2 0.10.6",
@@ -1642,7 +1640,7 @@ dependencies = [
  "blake2b_simd",
  "bls-signatures",
  "byteorder",
- "cid 0.8.6",
+ "cid",
  "data-encoding",
  "data-encoding-macro",
  "filecoin-proofs-api",
@@ -1651,12 +1649,12 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log",
- "multihash 0.16.3",
+ "multihash",
  "num-bigint",
  "num-derive",
  "num-integer",
  "num-traits",
- "quickcheck",
+ "quickcheck 1.0.3",
  "serde",
  "serde_repr",
  "serde_tuple",
@@ -1681,6 +1679,17 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1724,7 +1733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
- "rand",
+ "rand 0.8.5",
  "rand_core 0.6.4",
  "rand_xorshift",
  "subtle",
@@ -1968,10 +1977,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d44790246ec6b7314cba745992c23d479d018073e66d49ae40ae1b64e5dd8eb5"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "core2",
  "multibase",
- "multihash 0.16.3",
+ "multihash",
  "serde",
  "thiserror",
 ]
@@ -2014,7 +2023,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
  "typenum",
@@ -2234,26 +2243,6 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
 dependencies = [
- "blake2b_simd",
- "blake2s_simd 1.0.1",
- "blake3",
- "core2",
- "digest 0.10.6",
- "multihash-derive",
- "ripemd",
- "serde",
- "serde-big-array",
- "sha2 0.10.6",
- "sha3",
- "unsigned-varint",
-]
-
-[[package]]
-name = "multihash"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
-dependencies = [
  "arbitrary",
  "blake2b_simd",
  "blake2s_simd 1.0.1",
@@ -2261,8 +2250,9 @@ dependencies = [
  "core2",
  "digest 0.10.6",
  "multihash-derive",
- "quickcheck",
- "rand",
+ "quickcheck 0.9.2",
+ "rand 0.7.3",
+ "ripemd",
  "serde",
  "serde-big-array",
  "sha2 0.10.6",
@@ -2334,7 +2324,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
- "quickcheck",
+ "quickcheck 1.0.3",
 ]
 
 [[package]]
@@ -2467,7 +2457,7 @@ dependencies = [
  "ff",
  "group",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
  "subtle",
 ]
@@ -2650,13 +2640,25 @@ dependencies = [
 
 [[package]]
 name = "quickcheck"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
+dependencies = [
+ "env_logger 0.7.1",
+ "log",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "quickcheck"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
- "env_logger",
+ "env_logger 0.8.4",
  "log",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2687,13 +2689,36 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2711,6 +2736,9 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
 
 [[package]]
 name = "rand_core"
@@ -2718,7 +2746,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2951,7 +2988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e23de7a4a18dff77ab9531f279a882500b8cf3549fde044d4e10481b411f1e"
 dependencies = [
  "cbor4ii",
- "cid 0.8.6",
+ "cid",
  "scopeguard",
  "serde",
 ]
@@ -3175,8 +3212,8 @@ dependencies = [
  "memmap",
  "merkletree",
  "num_cpus",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rayon",
  "semver",
  "serde",
@@ -3602,7 +3639,7 @@ dependencies = [
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util 0.7.7",
@@ -3794,6 +3831,12 @@ checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 
 [[package]]
 name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -3971,7 +4014,7 @@ dependencies = [
  "memfd",
  "memoffset 0.6.5",
  "paste",
- "rand",
+ "rand 0.8.5",
  "rustix 0.35.13",
  "thiserror",
  "wasmtime-asm-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,9 @@ name = "arbitrary"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e90af4de65aa7b293ef2d09daff88501eb254f58edde2e1ac02c82d873eadad"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arbtest"
@@ -877,6 +880,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8beee4701e2e229e8098bbdecdca12449bc3e322f137d269182fa1291e20bd00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,9 +1238,12 @@ dependencies = [
 name = "fendermint_vm_message"
 version = "0.1.0"
 dependencies = [
+ "arbitrary",
  "cid",
+ "fendermint_vm_message",
  "fvm_ipld_encoding",
  "fvm_shared",
+ "quickcheck 1.0.3",
  "serde",
  "serde_tuple",
  "thiserror",
@@ -1616,6 +1633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b594b4d4c1393f03e3430f106c09874fcac565e68a560686de37ca2982a61d1a"
 dependencies = [
  "anyhow",
+ "arbitrary",
  "bitflags",
  "blake2b_simd",
  "bls-signatures",
@@ -1634,6 +1652,7 @@ dependencies = [
  "num-derive",
  "num-integer",
  "num-traits",
+ "quickcheck 1.0.3",
  "serde",
  "serde_repr",
  "serde_tuple",
@@ -2303,6 +2322,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "quickcheck 1.0.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -198,7 +198,7 @@ dependencies = [
  "memmap",
  "num_cpus",
  "pairing",
- "rand 0.8.5",
+ "rand",
  "rand_core 0.6.4",
  "rayon",
  "rustversion",
@@ -469,12 +469,25 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ed9c8b2d17acb8110c46f1da5bf4a696d745e1474a16db0cd2b49cd0249bf2"
 dependencies = [
+ "core2",
+ "multibase",
+ "multihash 0.16.3",
+ "serde",
+ "serde_bytes",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "cid"
+version = "0.9.0"
+source = "git+https://github.com/multiformats/rust-cid.git?tag=v0.9.0#8e964478de91df1cc887ade8a4f9606b3c4b391e"
+dependencies = [
  "arbitrary",
  "core2",
  "multibase",
- "multihash",
- "quickcheck 0.9.2",
- "rand 0.7.3",
+ "multihash 0.17.0",
+ "quickcheck",
+ "rand",
  "serde",
  "serde_bytes",
  "unsigned-varint",
@@ -1019,16 +1032,6 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
@@ -1158,7 +1161,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "cid",
+ "cid 0.9.0",
  "fendermint_abci",
  "fendermint_rocksdb",
  "fendermint_storage",
@@ -1180,12 +1183,12 @@ name = "fendermint_rocksdb"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.9.0",
  "fendermint_storage",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "num_cpus",
- "quickcheck 1.0.3",
+ "quickcheck",
  "rocksdb",
  "serde",
  "tempfile",
@@ -1198,7 +1201,7 @@ version = "0.1.0"
 dependencies = [
  "fvm_ipld_encoding",
  "im",
- "quickcheck 1.0.3",
+ "quickcheck",
  "quickcheck_macros",
  "serde",
 ]
@@ -1225,7 +1228,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "cid",
+ "cid 0.9.0",
  "fendermint_vm_actor_interface",
  "fendermint_vm_message",
  "fvm",
@@ -1239,11 +1242,11 @@ name = "fendermint_vm_message"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "cid",
+ "cid 0.9.0",
  "fendermint_vm_message",
  "fvm_ipld_encoding",
  "fvm_shared",
- "quickcheck 1.0.3",
+ "quickcheck",
  "quickcheck_macros",
  "serde",
  "serde_tuple",
@@ -1276,7 +1279,7 @@ dependencies = [
  "lazy_static",
  "merkletree",
  "neptune",
- "rand 0.8.5",
+ "rand",
  "serde",
  "sha2 0.10.6",
 ]
@@ -1301,7 +1304,7 @@ dependencies = [
  "memmap",
  "merkletree",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "rayon",
  "serde",
  "serde_json",
@@ -1504,7 +1507,7 @@ dependencies = [
  "anyhow",
  "blake2b_simd",
  "byteorder",
- "cid",
+ "cid 0.8.6",
  "derive-getters",
  "derive_builder",
  "derive_more",
@@ -1518,12 +1521,12 @@ dependencies = [
  "lazy_static",
  "log",
  "minstant",
- "multihash",
+ "multihash 0.16.3",
  "num-derive",
  "num-traits",
  "num_cpus",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "rayon",
  "replace_with",
  "serde",
@@ -1555,7 +1558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e84f16d6927ce342ef86bd20fcc2d5bd498ed33ae6d7a22fea7a1b453488ec88"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.8.6",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "itertools 0.10.5",
@@ -1571,8 +1574,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688239a96199577f6705a3f9689abfd795f867f91f5847bc7e236017cc672df7"
 dependencies = [
  "anyhow",
- "cid",
- "multihash",
+ "cid 0.8.6",
+ "multihash 0.16.3",
 ]
 
 [[package]]
@@ -1581,7 +1584,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c60423568393a284de6d7c342cd664690611f27d223eb78629fa568ddd4e7951"
 dependencies = [
- "cid",
+ "cid 0.8.6",
  "futures",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
@@ -1597,9 +1600,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0816a2a6df4853de08a723d261110d56a121aa313bc570fe9d248f0a4bc5288"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.8.6",
  "fvm_ipld_blockstore",
- "multihash",
+ "multihash 0.16.3",
  "serde",
  "serde_ipld_dagcbor",
  "serde_repr",
@@ -1615,12 +1618,12 @@ checksum = "0c942494dde990aeac314311bde34c787be99cab7d0836397a75556cbaa2c3e7"
 dependencies = [
  "anyhow",
  "byteorder",
- "cid",
+ "cid 0.8.6",
  "forest_hash_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "libipld-core",
- "multihash",
+ "multihash 0.16.3",
  "once_cell",
  "serde",
  "sha2 0.10.6",
@@ -1639,7 +1642,7 @@ dependencies = [
  "blake2b_simd",
  "bls-signatures",
  "byteorder",
- "cid",
+ "cid 0.8.6",
  "data-encoding",
  "data-encoding-macro",
  "filecoin-proofs-api",
@@ -1648,12 +1651,12 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log",
- "multihash",
+ "multihash 0.16.3",
  "num-bigint",
  "num-derive",
  "num-integer",
  "num-traits",
- "quickcheck 1.0.3",
+ "quickcheck",
  "serde",
  "serde_repr",
  "serde_tuple",
@@ -1678,17 +1681,6 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1732,7 +1724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
- "rand 0.8.5",
+ "rand",
  "rand_core 0.6.4",
  "rand_xorshift",
  "subtle",
@@ -1976,10 +1968,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d44790246ec6b7314cba745992c23d479d018073e66d49ae40ae1b64e5dd8eb5"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.8.6",
  "core2",
  "multibase",
- "multihash",
+ "multihash 0.16.3",
  "serde",
  "thiserror",
 ]
@@ -2022,7 +2014,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand 0.8.5",
+ "rand",
  "serde",
  "sha2 0.9.9",
  "typenum",
@@ -2242,6 +2234,26 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
 dependencies = [
+ "blake2b_simd",
+ "blake2s_simd 1.0.1",
+ "blake3",
+ "core2",
+ "digest 0.10.6",
+ "multihash-derive",
+ "ripemd",
+ "serde",
+ "serde-big-array",
+ "sha2 0.10.6",
+ "sha3",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "multihash"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
+dependencies = [
  "arbitrary",
  "blake2b_simd",
  "blake2s_simd 1.0.1",
@@ -2249,9 +2261,8 @@ dependencies = [
  "core2",
  "digest 0.10.6",
  "multihash-derive",
- "quickcheck 0.9.2",
- "rand 0.7.3",
- "ripemd",
+ "quickcheck",
+ "rand",
  "serde",
  "serde-big-array",
  "sha2 0.10.6",
@@ -2323,7 +2334,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
- "quickcheck 1.0.3",
+ "quickcheck",
 ]
 
 [[package]]
@@ -2456,7 +2467,7 @@ dependencies = [
  "ff",
  "group",
  "lazy_static",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
  "subtle",
 ]
@@ -2639,25 +2650,13 @@ dependencies = [
 
 [[package]]
 name = "quickcheck"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
-dependencies = [
- "env_logger 0.7.1",
- "log",
- "rand 0.7.3",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "quickcheck"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
- "env_logger 0.8.4",
+ "env_logger",
  "log",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -2688,36 +2687,13 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2735,9 +2711,6 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
 
 [[package]]
 name = "rand_core"
@@ -2745,16 +2718,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.8",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -2987,7 +2951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e23de7a4a18dff77ab9531f279a882500b8cf3549fde044d4e10481b411f1e"
 dependencies = [
  "cbor4ii",
- "cid",
+ "cid 0.8.6",
  "scopeguard",
  "serde",
 ]
@@ -3211,8 +3175,8 @@ dependencies = [
  "memmap",
  "merkletree",
  "num_cpus",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "rayon",
  "semver",
  "serde",
@@ -3638,7 +3602,7 @@ dependencies = [
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-util 0.7.7",
@@ -3830,12 +3794,6 @@ checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -4013,7 +3971,7 @@ dependencies = [
  "memfd",
  "memoffset 0.6.5",
  "paste",
- "rand 0.8.5",
+ "rand",
  "rustix 0.35.13",
  "thiserror",
  "wasmtime-asm-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,6 +1244,7 @@ dependencies = [
  "fvm_ipld_encoding",
  "fvm_shared",
  "quickcheck 1.0.3",
+ "quickcheck_macros",
  "serde",
  "serde_tuple",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ thiserror = "1"
 quickcheck = "1"
 quickcheck_macros = "1"
 arbitrary = { version = "1", features = ["derive"] }
+libsecp256k1 = "0.7"
+rand = "0.8"
+rand_chacha = "0.3"
+
 
 # Stable FVM dependencies from crates.io
 cid = { version = "0.8", default-features = false, features = ["serde-codec", "std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,17 @@ tempfile = "3.3"
 thiserror = "1"
 quickcheck = "1"
 quickcheck_macros = "1"
+arbitrary = { version = "1", features = ["derive"] }
 
 # Stable FVM dependencies from crates.io
-cid = { version = "0.8", default-features = false, features = ["serde-codec", "std", "arb"] }
+cid = { version = "0.8", default-features = false, features = ["serde-codec", "std"] }
 fvm_ipld_blockstore = "0.1"
 fvm_ipld_encoding = "0.3"
 fvm_ipld_car = "0.6"
 
 # The following are on crates.io but as pre-releases.
-fvm = { version = "3.0.0-alpha.22", default-features = false } # no opencl or it fails on CI
-fvm_shared = "3.0.0-alpha.18"
+fvm = { version = "3.0.0-alpha.22", default-features = false }     # no opencl or it fails on CI
+fvm_shared = { version = "3.0.0-alpha.18", features = ["crypto"] }
 
 # Tendermint dependencies are forked because we are building against 0.37 release candidates.
 tower-abci = { git = "https://github.com/consensus-shipyard/tower-abci.git", branch = "tendermint-v0.37" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,10 @@ rand_chacha = "0.3"
 fvm_ipld_blockstore = "0.1"
 fvm_ipld_encoding = "0.3"
 fvm_ipld_car = "0.6"
-# Using 0.9 because of its updated quickcheck dependency. 0.10 breaks some API.
-cid = { version = "0.9", features = ["serde-codec", "std"] }
+# Using 0.8 because of ref-fvm.
+# 0.9 would be better because of its updated quickcheck dependency.
+# 0.10 breaks some API.
+cid = { version = "0.8", features = ["serde-codec", "std"] }
 
 # The following are on crates.io but as pre-releases.
 fvm = { version = "3.0.0-alpha.22", default-features = false }     # no opencl or it fails on CI
@@ -43,7 +45,3 @@ fvm_shared = { version = "3.0.0-alpha.18", features = ["crypto"] }
 # Tendermint dependencies are forked because we are building against 0.37 release candidates.
 tower-abci = { git = "https://github.com/consensus-shipyard/tower-abci.git", branch = "tendermint-v0.37" }
 tendermint = { git = "https://github.com/aakoshh/tendermint-rs.git", branch = "mikhail/multi-tc-version-support" }
-
-[patch.crates-io]
-# Not sure if this is okay: ref-fvm and thus the IPLD blockstore depends on 0.8.x
-cid = { git = "https://github.com/multiformats/rust-cid.git", tag = "v0.9.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,11 @@ rand_chacha = "0.3"
 
 
 # Stable FVM dependencies from crates.io
-cid = { version = "0.8", default-features = false, features = ["serde-codec", "std"] }
 fvm_ipld_blockstore = "0.1"
 fvm_ipld_encoding = "0.3"
 fvm_ipld_car = "0.6"
+# Using 0.9 because of its updated quickcheck dependency. 0.10 breaks some API.
+cid = { version = "0.9", features = ["serde-codec", "std"] }
 
 # The following are on crates.io but as pre-releases.
 fvm = { version = "3.0.0-alpha.22", default-features = false }     # no opencl or it fails on CI
@@ -42,3 +43,7 @@ fvm_shared = { version = "3.0.0-alpha.18", features = ["crypto"] }
 # Tendermint dependencies are forked because we are building against 0.37 release candidates.
 tower-abci = { git = "https://github.com/consensus-shipyard/tower-abci.git", branch = "tendermint-v0.37" }
 tendermint = { git = "https://github.com/aakoshh/tendermint-rs.git", branch = "mikhail/multi-tc-version-support" }
+
+[patch.crates-io]
+# Not sure if this is okay: ref-fvm and thus the IPLD blockstore depends on 0.8.x
+cid = { git = "https://github.com/multiformats/rust-cid.git", tag = "v0.9.0" }

--- a/fendermint/vm/interpreter/src/chain.rs
+++ b/fendermint/vm/interpreter/src/chain.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use async_trait::async_trait;
@@ -54,6 +55,13 @@ where
                 let (state, ret) = self.inner.deliver(state, msg).await?;
                 Ok((state, ChainMessageApplyRet::Signed(ret)))
             }
+            ChainMessage::ForExecution(_) | ChainMessage::ForResolution(_) => {
+                // This only happens if a validator is malicious or we have made a programming error.
+                // I expect for now that we don't run with untrusted validators, so it's okay to quit.
+                Err(anyhow!(
+                    "The handling of ForExecution and ForResolution is not yet implemented."
+                ))
+            }
         }
     }
 
@@ -86,6 +94,10 @@ where
                 let (state, ret) = self.inner.check(state, msg, is_recheck).await?;
 
                 Ok((state, Ok(ret)))
+            }
+            ChainMessage::ForExecution(_) | ChainMessage::ForResolution(_) => {
+                // Users cannot send these messages, only validators can propose them in blocks.
+                Ok((state, Err(IllegalMessage)))
             }
         }
     }

--- a/fendermint/vm/interpreter/src/chain.rs
+++ b/fendermint/vm/interpreter/src/chain.rs
@@ -52,7 +52,7 @@ where
     ) -> anyhow::Result<(Self::State, Self::DeliverOutput)> {
         match msg {
             ChainMessage::Signed(msg) => {
-                let (state, ret) = self.inner.deliver(state, msg).await?;
+                let (state, ret) = self.inner.deliver(state, *msg).await?;
                 Ok((state, ChainMessageApplyRet::Signed(ret)))
             }
             ChainMessage::ForExecution(_) | ChainMessage::ForResolution(_) => {
@@ -91,7 +91,7 @@ where
     ) -> anyhow::Result<(Self::State, Self::Output)> {
         match msg {
             ChainMessage::Signed(msg) => {
-                let (state, ret) = self.inner.check(state, msg, is_recheck).await?;
+                let (state, ret) = self.inner.check(state, *msg, is_recheck).await?;
 
                 Ok((state, Ok(ret)))
             }

--- a/fendermint/vm/message/Cargo.toml
+++ b/fendermint/vm/message/Cargo.toml
@@ -21,8 +21,11 @@ quickcheck = { workspace = true, optional = true }
 [dev-dependencies]
 quickcheck = { workspace = true }
 quickcheck_macros = { workspace = true }
+cid = { workspace = true, features = ["arb"] }
 
 # Enable arb on self for tests.
+# Ideally we could do this with `#[cfg(any(test, feature = "arb"))]`,
+# however in that case all the extra dependencies would not kick in.
 fendermint_vm_message = { path = ".", features = ["arb"] }
 
 [features]

--- a/fendermint/vm/message/Cargo.toml
+++ b/fendermint/vm/message/Cargo.toml
@@ -14,3 +14,14 @@ serde_tuple = { workspace = true }
 cid = { workspace = true }
 fvm_shared = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
+
+arbitrary = { workspace = true, optional = true }
+quickcheck = { workspace = true, optional = true }
+
+[dev-dependencies]
+# Enable arb for tests.
+fendermint_vm_message = { path = ".", features = ["arb"] }
+
+[features]
+default = []
+arb = ["arbitrary", "quickcheck", "fvm_shared/arb", "cid/arb"]

--- a/fendermint/vm/message/Cargo.toml
+++ b/fendermint/vm/message/Cargo.toml
@@ -17,17 +17,18 @@ fvm_ipld_encoding = { workspace = true }
 
 arbitrary = { workspace = true, optional = true }
 quickcheck = { workspace = true, optional = true }
+rand = { workspace = true, optional = true }
 
 [dev-dependencies]
 quickcheck = { workspace = true }
 quickcheck_macros = { workspace = true }
-cid = { workspace = true, features = ["arb"] }
 
 # Enable arb on self for tests.
 # Ideally we could do this with `#[cfg(any(test, feature = "arb"))]`,
-# however in that case all the extra dependencies would not kick in.
+# however in that case all the extra dependencies would not kick in,
+# and we'd have to repeat all those dependencies.
 fendermint_vm_message = { path = ".", features = ["arb"] }
 
 [features]
 default = []
-arb = ["arbitrary", "quickcheck", "fvm_shared/arb", "cid/arb"]
+arb = ["arbitrary", "quickcheck", "fvm_shared/arb", "cid/arb", "rand"]

--- a/fendermint/vm/message/Cargo.toml
+++ b/fendermint/vm/message/Cargo.toml
@@ -19,7 +19,10 @@ arbitrary = { workspace = true, optional = true }
 quickcheck = { workspace = true, optional = true }
 
 [dev-dependencies]
-# Enable arb for tests.
+quickcheck = { workspace = true }
+quickcheck_macros = { workspace = true }
+
+# Enable arb on self for tests.
 fendermint_vm_message = { path = ".", features = ["arb"] }
 
 [features]

--- a/fendermint/vm/message/src/arb_cid.rs
+++ b/fendermint/vm/message/src/arb_cid.rs
@@ -1,0 +1,78 @@
+//! Unfortunately ref-fvm depends on cid:0.8.6, which depends on quickcheck:0.9
+//! whereas here we use quickcheck:0.1. This causes conflicts and the `Arbitrary`
+//! implementations for `Cid` are not usable to us, nor can we patch all `cid`
+//! dependencies to use 0.9 because then the IPLD and other FVM traits don't work.
+//!
+//! TODO: Remove this module when the `cid` dependency is updated.
+use cid::{
+    multihash::{Code, MultihashDigest, MultihashGeneric},
+    CidGeneric, Version,
+};
+use rand::{distributions::WeightedIndex, prelude::Distribution, Rng, RngCore, SeedableRng};
+
+use quickcheck::{Arbitrary, Gen};
+
+fn arbitrary_version(g: &mut Gen) -> Version {
+    let version = u64::from(bool::arbitrary(g));
+    Version::try_from(version).unwrap()
+}
+
+/// Copied from https://github.com/multiformats/rust-cid/blob/v0.10.0/src/arb.rs
+pub fn arbitrary_cid<const S: usize>(g: &mut Gen) -> CidGeneric<S> {
+    if S >= 32 && arbitrary_version(g) == Version::V0 {
+        let data: Vec<u8> = Vec::arbitrary(g);
+        let hash = Code::Sha2_256
+            .digest(&data)
+            .resize()
+            .expect("digest too large");
+        CidGeneric::new_v0(hash).expect("sha2_256 is a valid hash for cid v0")
+    } else {
+        // In real world lower IPLD Codec codes more likely to happen, hence distribute them
+        // with bias towards smaller values.
+        let weights = [128, 32, 4, 4, 2, 2, 1, 1];
+        let dist = WeightedIndex::new(weights.iter()).unwrap();
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(u64::arbitrary(g));
+        let codec = match dist.sample(&mut rng) {
+            0 => rng.gen_range(0..u64::pow(2, 7)),
+            1 => rng.gen_range(u64::pow(2, 7)..u64::pow(2, 14)),
+            2 => rng.gen_range(u64::pow(2, 14)..u64::pow(2, 21)),
+            3 => rng.gen_range(u64::pow(2, 21)..u64::pow(2, 28)),
+            4 => rng.gen_range(u64::pow(2, 28)..u64::pow(2, 35)),
+            5 => rng.gen_range(u64::pow(2, 35)..u64::pow(2, 42)),
+            6 => rng.gen_range(u64::pow(2, 42)..u64::pow(2, 49)),
+            7 => rng.gen_range(u64::pow(2, 56)..u64::pow(2, 63)),
+            _ => unreachable!(),
+        };
+
+        let hash: MultihashGeneric<S> = arbitrary_multihash(g);
+        CidGeneric::new_v1(codec, hash)
+    }
+}
+
+/// Generates a random valid multihash.
+///
+/// Copied from https://github.com/multiformats/rust-multihash/blob/v0.18.0/src/arb.rs
+fn arbitrary_multihash<const S: usize>(g: &mut Gen) -> MultihashGeneric<S> {
+    // In real world lower multihash codes are more likely to happen, hence distribute them
+    // with bias towards smaller values.
+    let weights = [128, 64, 32, 16, 8, 4, 2, 1];
+    let dist = WeightedIndex::new(weights.iter()).unwrap();
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(u64::arbitrary(g));
+    let code = match dist.sample(&mut rng) {
+        0 => rng.gen_range(0..u64::pow(2, 7)),
+        1 => rng.gen_range(u64::pow(2, 7)..u64::pow(2, 14)),
+        2 => rng.gen_range(u64::pow(2, 14)..u64::pow(2, 21)),
+        3 => rng.gen_range(u64::pow(2, 21)..u64::pow(2, 28)),
+        4 => rng.gen_range(u64::pow(2, 28)..u64::pow(2, 35)),
+        5 => rng.gen_range(u64::pow(2, 35)..u64::pow(2, 42)),
+        6 => rng.gen_range(u64::pow(2, 42)..u64::pow(2, 49)),
+        7 => rng.gen_range(u64::pow(2, 56)..u64::pow(2, 63)),
+        _ => unreachable!(),
+    };
+
+    // Maximum size is S byte due to the generic.
+    let size = rng.gen_range(0..S);
+    let mut data = [0; S];
+    rng.fill_bytes(&mut data);
+    MultihashGeneric::wrap(code, &data[..size]).unwrap()
+}

--- a/fendermint/vm/message/src/arb_cid.rs
+++ b/fendermint/vm/message/src/arb_cid.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! Unfortunately ref-fvm depends on cid:0.8.6, which depends on quickcheck:0.9
 //! whereas here we use quickcheck:0.1. This causes conflicts and the `Arbitrary`
 //! implementations for `Cid` are not usable to us, nor can we patch all `cid`

--- a/fendermint/vm/message/src/arb_cid.rs
+++ b/fendermint/vm/message/src/arb_cid.rs
@@ -6,6 +6,7 @@
 //! dependencies to use 0.9 because then the IPLD and other FVM traits don't work.
 //!
 //! TODO: Remove this module when the `cid` dependency is updated.
+//! NOTE: A simpler alternative is https://github.com/ChainSafe/forest/blob/v0.6.0/blockchain/blocks/src/lib.rs
 use cid::{
     multihash::{Code, MultihashDigest, MultihashGeneric},
     CidGeneric, Version,

--- a/fendermint/vm/message/src/chain.rs
+++ b/fendermint/vm/message/src/chain.rs
@@ -35,18 +35,15 @@ pub enum ChainMessage {
 
 #[cfg(feature = "arb")]
 mod arb {
-    use cid::Cid;
-
-    use crate::signed::SignedMessage;
-
     use super::ChainMessage;
+    use crate::signed::SignedMessage;
 
     impl quickcheck::Arbitrary for ChainMessage {
         fn arbitrary(g: &mut quickcheck::Gen) -> Self {
             match u8::arbitrary(g) % 3 {
                 0 => ChainMessage::Signed(SignedMessage::arbitrary(g)),
-                1 => ChainMessage::ForExecution(Cid::arbitrary(g)),
-                _ => ChainMessage::ForExecution(Cid::arbitrary(g)),
+                1 => ChainMessage::ForResolution(crate::arb_cid::arbitrary_cid(g)),
+                _ => ChainMessage::ForExecution(crate::arb_cid::arbitrary_cid(g)),
             }
         }
     }

--- a/fendermint/vm/message/src/chain.rs
+++ b/fendermint/vm/message/src/chain.rs
@@ -12,10 +12,10 @@ use crate::signed::SignedMessage;
 /// signed by BLS signatures are aggregated to the block level, and their original
 /// signatures are stripped from the messages, to save space. Tendermint Core will
 /// not do this for us (perhaps with ABCI++ Vote Extensions we could do it), though.
-#[derive(Clone, Debug, Serialize, Deserialize, Hash, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Hash, PartialEq, Eq)]
 pub enum ChainMessage {
     /// A message that can be passed on to the FVM as-is.
-    Signed(SignedMessage),
+    Signed(Box<SignedMessage>),
     // TODO: ForResolution - A message CID proposed for async resolution.
     // This will not need a signature, it is proposed by the validator who made the block.
     // We might want to add a `from` and a signature anyway if we want to reward relayers.
@@ -41,7 +41,7 @@ mod arb {
     impl quickcheck::Arbitrary for ChainMessage {
         fn arbitrary(g: &mut quickcheck::Gen) -> Self {
             match u8::arbitrary(g) % 3 {
-                0 => ChainMessage::Signed(SignedMessage::arbitrary(g)),
+                0 => ChainMessage::Signed(Box::new(SignedMessage::arbitrary(g))),
                 1 => ChainMessage::ForResolution(crate::arb_cid::arbitrary_cid(g)),
                 _ => ChainMessage::ForExecution(crate::arb_cid::arbitrary_cid(g)),
             }

--- a/fendermint/vm/message/src/lib.rs
+++ b/fendermint/vm/message/src/lib.rs
@@ -4,6 +4,8 @@ use cid::{multihash, multihash::MultihashDigest, Cid};
 use fvm_ipld_encoding::{to_vec, Error as IpldError, DAG_CBOR};
 use serde::Serialize;
 
+#[cfg(feature = "arb")]
+mod arb_cid;
 pub mod chain;
 pub mod signed;
 


### PR DESCRIPTION
Related to #30 

The PR contains `Arbitrary` instances for messages and a quickcheck test to make sure a `ChainMessage` can be serialized to/from binary as intended with IPLD.


#### Invalid arbitrary data from upstream

I had to fix some of the arbitrary data generated by the upstream libraries: 
* `TokenAmount` has a `BigInt` that can be too large to serialize according to the Filecoin spec.
* `DelegatedAddress` has a `length` field that had a value inconsistent with how many bytes it had filled with non-zero values. 

I don't know if these were done like this deliberately as "completely arbitrary" or they are a result of oversight.

#### Reserved message types

I added two `ChainMessage` types that I do not intend to handle in Milestone 1, but I wanted to see if they work with the serialization.


#### Copied arbitrary CID generation

There is a version conflict with the `cid` and `multihash` libraries in that the versions used by `ref-fvm` rely on an earlier version of `quickcheck`, which makes those fancy `Arbitrary` instances unusable. I copied them so that I can generate messages with CIDs. 

Only after did I notice that Forest also has a [simpler arbitrary CID](https://github.com/ChainSafe/forest/blob/v0.6.0/blockchain/blocks/src/lib.rs) that only generates one version and doesn't try to do weighted sampling. Oh well.