### PR TITLE
FIX: Open db and paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,6 +1058,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
+dependencies = [
+ "libc",
+ "redox_users",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,6 +1315,7 @@ dependencies = [
  "cid",
  "clap 4.1.13",
  "config 0.13.3",
+ "dirs",
  "fendermint_abci",
  "fendermint_rocksdb",
  "fendermint_storage",
@@ -3105,6 +3126,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom 0.2.8",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ arbitrary = { version = "1", features = ["derive"] }
 arbtest = "0.2"
 clap = { version = "4.1", features = ["derive"] }
 config = "0.13"
+dirs = "5.0"
 futures = "0.3"
 paste = "1"
 serde = { version = "1", features = ["derive"] }

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 clap = { workspace = true }
 config = { workspace = true }
+dirs = { workspace = true }
 tokio = { workspace = true }
 tendermint = { workspace = true }
 tower-abci = { workspace = true }

--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -1,5 +1,5 @@
-data_dir = "/home/aakoshh/.fendermint/data"
-builtin_actors_bundle = "/home/aakoshh/.fendermint/bundle.car"
+data_dir = "~/.fendermint/data"
+builtin_actors_bundle = "~/.fendermint/bundle.car"
 
 [abci]
 host = "127.0.0.1"

--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -1,5 +1,5 @@
-data_dir = "~/.fendermint/data"
-builtin_actors_bundle = "~/.fendermint/bundle.car"
+data_dir = "/home/aakoshh/.fendermint/data"
+builtin_actors_bundle = "/home/aakoshh/.fendermint/bundle.car"
 
 [abci]
 host = "127.0.0.1"

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -4,11 +4,12 @@
 use anyhow::{anyhow, Context};
 use fendermint_abci::ApplicationService;
 use fendermint_app::{App, AppStore};
-use fendermint_rocksdb::{RocksDb, RocksDbConfig};
+use fendermint_rocksdb::{namespaces, RocksDb, RocksDbConfig};
 use fendermint_vm_interpreter::{
     bytes::BytesMessageInterpreter, chain::ChainMessageInterpreter, fvm::FvmMessageInterpreter,
     signed::SignedMessageInterpreter,
 };
+use tracing::debug;
 
 use crate::{cmd, options::RunArgs, settings::Settings};
 
@@ -19,15 +20,14 @@ cmd! {
         let interpreter = ChainMessageInterpreter::new(interpreter);
         let interpreter = BytesMessageInterpreter::new(interpreter);
 
-        let db = open_db(&settings).expect("error opening DB");
-        let app_ns = db.new_cf_handle("app").unwrap();
-        let state_hist_ns = db.new_cf_handle("state_hist").unwrap();
+        let ns = Namespaces::default();
+        let db = open_db(&settings, &ns).expect("error opening DB");
 
         let app = App::<_, AppStore, _>::new(
             db,
             settings.builtin_actors_bundle,
-            app_ns,
-            state_hist_ns,
+            ns.app,
+            ns.state_hist,
             interpreter,
         );
 
@@ -56,8 +56,19 @@ cmd! {
     }
 }
 
-fn open_db(settings: &Settings) -> anyhow::Result<RocksDb> {
+namespaces! {
+    Namespaces {
+        app,
+        state_hist
+    }
+}
+
+fn open_db(settings: &Settings, ns: &Namespaces) -> anyhow::Result<RocksDb> {
     let path = settings.data_dir.join("rocksdb");
-    let db = RocksDb::open(path, &RocksDbConfig::default())?;
+    debug!(
+        path = path.to_string_lossy().into_owned(),
+        "opening database"
+    );
+    let db = RocksDb::open_cf(path, &RocksDbConfig::default(), ns.values().iter())?;
     Ok(db)
 }

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -9,7 +9,7 @@ use fendermint_vm_interpreter::{
     bytes::BytesMessageInterpreter, chain::ChainMessageInterpreter, fvm::FvmMessageInterpreter,
     signed::SignedMessageInterpreter,
 };
-use tracing::debug;
+use tracing::info;
 
 use crate::{cmd, options::RunArgs, settings::Settings};
 
@@ -25,7 +25,7 @@ cmd! {
 
         let app = App::<_, AppStore, _>::new(
             db,
-            settings.builtin_actors_bundle,
+            settings.builtin_actors_bundle(),
             ns.app,
             ns.state_hist,
             interpreter,
@@ -64,8 +64,8 @@ namespaces! {
 }
 
 fn open_db(settings: &Settings, ns: &Namespaces) -> anyhow::Result<RocksDb> {
-    let path = settings.data_dir.join("rocksdb");
-    debug!(
+    let path = settings.data_dir().join("rocksdb");
+    info!(
         path = path.to_string_lossy().into_owned(),
         "opening database"
     );

--- a/fendermint/app/src/options.rs
+++ b/fendermint/app/src/options.rs
@@ -12,8 +12,8 @@ pub struct Options {
     /// Set a custom directory for configuration files.
     ///
     /// By default the application will try to find where the config directory is.
-    #[arg(short, long, value_name = "FILE")]
-    config_dir: Option<PathBuf>,
+    #[arg(short, long, value_name = "DIR")]
+    pub config_dir: Option<PathBuf>,
 
     /// Optionally override the default configuration.
     #[arg(short, long, default_value = "dev")]
@@ -28,20 +28,6 @@ pub struct Options {
 }
 
 impl Options {
-    /// Return the configured config directory, or a default, if they exist.
-    pub fn config_dir(&self) -> Option<PathBuf> {
-        if let Some(config_dir) = &self.config_dir {
-            return Some(config_dir.clone());
-        }
-        for d in &["./config", "~/.fendermint/config"] {
-            let p = PathBuf::from(d);
-            if p.is_dir() {
-                return Some(p);
-            }
-        }
-        None
-    }
-
     pub fn tracing_level(&self) -> Level {
         match self.debug {
             0 => Level::ERROR,

--- a/fendermint/app/src/store.rs
+++ b/fendermint/app/src/store.rs
@@ -11,7 +11,7 @@ pub struct AppStore;
 
 impl KVStore for AppStore {
     type Repr = Vec<u8>;
-    type Namespace = &'static str;
+    type Namespace = String;
 }
 
 impl<T> Codec<T> for AppStore where AppStore: Encode<T> + Decode<T> {}

--- a/fendermint/rocksdb/src/lib.rs
+++ b/fendermint/rocksdb/src/lib.rs
@@ -7,4 +7,6 @@ mod blockstore;
 #[cfg(feature = "kvstore")]
 mod kvstore;
 
+pub mod namespaces;
+
 pub use rocks::{Error as RocksDbError, RocksDb, RocksDbConfig};

--- a/fendermint/rocksdb/src/namespaces.rs
+++ b/fendermint/rocksdb/src/namespaces.rs
@@ -6,7 +6,13 @@
 /// # Example
 ///
 /// ```
-/// namespaces!(MySpace { foo, bar })
+/// use fendermint_rocksdb::namespaces;
+///
+/// namespaces!(MySpace { foo, bar });
+///
+/// let ms = MySpace::default();
+/// let nss = ms.values();
+/// let ns_foo = &ms.foo;
 /// ```
 #[macro_export]
 macro_rules! namespaces {

--- a/fendermint/rocksdb/src/namespaces.rs
+++ b/fendermint/rocksdb/src/namespaces.rs
@@ -1,0 +1,33 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+/// List all column families to help keep them unique.
+///
+/// # Example
+///
+/// ```
+/// namespaces!(MySpace { foo, bar })
+/// ```
+#[macro_export]
+macro_rules! namespaces {
+    ($name:ident { $($col:ident),* }) => {
+        struct $name {
+            pub $($col: String),+
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self {
+                    $($col: stringify!($col).to_owned()),+
+                }
+            }
+        }
+
+        impl $name {
+            /// List column family names, all of which are required for re-opening the databasae.
+            pub fn values(&self) -> Vec<&str> {
+                vec![$(self.$col.as_ref()),+]
+            }
+        }
+    };
+}


### PR DESCRIPTION
Contains two fixes:
* Opening RocksDB a second time needs all the column families to be passed up front
* Expanding the `~` in the paths in the config


# Example 

```console
❯ cargo run -p fendermint_app -- --config-dir ./fendermint/app/config -ddd  run
   ...
     Running `target/debug/fendermint --config-dir ./fendermint/app/config -ddd run`
2023-03-27T16:04:10.752139Z  INFO fendermint::cmd::run: opening database path="/home/aakoshh/.fendermint/data/rocksdb"
2023-03-27T16:04:11.085806Z  INFO tower_abci::server: starting ABCI server addr="127.0.0.1:26658"
2023-03-27T16:04:11.085922Z  INFO tower_abci::server: bound tcp listener local_addr=127.0.0.1:26658

```