### PR TITLE
FM-17: Map events to ABCI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
- "gimli 0.27.1",
+ "gimli 0.27.2",
 ]
 
 [[package]]
@@ -1119,9 +1119,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -1169,6 +1169,7 @@ dependencies = [
  "fvm_ipld_car",
  "fvm_ipld_encoding",
  "fvm_shared",
+ "hex",
  "serde",
  "tempfile",
  "tendermint",
@@ -1499,9 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "3.0.0-alpha.24"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560201e145435e4a3741fe5e6f37b7854273af9f344ca13957232ccb58834a1f"
+checksum = "9efd2ca858542b73acd5f679bac84ab9de2af8ccb35a3528e414e08b85e55982"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -1717,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "glob"
@@ -2217,14 +2218,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2391,9 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"
@@ -3511,9 +3512,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "af0097eaf301d576d0b2aead7a59facab6d53cc636340f0291fab8446a2e8613"
 dependencies = [
  "serde",
  "time-core",
@@ -3872,9 +3873,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.100.0"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b20236ab624147dfbb62cf12a19aaf66af0e41b8398838b66e997d07d269d4"
+checksum = "9cc3222d9e47412382cc95e2f013c6a9f510bcff80af92de5665ae3ec1e4a2f6"
 dependencies = [
  "indexmap",
  "url",
@@ -3882,12 +3883,12 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.50"
+version = "0.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d3f7d7cb1e00ae9f91bb21f2856cdc68a913afb3b6b33fca5a83dba8c8c4eb"
+checksum = "abfea0b7816054bcad689e7c68a6f957eb023d0e70f69835db400f1a51ad7dec"
 dependencies = [
  "anyhow",
- "wasmparser 0.100.0",
+ "wasmparser 0.101.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ libsecp256k1 = "0.7"
 rand = "0.8"
 rand_chacha = "0.3"
 hex = "0.4"
+base64 = "0.21"
 
 
 # Stable FVM dependencies from crates.io
@@ -40,8 +41,8 @@ fvm_ipld_car = "0.6"
 cid = { version = "0.8", features = ["serde-codec", "std"] }
 
 # The following are on crates.io but as pre-releases.
-fvm = { version = "3.0.0-alpha.22", default-features = false }     # no opencl or it fails on CI
-fvm_shared = { version = "3.0.0-alpha.18", features = ["crypto"] }
+fvm = { version = "3.0.0-rc.1", default-features = false }         # no opencl feature or it fails on CI
+fvm_shared = { version = "3.0.0-alpha.20", features = ["crypto"] }
 
 # Tendermint dependencies are forked because we are building against 0.37 release candidates.
 tower-abci = { git = "https://github.com/consensus-shipyard/tower-abci.git", branch = "tendermint-v0.37" }

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = { workspace = true }
 tokio = { workspace = true }
 tendermint = { workspace = true }
 serde = { workspace = true }
+hex = { workspace = true }
 
 fendermint_abci = { path = "../abci" }
 fendermint_storage = { path = "../storage" }

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -332,7 +332,7 @@ fn to_deliver_tx(ret: FvmApplyRet) -> response::DeliverTx {
     let gas_used: i64 = receipt.gas_used.try_into().expect("gas used not i64");
 
     let data = receipt.return_data.to_vec().into();
-    let events = to_events(ret.apply_ret.events);
+    let events = to_events("message", ret.apply_ret.events);
 
     response::DeliverTx {
         code,
@@ -378,13 +378,13 @@ fn to_end_block(_ret: ()) -> response::EndBlock {
 ///
 /// (Currently just a placeholder).
 fn to_begin_block(ret: FvmApplyRet) -> response::BeginBlock {
-    let events = to_events(ret.apply_ret.events);
+    let events = to_events("begin", ret.apply_ret.events);
 
     response::BeginBlock { events }
 }
 
 /// Convert events to key-value pairs.
-fn to_events(stamped_events: Vec<StampedEvent>) -> Vec<Event> {
+fn to_events(kind: &str, stamped_events: Vec<StampedEvent>) -> Vec<Event> {
     stamped_events
         .into_iter()
         .map(|se| {
@@ -404,7 +404,7 @@ fn to_events(stamped_events: Vec<StampedEvent>) -> Vec<Event> {
                 });
             }
 
-            Event::new("StampedEvent", attrs)
+            Event::new(kind.to_string(), attrs)
         })
         .collect()
 }


### PR DESCRIPTION
Closes #17 

Now that a new version of `fvm_shared` made the necessary fields public, was able to finish mapping events. 

I think the Go version of `EventAttribute` might accept `bytes`, which it turns into Base64 strings during serialization; the Rust library expects `String` for key and value, which it will encode as Base64. The value coming from `StampedEvent` is `Vec<u8>`, so I first converted it `hex`, which then will be converted into Base64, which is a bit ugly, but not sure what else I could do (apart from double Base64 encoding, which could be shorter, but perhaps we use hex more often).

Here are some relevant docs:
* https://docs.cosmos.network/v0.46/core/events.html
* https://docs.tendermint.com/v0.34/tendermint-core/subscription.html
* https://docs.tendermint.com/v0.34/app-dev/indexing-transactions.html
* https://docs.ethermint.zone/quickstart/events.html