### PR TITLE
RF: Move commands to submodule

### DIFF
--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -46,3 +46,8 @@ tempfile = { workspace = true }
 # actor project to be released. In prod, we'd just load it from a file, so let's see if that works.
 # We can build a bundle CAR with the Makefile.
 # actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "next" }
+
+# Using a single binary to run the application as well as to execute client commands.
+[[bin]]
+name = "fendermint"
+path = "src/main.rs"

--- a/fendermint/app/src/cmd/mod.rs
+++ b/fendermint/app/src/cmd/mod.rs
@@ -1,0 +1,6 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+//! CLI command implementations.
+
+pub mod run;

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -1,0 +1,72 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Context};
+use fendermint_abci::ApplicationService;
+use fendermint_app::{App, AppStore};
+use fendermint_rocksdb::{RocksDb, RocksDbConfig};
+use fendermint_vm_interpreter::{
+    bytes::BytesMessageInterpreter, chain::ChainMessageInterpreter, fvm::FvmMessageInterpreter,
+    signed::SignedMessageInterpreter,
+};
+
+use crate::settings::Settings;
+
+pub async fn run(config_dir: Option<PathBuf>, mode: &str) -> anyhow::Result<()> {
+    let config_dir = match config_dir {
+        Some(d) if d.is_dir() => d,
+        Some(d) if d.exists() => return Err(anyhow!("config '{d:?}' is a not a directory")),
+        Some(d) => return Err(anyhow!("config '{d:?}' does not exist")),
+        None => return Err(anyhow!("could not find a config directory to use")),
+    };
+
+    let settings = Settings::new(config_dir, mode).context("error parsing settings")?;
+
+    let interpreter = FvmMessageInterpreter::<RocksDb>::new();
+    let interpreter = SignedMessageInterpreter::new(interpreter);
+    let interpreter = ChainMessageInterpreter::new(interpreter);
+    let interpreter = BytesMessageInterpreter::new(interpreter);
+
+    let db = open_db(&settings).expect("error opening DB");
+    let app_ns = db.new_cf_handle("app").unwrap();
+    let state_hist_ns = db.new_cf_handle("state_hist").unwrap();
+
+    let app = App::<_, AppStore, _>::new(
+        db,
+        settings.builtin_actors_bundle,
+        app_ns,
+        state_hist_ns,
+        interpreter,
+    );
+
+    let service = ApplicationService(app);
+
+    // Split it into components.
+    let (consensus, mempool, snapshot, info) =
+        tower_abci::split::service(service, settings.abci.bound);
+
+    // Hand those components to the ABCI server. This is where tower layers could be added.
+    let server = tower_abci::Server::builder()
+        .consensus(consensus)
+        .snapshot(snapshot)
+        .mempool(mempool)
+        .info(info)
+        .finish()
+        .context("error creating ABCI server")?;
+
+    // Run the ABCI server.
+    server
+        .listen(settings.abci.listen_addr())
+        .await
+        .map_err(|e| anyhow!("error listening: {e}"))?;
+
+    Ok(())
+}
+
+fn open_db(settings: &Settings) -> anyhow::Result<RocksDb> {
+    let path = settings.data_dir.join("rocksdb");
+    let db = RocksDb::open(path, &RocksDbConfig::default())?;
+    Ok(db)
+}

--- a/fendermint/app/src/lib.rs
+++ b/fendermint/app/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 mod app;
-pub mod options;
-pub mod settings;
 mod store;
 mod tmconv;
 

--- a/fendermint/app/src/main.rs
+++ b/fendermint/app/src/main.rs
@@ -2,18 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use clap::Parser;
-use fendermint_abci::ApplicationService;
-use fendermint_app::{
-    options::{Command, Options},
-    settings::Settings,
-    App, AppStore,
-};
-use fendermint_rocksdb::{RocksDb, RocksDbConfig};
-use fendermint_vm_interpreter::{
-    bytes::BytesMessageInterpreter, chain::ChainMessageInterpreter, fvm::FvmMessageInterpreter,
-    signed::SignedMessageInterpreter,
-};
 use tracing_subscriber::FmtSubscriber;
+
+mod cmd;
+mod options;
+mod settings;
+
+use options::{Commands, Options};
 
 #[tokio::main]
 async fn main() {
@@ -26,60 +21,15 @@ async fn main() {
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
-    if let Some(Command::Run { ref mode }) = opts.command {
-        let config_dir = match opts.config_dir() {
-            Some(d) if d.is_dir() => d,
-            Some(d) if d.exists() => panic!("config '{d:?}' is a not a directory"),
-            Some(d) => panic!("config '{d:?}' does not exist"),
-            None => panic!("could not find a config directory to use"),
+    if let Some(ref cmd) = opts.command {
+        let result = match cmd {
+            Commands::Run { mode } => cmd::run::run(opts.config_dir(), mode.as_ref()).await,
         };
-
-        let settings = Settings::new(config_dir, mode).expect("error parsing settings");
-
-        let interpreter = FvmMessageInterpreter::<RocksDb>::new();
-        let interpreter = SignedMessageInterpreter::new(interpreter);
-        let interpreter = ChainMessageInterpreter::new(interpreter);
-        let interpreter = BytesMessageInterpreter::new(interpreter);
-
-        let db = open_db(&settings).expect("error opening DB");
-        let app_ns = db.new_cf_handle("app").unwrap();
-        let state_hist_ns = db.new_cf_handle("state_hist").unwrap();
-
-        let app = App::<_, AppStore, _>::new(
-            db,
-            settings.builtin_actors_bundle,
-            app_ns,
-            state_hist_ns,
-            interpreter,
-        );
-
-        let service = ApplicationService(app);
-
-        // Split it into components.
-        let (consensus, mempool, snapshot, info) =
-            tower_abci::split::service(service, settings.abci.bound);
-
-        // Hand those components to the ABCI server. This is where tower layers could be added.
-        let server = tower_abci::Server::builder()
-            .consensus(consensus)
-            .snapshot(snapshot)
-            .mempool(mempool)
-            .info(info)
-            .finish()
-            .expect("error creating ABCI server");
-
-        // Run the ABCI server.
-        server
-            .listen(settings.abci.listen_addr())
-            .await
-            .expect("error listening to ABCI requests");
+        if let Err(e) = result {
+            tracing::error!("failed to execute {cmd:?}: {e}");
+            std::process::exit(1);
+        }
     }
-}
-
-fn open_db(settings: &Settings) -> anyhow::Result<RocksDb> {
-    let path = settings.data_dir.join("rocksdb");
-    let db = RocksDb::open(path, &RocksDbConfig::default())?;
-    Ok(db)
 }
 
 #[cfg(test)]

--- a/fendermint/app/src/options.rs
+++ b/fendermint/app/src/options.rs
@@ -20,7 +20,7 @@ pub struct Options {
     pub debug: u8,
 
     #[command(subcommand)]
-    pub command: Option<Command>,
+    pub command: Option<Commands>,
 }
 
 impl Options {
@@ -49,8 +49,8 @@ impl Options {
     }
 }
 
-#[derive(Subcommand)]
-pub enum Command {
+#[derive(Subcommand, Debug)]
+pub enum Commands {
     /// Run the [`App`], listening to ABCI requests from Tendermint.
     Run {
         /// Optionally override the default configuration.


### PR DESCRIPTION
As a preparation for #54, the PR moves the implementation of the `Commands` into a new `cmd` module. For now I am keeping all commands in the `fendermint_app` crate. 

# Example 

```console
$ target/debug/fendermint --help
Usage: fendermint [OPTIONS] [COMMAND]

Commands:
  run
          Run the [`App`], listening to ABCI requests from Tendermint
  help
          Print this message or the help of the given subcommand(s)

Options:
  -c, --config-dir <FILE>
          Set a custom directory for configuration files.
          
          By default the application will try to find where the config directory is.

  -d, --debug...
          Turn debugging information on

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```