### PR TITLE
FM-54: Keygen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,6 +1291,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.21.0",
  "cid",
  "clap 4.1.13",
  "config 0.13.3",
@@ -1301,6 +1308,10 @@ dependencies = [
  "fvm_shared",
  "hex",
  "k256",
+ "libsecp256k1",
+ "quickcheck 1.0.3",
+ "quickcheck_macros",
+ "rand_chacha 0.3.1",
  "serde",
  "serde_json",
  "tempfile",
@@ -2268,7 +2279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
 dependencies = [
  "arrayref",
- "base64",
+ "base64 0.13.1",
  "digest 0.9.0",
  "hmac-drbg",
  "libsecp256k1-core",
@@ -3178,7 +3189,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "serde",
 ]

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -43,6 +43,9 @@ tempfile = { workspace = true }
 quickcheck = { workspace = true }
 quickcheck_macros = { workspace = true }
 
+fendermint_vm_genesis = { path = "../vm/genesis", features = ["arb"] }
+
+
 # Load the same built-in actor bundle as the ref-fvm integration tests. We'll probably need built-in actors,
 # for example to deploy Solidity code. We can compile Wasm actors and deploy them too, but certain functions
 # in `ref-fvm` like looking up actor addresses depend on built-in actors like the `InitActor` maintaining state.

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+base64 = { workspace = true }
 clap = { workspace = true }
 config = { workspace = true }
 tokio = { workspace = true }
@@ -20,6 +21,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 hex = { workspace = true }
 k256 = { workspace = true }
+libsecp256k1 = { workspace = true }
+rand_chacha = { workspace = true }
 
 fendermint_abci = { path = "../abci" }
 fendermint_storage = { path = "../storage" }
@@ -37,6 +40,8 @@ fvm_shared = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+quickcheck = { workspace = true }
+quickcheck_macros = { workspace = true }
 
 # Load the same built-in actor bundle as the ref-fvm integration tests. We'll probably need built-in actors,
 # for example to deploy Solidity code. We can compile Wasm actors and deploy them too, but certain functions

--- a/fendermint/app/src/cmd/keygen.rs
+++ b/fendermint/app/src/cmd/keygen.rs
@@ -1,9 +1,8 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::fs::File;
 use std::io::Write;
-use std::path::PathBuf;
+use std::{fs::File, path::Path};
 
 use base64::Engine;
 use libsecp256k1::{PublicKey, SecretKey};
@@ -37,7 +36,7 @@ fn public_to_b64(pk: &PublicKey) -> String {
     to_b64(&pk.serialize_compressed())
 }
 
-fn export(output_dir: &PathBuf, name: &str, ext: &str, b64: &str) -> anyhow::Result<()> {
+fn export(output_dir: &Path, name: &str, ext: &str, b64: &str) -> anyhow::Result<()> {
     let output_path = output_dir.join(format!("{name}.{ext}"));
     let mut output = File::create(output_path)?;
     write!(&mut output, "{}", b64)?;

--- a/fendermint/app/src/cmd/keygen.rs
+++ b/fendermint/app/src/cmd/keygen.rs
@@ -43,3 +43,20 @@ fn export(output_dir: &PathBuf, name: &str, ext: &str, b64: &str) -> anyhow::Res
     write!(&mut output, "{}", b64)?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use fendermint_vm_genesis::ValidatorKey;
+    use libsecp256k1::PublicKey;
+    use quickcheck_macros::quickcheck;
+
+    use super::public_to_b64;
+
+    #[quickcheck]
+    fn prop_public_key_deserialize_to_genesis(vk: ValidatorKey) {
+        let b64 = public_to_b64(&vk.0);
+        let json = serde_json::json!(b64);
+        let pk: PublicKey = serde_json::from_value(json).unwrap();
+        assert_eq!(pk, vk.0)
+    }
+}

--- a/fendermint/app/src/cmd/keygen.rs
+++ b/fendermint/app/src/cmd/keygen.rs
@@ -1,0 +1,10 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use crate::{cmd, options::KeygenArgs};
+
+cmd! {
+  KeygenArgs(self) {
+    todo!()
+  }
+}

--- a/fendermint/app/src/cmd/mod.rs
+++ b/fendermint/app/src/cmd/mod.rs
@@ -3,4 +3,68 @@
 
 //! CLI command implementations.
 
+use crate::{
+    options::{Commands, Options},
+    settings::Settings,
+};
+use anyhow::{anyhow, Context};
+use async_trait::async_trait;
+
+pub mod keygen;
 pub mod run;
+
+#[async_trait]
+pub trait Cmd {
+    async fn exec(&self, settings: Settings) -> anyhow::Result<()>;
+}
+
+/// Convenience macro to simplify declaring commands that either need or don't need settings.
+///
+/// ```text
+/// cmd! {
+///   <type-name>(self, settings) {
+///     <exec-body>
+///   }
+/// }
+/// ```
+#[macro_export]
+macro_rules! cmd {
+    // A command which needs access to the settings.
+    ($name:ident($self:ident, $settings:ident) $exec:expr) => {
+        #[async_trait::async_trait]
+        impl $crate::cmd::Cmd for $name {
+            async fn exec(&$self, $settings: $crate::settings::Settings) -> anyhow::Result<()> {
+                $exec
+            }
+        }
+    };
+
+    // A command which is self-contained and doesn't need the settings.
+    ($name:ident($self:ident) $exec:expr) => {
+        cmd!($name($self, _settings) $exec);
+    };
+}
+
+impl Options {
+    /// Execute the command specified in the options.
+    pub async fn exec(&self) -> anyhow::Result<()> {
+        match &self.command {
+            Commands::Run(args) => args.exec(self.settings()?).await,
+            Commands::Keygen(_args) => todo!(),
+        }
+    }
+
+    /// Try to parse the settings in the configuration directory.
+    fn settings(&self) -> anyhow::Result<Settings> {
+        let config_dir = match self.config_dir() {
+            Some(d) if d.is_dir() => d,
+            Some(d) if d.exists() => return Err(anyhow!("config '{d:?}' is a not a directory")),
+            Some(d) => return Err(anyhow!("config '{d:?}' does not exist")),
+            None => return Err(anyhow!("could not find a config directory to use")),
+        };
+
+        let settings = Settings::new(config_dir, &self.mode).context("error parsing settings")?;
+
+        Ok(settings)
+    }
+}

--- a/fendermint/app/src/cmd/mod.rs
+++ b/fendermint/app/src/cmd/mod.rs
@@ -44,7 +44,7 @@ macro_rules! cmd {
 
     // A command which works on the full `Settings`.
     ($name:ident($self:ident, $settings:ident) $exec:expr) => {
-        cmd!($name($self, _settings: $crate::settings::Settings) $exec);
+        cmd!($name($self, $settings: $crate::settings::Settings) $exec);
     };
 
     // A command which is self-contained and doesn't need any settings.

--- a/fendermint/app/src/cmd/mod.rs
+++ b/fendermint/app/src/cmd/mod.rs
@@ -15,7 +15,8 @@ pub mod run;
 
 #[async_trait]
 pub trait Cmd {
-    async fn exec(&self, settings: Settings) -> anyhow::Result<()>;
+    type Settings;
+    async fn exec(&self, settings: Self::Settings) -> anyhow::Result<()>;
 }
 
 /// Convenience macro to simplify declaring commands that either need or don't need settings.
@@ -29,42 +30,47 @@ pub trait Cmd {
 /// ```
 #[macro_export]
 macro_rules! cmd {
-    // A command which needs access to the settings.
-    ($name:ident($self:ident, $settings:ident) $exec:expr) => {
+    // A command which needs access to some settings.
+    ($name:ident($self:ident, $settings_name:ident : $settings_type:ty) $exec:expr) => {
         #[async_trait::async_trait]
         impl $crate::cmd::Cmd for $name {
-            async fn exec(&$self, $settings: $crate::settings::Settings) -> anyhow::Result<()> {
+            type Settings = $settings_type;
+
+            async fn exec(&$self, $settings_name: Self::Settings) -> anyhow::Result<()> {
                 $exec
             }
         }
     };
 
-    // A command which is self-contained and doesn't need the settings.
+    // A command which works on the full `Settings`.
+    ($name:ident($self:ident, $settings:ident) $exec:expr) => {
+        cmd!($name($self, _settings: $crate::settings::Settings) $exec);
+    };
+
+    // A command which is self-contained and doesn't need any settings.
     ($name:ident($self:ident) $exec:expr) => {
-        cmd!($name($self, _settings) $exec);
+        cmd!($name($self, _settings: ()) $exec);
     };
 }
 
-impl Options {
-    /// Execute the command specified in the options.
-    pub async fn exec(&self) -> anyhow::Result<()> {
-        match &self.command {
-            Commands::Run(args) => args.exec(self.settings()?).await,
-            Commands::Keygen(_args) => todo!(),
-        }
+/// Execute the command specified in the options.
+pub async fn exec(opts: &Options) -> anyhow::Result<()> {
+    match &opts.command {
+        Commands::Run(args) => args.exec(settings(opts)?).await,
+        Commands::Keygen(args) => args.exec(()).await,
     }
+}
 
-    /// Try to parse the settings in the configuration directory.
-    fn settings(&self) -> anyhow::Result<Settings> {
-        let config_dir = match self.config_dir() {
-            Some(d) if d.is_dir() => d,
-            Some(d) if d.exists() => return Err(anyhow!("config '{d:?}' is a not a directory")),
-            Some(d) => return Err(anyhow!("config '{d:?}' does not exist")),
-            None => return Err(anyhow!("could not find a config directory to use")),
-        };
+/// Try to parse the settings in the configuration directory.
+fn settings(opts: &Options) -> anyhow::Result<Settings> {
+    let config_dir = match opts.config_dir() {
+        Some(d) if d.is_dir() => d,
+        Some(d) if d.exists() => return Err(anyhow!("config '{d:?}' is a not a directory")),
+        Some(d) => return Err(anyhow!("config '{d:?}' does not exist")),
+        None => return Err(anyhow!("could not find a config directory to use")),
+    };
 
-        let settings = Settings::new(config_dir, &self.mode).context("error parsing settings")?;
+    let settings = Settings::new(config_dir, &opts.mode).context("error parsing settings")?;
 
-        Ok(settings)
-    }
+    Ok(settings)
 }

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -1,8 +1,6 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::path::PathBuf;
-
 use anyhow::{anyhow, Context};
 use fendermint_abci::ApplicationService;
 use fendermint_app::{App, AppStore};
@@ -12,57 +10,50 @@ use fendermint_vm_interpreter::{
     signed::SignedMessageInterpreter,
 };
 
-use crate::settings::Settings;
+use crate::{cmd, options::RunArgs, settings::Settings};
 
-pub async fn run(config_dir: Option<PathBuf>, mode: &str) -> anyhow::Result<()> {
-    let config_dir = match config_dir {
-        Some(d) if d.is_dir() => d,
-        Some(d) if d.exists() => return Err(anyhow!("config '{d:?}' is a not a directory")),
-        Some(d) => return Err(anyhow!("config '{d:?}' does not exist")),
-        None => return Err(anyhow!("could not find a config directory to use")),
-    };
+cmd! {
+  RunArgs(self, settings) {
+        let interpreter = FvmMessageInterpreter::<RocksDb>::new();
+        let interpreter = SignedMessageInterpreter::new(interpreter);
+        let interpreter = ChainMessageInterpreter::new(interpreter);
+        let interpreter = BytesMessageInterpreter::new(interpreter);
 
-    let settings = Settings::new(config_dir, mode).context("error parsing settings")?;
+        let db = open_db(&settings).expect("error opening DB");
+        let app_ns = db.new_cf_handle("app").unwrap();
+        let state_hist_ns = db.new_cf_handle("state_hist").unwrap();
 
-    let interpreter = FvmMessageInterpreter::<RocksDb>::new();
-    let interpreter = SignedMessageInterpreter::new(interpreter);
-    let interpreter = ChainMessageInterpreter::new(interpreter);
-    let interpreter = BytesMessageInterpreter::new(interpreter);
+        let app = App::<_, AppStore, _>::new(
+            db,
+            settings.builtin_actors_bundle,
+            app_ns,
+            state_hist_ns,
+            interpreter,
+        );
 
-    let db = open_db(&settings).expect("error opening DB");
-    let app_ns = db.new_cf_handle("app").unwrap();
-    let state_hist_ns = db.new_cf_handle("state_hist").unwrap();
+        let service = ApplicationService(app);
 
-    let app = App::<_, AppStore, _>::new(
-        db,
-        settings.builtin_actors_bundle,
-        app_ns,
-        state_hist_ns,
-        interpreter,
-    );
+        // Split it into components.
+        let (consensus, mempool, snapshot, info) =
+            tower_abci::split::service(service, settings.abci.bound);
 
-    let service = ApplicationService(app);
+        // Hand those components to the ABCI server. This is where tower layers could be added.
+        let server = tower_abci::Server::builder()
+            .consensus(consensus)
+            .snapshot(snapshot)
+            .mempool(mempool)
+            .info(info)
+            .finish()
+            .context("error creating ABCI server")?;
 
-    // Split it into components.
-    let (consensus, mempool, snapshot, info) =
-        tower_abci::split::service(service, settings.abci.bound);
+        // Run the ABCI server.
+        server
+            .listen(settings.abci.listen_addr())
+            .await
+            .map_err(|e| anyhow!("error listening: {e}"))?;
 
-    // Hand those components to the ABCI server. This is where tower layers could be added.
-    let server = tower_abci::Server::builder()
-        .consensus(consensus)
-        .snapshot(snapshot)
-        .mempool(mempool)
-        .info(info)
-        .finish()
-        .context("error creating ABCI server")?;
-
-    // Run the ABCI server.
-    server
-        .listen(settings.abci.listen_addr())
-        .await
-        .map_err(|e| anyhow!("error listening: {e}"))?;
-
-    Ok(())
+        Ok(())
+    }
 }
 
 fn open_db(settings: &Settings) -> anyhow::Result<RocksDb> {

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -13,7 +13,7 @@ use fendermint_vm_interpreter::{
 use crate::{cmd, options::RunArgs, settings::Settings};
 
 cmd! {
-  RunArgs(self, settings) {
+  RunArgs(self, settings: Settings) {
         let interpreter = FvmMessageInterpreter::<RocksDb>::new();
         let interpreter = SignedMessageInterpreter::new(interpreter);
         let interpreter = ChainMessageInterpreter::new(interpreter);

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -13,7 +13,7 @@ use fendermint_vm_interpreter::{
 use crate::{cmd, options::RunArgs, settings::Settings};
 
 cmd! {
-  RunArgs(self, settings: Settings) {
+  RunArgs(self, settings) {
         let interpreter = FvmMessageInterpreter::<RocksDb>::new();
         let interpreter = SignedMessageInterpreter::new(interpreter);
         let interpreter = ChainMessageInterpreter::new(interpreter);

--- a/fendermint/app/src/main.rs
+++ b/fendermint/app/src/main.rs
@@ -8,7 +8,7 @@ mod cmd;
 mod options;
 mod settings;
 
-use options::{Commands, Options};
+use options::Options;
 
 #[tokio::main]
 async fn main() {
@@ -21,14 +21,9 @@ async fn main() {
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
-    if let Some(ref cmd) = opts.command {
-        let result = match cmd {
-            Commands::Run { mode } => cmd::run::run(opts.config_dir(), mode.as_ref()).await,
-        };
-        if let Err(e) = result {
-            tracing::error!("failed to execute {cmd:?}: {e}");
-            std::process::exit(1);
-        }
+    if let Err(e) = opts.exec().await {
+        tracing::error!("failed to execute {:?}: {e}", opts.command);
+        std::process::exit(1);
     }
 }
 

--- a/fendermint/app/src/main.rs
+++ b/fendermint/app/src/main.rs
@@ -21,8 +21,8 @@ async fn main() {
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
-    if let Err(e) = opts.exec().await {
-        tracing::error!("failed to execute {:?}: {e}", opts.command);
+    if let Err(e) = cmd::exec(&opts).await {
+        tracing::error!("failed to execute {:?}: {e}", opts);
         std::process::exit(1);
     }
 }

--- a/fendermint/app/src/options.rs
+++ b/fendermint/app/src/options.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use clap::{Args, Parser, Subcommand};
 use tracing::Level;
 
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 #[command(version)]
 pub struct Options {
     /// Set a custom directory for configuration files.

--- a/fendermint/app/src/options.rs
+++ b/fendermint/app/src/options.rs
@@ -69,7 +69,7 @@ pub struct KeygenArgs {
     /// Name used to distinguish the files from other exported keys.
     #[arg(short, long)]
     pub name: String,
-    /// Directory to export the key files to.
-    #[arg(short, long)]
-    pub out_dir: Option<PathBuf>,
+    /// Directory to export the key files to; it must exist.
+    #[arg(short, long, default_value = ".")]
+    pub out_dir: PathBuf,
 }

--- a/fendermint/app/src/options.rs
+++ b/fendermint/app/src/options.rs
@@ -57,7 +57,7 @@ impl Options {
 pub enum Commands {
     /// Run the [`App`], listening to ABCI requests from Tendermint.
     Run(RunArgs),
-    /// Generate a new Secp256k1 key pair and export them to files.
+    /// Generate a new Secp256k1 key pair and export them to files in base64 format.
     Keygen(KeygenArgs),
 }
 

--- a/fendermint/app/src/options.rs
+++ b/fendermint/app/src/options.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use tracing::Level;
 
 #[derive(Parser)]
@@ -15,12 +15,16 @@ pub struct Options {
     #[arg(short, long, value_name = "FILE")]
     config_dir: Option<PathBuf>,
 
+    /// Optionally override the default configuration.
+    #[arg(short, long, default_value = "dev")]
+    pub mode: String,
+
     /// Turn debugging information on.
     #[arg(short, long, action = clap::ArgAction::Count)]
     pub debug: u8,
 
     #[command(subcommand)]
-    pub command: Option<Commands>,
+    pub command: Commands,
 }
 
 impl Options {
@@ -52,9 +56,20 @@ impl Options {
 #[derive(Subcommand, Debug)]
 pub enum Commands {
     /// Run the [`App`], listening to ABCI requests from Tendermint.
-    Run {
-        /// Optionally override the default configuration.
-        #[arg(short, long, default_value = "dev")]
-        mode: String,
-    },
+    Run(RunArgs),
+    /// Generate a new Secp256k1 key pair and export them to files.
+    Keygen(KeygenArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct RunArgs;
+
+#[derive(Args, Debug)]
+pub struct KeygenArgs {
+    /// Name used to distinguish the files from other exported keys.
+    #[arg(short, long)]
+    pub name: String,
+    /// Directory to export the key files to.
+    #[arg(short, long)]
+    pub out_dir: Option<PathBuf>,
 }

--- a/fendermint/vm/genesis/src/lib.rs
+++ b/fendermint/vm/genesis/src/lib.rs
@@ -211,13 +211,19 @@ mod arb {
         }
     }
 
-    impl Arbitrary for Validator {
+    impl Arbitrary for ValidatorKey {
         fn arbitrary(g: &mut Gen) -> Self {
             let mut rng = StdRng::seed_from_u64(u64::arbitrary(g));
             let sk = libsecp256k1::SecretKey::random(&mut rng);
             let pk = libsecp256k1::PublicKey::from_secret_key(&sk);
+            Self::new(pk)
+        }
+    }
+
+    impl Arbitrary for Validator {
+        fn arbitrary(g: &mut Gen) -> Self {
             Self {
-                public_key: ValidatorKey::new(pk),
+                public_key: ValidatorKey::arbitrary(g),
                 power: Power(u64::arbitrary(g)),
             }
         }


### PR DESCRIPTION
Closes #54 

Adds a `keygen` command to generate a public and private key pair. 

# Usage
```console
❯ target/debug/fendermint keygen --help
Generate a new Secp256k1 key pair and export them to files in base64 format

Usage: fendermint keygen [OPTIONS] --name <NAME>

Options:
  -n, --name <NAME>        Name used to distinguish the files from other exported keys
  -o, --out-dir <OUT_DIR>  Directory to export the key files to; it must exist [default: .]
  -h, --help               Print help
```


# Example
```console
❯ mkdir test-keys
❯ target/debug/fendermint keygen --name alice --out-dir test-keys
❯ ls test-keys
alice.pk  alice.sk
❯ cat test-keys/alice.pk
A9+3i7HR5ijRI2naXwCf1yCO40NO1BB8KTuAtGkzIwZ2⏎         
```