### PR TITLE
FM-36: Save state root history

### DIFF
--- a/fendermint/app/src/main.rs
+++ b/fendermint/app/src/main.rs
@@ -17,8 +17,9 @@ async fn main() {
     let interpreter = BytesMessageInterpreter::new(interpreter);
 
     let db = open_db();
-    let ns = db.new_cf_handle("app").unwrap();
-    let app = app::App::<_, AppStore, _>::new(db, ns, interpreter);
+    let app_ns = db.new_cf_handle("app").unwrap();
+    let state_hist_ns = db.new_cf_handle("state_hist").unwrap();
+    let app = app::App::<_, AppStore, _>::new(db, app_ns, state_hist_ns, interpreter);
     let _service = ApplicationService(app);
 }
 


### PR DESCRIPTION
Closes #36 

The PR adds a `KVCollection<S, BlockHeight, Cid>` to the `App` where it stores a fixed (currently 1 days worth, thinking 1 second blocks, which is the Tendermint default) number of historical entries for state root hashes. 

These are pruned and inserted during block `commit`, and used during `query` to figure out what state we can run our query on. If the height the user is looking for is no longer maintained, we return the latest height.