### PR TITLE
CHORE: Factor out golden test macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,6 +1203,11 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "arbtest",
+ "cid",
+ "fvm_ipld_encoding",
+ "hex",
+ "quickcheck 1.0.3",
+ "serde",
 ]
 
 [[package]]
@@ -1235,6 +1240,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "cid",
+ "fendermint_testing",
  "fendermint_vm_message",
  "fvm_ipld_encoding",
  "fvm_shared",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ license-file = "LICENSE-APACHE"
 anyhow = "1"
 async-trait = "0.1"
 async-stm = "0.2"
+arbitrary = { version = "1", features = ["derive"] }
+arbtest = "0.2"
 futures = "0.3"
 paste = "1"
 serde = { version = "1", features = ["derive"] }
@@ -23,7 +25,6 @@ tempfile = "3.3"
 thiserror = "1"
 quickcheck = "1"
 quickcheck_macros = "1"
-arbitrary = { version = "1", features = ["derive"] }
 libsecp256k1 = "0.7"
 rand = "0.8"
 rand_chacha = "0.3"

--- a/fendermint/testing/Cargo.toml
+++ b/fendermint/testing/Cargo.toml
@@ -9,7 +9,13 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arbitrary = { version = "1.2" }
+serde = { workspace = true }
+arbitrary = { workspace = true }
+quickcheck = { workspace = true }
+hex = { workspace = true }
+
+cid = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
 
 [dev-dependencies]
-arbtest = { version = "0.2" }
+arbtest = { workspace = true }

--- a/fendermint/testing/src/golden.rs
+++ b/fendermint/testing/src/golden.rs
@@ -1,0 +1,136 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+use cid::Cid;
+use serde::{de::DeserializeOwned, Serialize};
+use std::fmt::Debug;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::Path;
+
+/// Path to a golden file.
+fn path(prefix: &str, name: &str, ext: &str) -> String {
+    // All files will have the same name but different extension.
+    // They should be under `fendermint/vm/message/golden`.
+    let path = Path::new("golden").join(prefix).join(name);
+    format!("{}.{}", path.display(), ext)
+}
+
+/// Read the contents of an existing golden file, or create it by turning `fallback` into string first.
+fn read_or_create<T>(
+    prefix: &str,
+    name: &str,
+    ext: &str,
+    fallback: &T,
+    to_string: fn(&T) -> String,
+) -> String {
+    let p = path(prefix, name, ext);
+    let p = Path::new(&p);
+
+    if !p.exists() {
+        if let Some(p) = p.parent() {
+            std::fs::create_dir_all(p).expect("failed to create golden directory");
+        }
+        let s = to_string(fallback);
+        let mut f = File::create(p)
+            .unwrap_or_else(|e| panic!("Cannot create golden file at {:?}: {}", p, e));
+        f.write_all(s.as_bytes()).unwrap();
+    }
+
+    let mut f =
+        File::open(p).unwrap_or_else(|e| panic!("Cannot open golden file at {:?}: {}", p, e));
+
+    let mut s = String::new();
+    f.read_to_string(&mut s).expect("Cannot read golden file.");
+    s.trim_end().to_owned()
+}
+
+/// Check that a golden file we created earlier can still be read by the current model by
+/// comparing to a debug string (which should at least be readable enough to show what changed).
+///
+/// If the golden file doesn't exist, create one now.
+///
+/// Note that the CBOR files will be encoded as hexadecimal strings.
+/// To view them in something like https://cbor.dev/ you can use for example `xxd`:
+///
+/// ```text
+/// cat example.cbor | xxd -r -p > example.cbor.bin
+/// ```
+pub fn test_cbor_txt<T: Serialize + DeserializeOwned + Debug>(
+    prefix: &str,
+    name: &str,
+    arb_data: fn(g: &mut quickcheck::Gen) -> T,
+) -> T {
+    // We may not need this, but it shouldn't be too expensive to generate.
+    let mut g = quickcheck::Gen::new(10);
+    let data0 = arb_data(&mut g);
+
+    // Debug string of a wrapper.
+    let to_debug = |w: &T| format!("{:?}", w);
+
+    let cbor = read_or_create(prefix, name, "cbor", &data0, |d| {
+        let bz = fvm_ipld_encoding::to_vec(d).expect("failed to serialize");
+        hex::encode(bz)
+    });
+
+    let bz = hex::decode(cbor).expect("failed to decode hex");
+    let data1: T = fvm_ipld_encoding::from_slice(&bz)
+        .unwrap_or_else(|_| panic!("Cannot deserialize {}/{}.cbor", prefix, name));
+
+    // Use the deserialised data as fallback for the debug string, so if the txt doesn't exist, it's created
+    // from what we just read back.
+    let txt = read_or_create(prefix, name, "txt", &data0, to_debug);
+
+    // This will fail if either the CBOR or the Debug format changes.
+    // At that point we should either know that it's a legitimate regression because we changed the model,
+    // or catch it as an unexpected regression, indicating that we made some backwards incompatible change.
+    assert_eq!(to_debug(&data1), txt.trim_end());
+
+    data1
+}
+
+/// Test that the CID of something we deserialized from CBOR matches what we saved earlier,
+/// ie. that we produce the same CID, which is important if it's the basis of signing.
+pub fn test_cid<T: Debug>(prefix: &str, name: &str, data: T, cid: fn(&T) -> Cid) {
+    let exp_cid = hex::encode(cid(&data).to_bytes());
+    let got_cid = read_or_create(prefix, name, "cid", &exp_cid, |d| d.to_owned());
+    assert_eq!(got_cid, exp_cid)
+}
+
+/// Create a test which calls [`test_cbor_txt`].
+///
+/// # Example
+///
+/// ```ignore
+///        golden_cbor! { "query/response", actor_state, |g| {
+///            ActorState::arbitrary(g)
+///        }}
+/// ```
+#[macro_export]
+macro_rules! golden_cbor {
+    ($prefix:literal, $name:ident, $gen:expr) => {
+        #[test]
+        fn $name() {
+            let label = stringify!($name);
+            $crate::golden::test_cbor_txt($prefix, &label, $gen);
+        }
+    };
+}
+
+/// Create a test which calls [`test_cid`].
+///
+/// # Example
+///
+/// ```ignore
+///    golden_cid! { "fvm", message, |g| SignedMessage::arbitrary(g).message, |m| SignedMessage::cid(m).unwrap() }
+/// ```
+#[macro_export]
+macro_rules! golden_cid {
+    ($prefix:literal, $name:ident, $gen:expr, $cid:expr) => {
+        #[test]
+        fn $name() {
+            let label = stringify!($name);
+            let data = $crate::golden::test_cbor_txt($prefix, &label, $gen);
+            $crate::golden::test_cid($prefix, &label, data, $cid);
+        }
+    };
+}

--- a/fendermint/testing/src/lib.rs
+++ b/fendermint/testing/src/lib.rs
@@ -1,3 +1,4 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
+pub mod golden;
 pub mod smt;

--- a/fendermint/vm/message/Cargo.toml
+++ b/fendermint/vm/message/Cargo.toml
@@ -29,6 +29,7 @@ hex = { workspace = true }
 # however in that case all the extra dependencies would not kick in,
 # and we'd have to repeat all those dependencies.
 fendermint_vm_message = { path = ".", features = ["arb"] }
+fendermint_testing = { path = "../../testing" }
 
 [features]
 default = []

--- a/fendermint/vm/message/tests/golden.rs
+++ b/fendermint/vm/message/tests/golden.rs
@@ -1,158 +1,44 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use cid::Cid;
-use serde::{de::DeserializeOwned, Serialize};
-use std::fmt::Debug;
-use std::fs::File;
-use std::io::{Read, Write};
-use std::path::Path;
-
-/// Path to a golden file.
-fn path(prefix: &str, name: &str, ext: &str) -> String {
-    // All files will have the same name but different extension.
-    // They should be under `fendermint/vm/message/golden`.
-    let path = Path::new("golden").join(prefix).join(name);
-    format!("{}.{}", path.display(), ext)
-}
-
-/// Read the contents of an existing golden file, or create it by turning `fallback` into string first.
-fn read_or_create<T>(
-    prefix: &str,
-    name: &str,
-    ext: &str,
-    fallback: &T,
-    to_string: fn(&T) -> String,
-) -> String {
-    let p = path(prefix, name, ext);
-    let p = Path::new(&p);
-
-    if !p.exists() {
-        if let Some(p) = p.parent() {
-            std::fs::create_dir_all(p).expect("failed to create golden directory");
-        }
-        let s = to_string(fallback);
-        let mut f = File::create(p)
-            .unwrap_or_else(|e| panic!("Cannot create golden file at {:?}: {}", p, e));
-        f.write_all(s.as_bytes()).unwrap();
-    }
-
-    let mut f =
-        File::open(p).unwrap_or_else(|e| panic!("Cannot open golden file at {:?}: {}", p, e));
-
-    let mut s = String::new();
-    f.read_to_string(&mut s).expect("Cannot read golden file.");
-    s.trim_end().to_owned()
-}
-
-/// Check that a golden file we created earlier can still be read by the current model by
-/// comparing to a debug string (which should at least be readable enough to show what changed).
-///
-/// If the golden file doesn't exist, create one now.
-///
-/// Note that the CBOR files will be encoded as hexadecimal strings.
-/// To view them in something like https://cbor.dev/ you can use for example `xxd`:
-///
-/// ```text
-/// cat example.cbor | xxd -r -p > example.cbor.bin
-/// ```
-fn test_cbor_txt<T: Serialize + DeserializeOwned + Debug>(
-    prefix: &str,
-    name: &str,
-    arb_data: fn(g: &mut quickcheck::Gen) -> T,
-) -> T {
-    // We may not need this, but it shouldn't be too expensive to generate.
-    let mut g = quickcheck::Gen::new(10);
-    let data0 = arb_data(&mut g);
-
-    // Debug string of a wrapper.
-    let to_debug = |w: &T| format!("{:?}", w);
-
-    let cbor = read_or_create(prefix, name, "cbor", &data0, |d| {
-        let bz = fvm_ipld_encoding::to_vec(d).expect("failed to serialize");
-        hex::encode(bz)
-    });
-
-    let bz = hex::decode(cbor).expect("failed to decode hex");
-    let data1: T = fvm_ipld_encoding::from_slice(&bz)
-        .unwrap_or_else(|_| panic!("Cannot deserialize {}/{}.cbor", prefix, name));
-
-    // Use the deserialised data as fallback for the debug string, so if the txt doesn't exist, it's created
-    // from what we just read back.
-    let txt = read_or_create(prefix, name, "txt", &data0, to_debug);
-
-    // This will fail if either the CBOR or the Debug format changes.
-    // At that point we should either know that it's a legitimate regression because we changed the model,
-    // or catch it as an unexpected regression, indicating that we made some backwards incompatible change.
-    assert_eq!(to_debug(&data1), txt.trim_end());
-
-    data1
-}
-
-/// Test that the CID of something we deserialized from CBOR matches what we saved earlier,
-/// ie. that we produce the same CID, which is important if it's the basis of signing.
-pub fn test_cid<T: Debug>(prefix: &str, name: &str, data: T, cid: fn(&T) -> Cid) {
-    let exp_cid = hex::encode(cid(&data).to_bytes());
-    let got_cid = read_or_create(prefix, name, "cid", &exp_cid, |d| d.to_owned());
-    assert_eq!(got_cid, exp_cid)
-}
-
-macro_rules! golden_cbor {
-    ($prefix:literal, $name:ident, $gen:expr) => {
-        #[test]
-        fn $name() {
-            let label = stringify!($name);
-            crate::test_cbor_txt($prefix, &label, $gen);
-        }
-    };
-}
-
-macro_rules! golden_cid {
-    ($prefix:literal, $name:ident, $gen:expr, $cid:expr) => {
-        #[test]
-        fn $name() {
-            let label = stringify!($name);
-            let data = crate::test_cbor_txt($prefix, &label, $gen);
-            crate::test_cid($prefix, &label, data, $cid);
-        }
-    };
-}
 
 /// Examples of `ChainMessage`, which is what the client has to send,
 /// or at least what appears in blocks.
 mod chain {
+    use fendermint_testing::golden_cbor;
     use fendermint_vm_message::chain::ChainMessage;
     use quickcheck::Arbitrary;
 
     golden_cbor! { "chain", signed, |g| {
         loop {
-          if let msg @ ChainMessage::Signed(_) = ChainMessage::arbitrary(g) {
-            return msg
-          }
+            if let msg @ ChainMessage::Signed(_) = ChainMessage::arbitrary(g) {
+                return msg
+            }
         }
       }
     }
 
     golden_cbor! { "chain", for_execution, |g| {
         loop {
-          if let msg @ ChainMessage::ForExecution(_) = ChainMessage::arbitrary(g) {
-            return msg
-          }
+            if let msg @ ChainMessage::ForExecution(_) = ChainMessage::arbitrary(g) {
+                return msg
+            }
         }
       }
     }
 
     golden_cbor! { "chain", for_resolution, |g| {
         loop {
-          if let msg @ ChainMessage::ForResolution(_) = ChainMessage::arbitrary(g) {
-            return msg
-          }
+            if let msg @ ChainMessage::ForResolution(_) = ChainMessage::arbitrary(g) {
+                return msg
+            }
         }
-      }
+    }
     }
 }
 
 /// Examples of FVM messages, which is what the client needs to sign.
 mod fvm {
+    use fendermint_testing::golden_cid;
     use fendermint_vm_message::signed::SignedMessage;
     use quickcheck::Arbitrary;
 
@@ -162,6 +48,7 @@ mod fvm {
 /// Examples of query requests the client needs to send, and client responses it will receive.
 mod query {
     mod request {
+        use fendermint_testing::golden_cbor;
         use fendermint_vm_message::query::FvmQuery;
         use quickcheck::Arbitrary;
 
@@ -183,6 +70,7 @@ mod query {
     }
 
     mod response {
+        use fendermint_testing::golden_cbor;
         use fendermint_vm_message::query::ActorState;
         use quickcheck::Arbitrary;
 


### PR DESCRIPTION
The PR moves the macros and methods used in `fendermint/vm/message/tests/golden.rs` to be under `fendermint/testing/src/golden.rs` so we can use it in non-message crates.