### PR TITLE
FM-57: Genesis / New command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,6 +1330,7 @@ dependencies = [
  "hex",
  "k256",
  "libsecp256k1",
+ "num-traits",
  "quickcheck 1.0.3",
  "quickcheck_macros",
  "rand_chacha 0.3.1",

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -24,6 +24,7 @@ hex = { workspace = true }
 k256 = { workspace = true }
 libsecp256k1 = { workspace = true }
 rand_chacha = { workspace = true }
+num-traits = { workspace = true }
 
 fendermint_abci = { path = "../abci" }
 fendermint_storage = { path = "../storage" }

--- a/fendermint/app/src/cmd/genesis.rs
+++ b/fendermint/app/src/cmd/genesis.rs
@@ -1,0 +1,30 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use fendermint_vm_genesis::Genesis;
+
+use crate::cmd;
+use crate::options::GenesisNewArgs;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+cmd! {
+  GenesisNewArgs(self, genesis_file: PathBuf) {
+    let genesis = Genesis {
+      network_name: self.network_name.clone(),
+      network_version: self.network_version,
+      base_fee: self.base_fee.clone(),
+      validators: Vec::new(),
+      accounts: Vec::new()
+    };
+
+    let json = serde_json::to_string_pretty(&genesis)?;
+
+    let mut file = File::create(genesis_file)?;
+
+    write!(file, "{}", json)?;
+
+    Ok(())
+  }
+}

--- a/fendermint/app/src/cmd/mod.rs
+++ b/fendermint/app/src/cmd/mod.rs
@@ -60,6 +60,7 @@ pub async fn exec(opts: &Options) -> anyhow::Result<()> {
     match &opts.command {
         Commands::Run(args) => args.exec(settings(opts)?).await,
         Commands::Keygen(args) => args.exec(()).await,
+        Commands::Genesis(args) => todo!(),
     }
 }
 

--- a/fendermint/app/src/cmd/mod.rs
+++ b/fendermint/app/src/cmd/mod.rs
@@ -6,12 +6,13 @@
 use std::path::PathBuf;
 
 use crate::{
-    options::{Commands, Options},
+    options::{Commands, GenesisCommands, Options},
     settings::{expand_tilde, Settings},
 };
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 
+pub mod genesis;
 pub mod keygen;
 pub mod run;
 
@@ -57,11 +58,17 @@ macro_rules! cmd {
 
 /// Execute the command specified in the options.
 pub async fn exec(opts: &Options) -> anyhow::Result<()> {
-    match &opts.command {
-        Commands::Run(args) => args.exec(settings(opts)?).await,
-        Commands::Keygen(args) => args.exec(()).await,
-        Commands::Genesis(args) => todo!(),
-    }
+    let fut = match &opts.command {
+        Commands::Run(args) => args.exec(settings(opts)?),
+        Commands::Keygen(args) => args.exec(()),
+        Commands::Genesis(gargs) => {
+            let genesis_file = gargs.genesis_file.clone();
+            match &gargs.command {
+                GenesisCommands::New(args) => args.exec(genesis_file),
+            }
+        }
+    };
+    fut.await
 }
 
 /// Try to parse the settings in the configuration directory.

--- a/fendermint/app/src/options.rs
+++ b/fendermint/app/src/options.rs
@@ -4,7 +4,10 @@
 use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand};
+use num_traits::Num;
 use tracing::Level;
+
+use fvm_shared::{bigint::BigInt, econ::TokenAmount, version::NetworkVersion};
 
 #[derive(Parser, Debug)]
 #[command(version)]
@@ -45,6 +48,14 @@ pub enum Commands {
     Run(RunArgs),
     /// Generate a new Secp256k1 key pair and export them to files in base64 format.
     Keygen(KeygenArgs),
+    /// Subcommands related to the construction of Genesis files.
+    Genesis(GenesisArgs),
+}
+
+#[derive(Subcommand, Debug)]
+pub enum GenesisCommands {
+    /// Create a new Genesis file, with accounts and validators to be added later.
+    New(GenesisNewArgs),
 }
 
 #[derive(Args, Debug)]
@@ -58,4 +69,44 @@ pub struct KeygenArgs {
     /// Directory to export the key files to; it must exist.
     #[arg(short, long, default_value = ".")]
     pub out_dir: PathBuf,
+}
+
+#[derive(Args, Debug)]
+pub struct GenesisArgs {
+    /// Path to the genesis JSON file.
+    #[arg(short, long)]
+    pub genesis_file: PathBuf,
+
+    #[command(subcommand)]
+    pub command: GenesisCommands,
+}
+
+#[derive(Args, Debug)]
+pub struct GenesisNewArgs {
+    /// Name of the network and chain.
+    #[arg(long)]
+    pub network_name: String,
+    /// Network version, governs which set of built-in actors to use.
+    #[arg(long, default_value = "18", value_parser = parse_network_version)]
+    pub network_version: NetworkVersion,
+    /// Base fee for running transactions.
+    #[arg(long, value_parser = parse_token_amount)]
+    pub base_fee: TokenAmount,
+}
+
+fn parse_network_version(s: &str) -> Result<NetworkVersion, String> {
+    let nv: u32 = s
+        .parse()
+        .map_err(|_| format!("`{s}` isn't a network version"))?;
+    if nv >= 18 {
+        Ok(NetworkVersion::from(nv))
+    } else {
+        Err("the minimum network version is 18".to_owned())
+    }
+}
+
+fn parse_token_amount(s: &str) -> Result<TokenAmount, String> {
+    BigInt::from_str_radix(s, 10)
+        .map_err(|e| format!("not a token amount: {e}"))
+        .map(|i| TokenAmount::from_atto(i))
 }

--- a/fendermint/app/src/options.rs
+++ b/fendermint/app/src/options.rs
@@ -108,5 +108,5 @@ fn parse_network_version(s: &str) -> Result<NetworkVersion, String> {
 fn parse_token_amount(s: &str) -> Result<TokenAmount, String> {
     BigInt::from_str_radix(s, 10)
         .map_err(|e| format!("not a token amount: {e}"))
-        .map(|i| TokenAmount::from_atto(i))
+        .map(TokenAmount::from_atto)
 }

--- a/fendermint/vm/genesis/src/arb.rs
+++ b/fendermint/vm/genesis/src/arb.rs
@@ -1,0 +1,72 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+use crate::{
+    Account, Actor, ActorAddr, ActorMeta, Genesis, Multisig, Power, Validator, ValidatorKey,
+};
+use fendermint_testing::arb::{ArbAddress, ArbTokenAmount};
+use fvm_shared::version::NetworkVersion;
+use quickcheck::{Arbitrary, Gen};
+use rand::{rngs::StdRng, SeedableRng};
+
+impl Arbitrary for ActorMeta {
+    fn arbitrary(g: &mut Gen) -> Self {
+        if bool::arbitrary(g) {
+            ActorMeta::Account(Account {
+                owner: ActorAddr(ArbAddress::arbitrary(g).0),
+            })
+        } else {
+            let n = u64::arbitrary(g) % 4 + 2;
+            let signers = (0..n)
+                .map(|_| ActorAddr(ArbAddress::arbitrary(g).0))
+                .collect();
+            let threshold = u64::arbitrary(g) % n + 1;
+            ActorMeta::MultiSig(Multisig {
+                signers,
+                threshold,
+                vesting_duration: u64::arbitrary(g),
+                vesting_start: u64::arbitrary(g),
+            })
+        }
+    }
+}
+
+impl Arbitrary for Actor {
+    fn arbitrary(g: &mut Gen) -> Self {
+        Self {
+            meta: ActorMeta::arbitrary(g),
+            balance: ArbTokenAmount::arbitrary(g).0,
+        }
+    }
+}
+
+impl Arbitrary for ValidatorKey {
+    fn arbitrary(g: &mut Gen) -> Self {
+        let mut rng = StdRng::seed_from_u64(u64::arbitrary(g));
+        let sk = libsecp256k1::SecretKey::random(&mut rng);
+        let pk = libsecp256k1::PublicKey::from_secret_key(&sk);
+        Self::new(pk)
+    }
+}
+
+impl Arbitrary for Validator {
+    fn arbitrary(g: &mut Gen) -> Self {
+        Self {
+            public_key: ValidatorKey::arbitrary(g),
+            power: Power(u64::arbitrary(g)),
+        }
+    }
+}
+
+impl Arbitrary for Genesis {
+    fn arbitrary(g: &mut Gen) -> Self {
+        let nv = usize::arbitrary(g) % 10 + 1;
+        let na = usize::arbitrary(g) % 10;
+        Self {
+            network_name: String::arbitrary(g),
+            network_version: NetworkVersion::new(*g.choose(&[18u32]).unwrap()),
+            base_fee: ArbTokenAmount::arbitrary(g).0,
+            validators: (0..nv).map(|_| Arbitrary::arbitrary(g)).collect(),
+            accounts: (0..na).map(|_| Arbitrary::arbitrary(g)).collect(),
+        }
+    }
+}

--- a/fendermint/vm/genesis/src/encoding.rs
+++ b/fendermint/vm/genesis/src/encoding.rs
@@ -1,0 +1,75 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+use std::str::FromStr;
+
+use fvm_shared::bigint::BigInt;
+use fvm_shared::{address::Address, econ::TokenAmount};
+use num_traits::Num;
+use serde::de::Error;
+use serde::{de, Deserialize, Serialize, Serializer};
+
+use crate::ActorAddr;
+
+impl Serialize for ActorAddr {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            self.0.to_string().serialize(serializer)
+        } else {
+            self.0.serialize(serializer)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ActorAddr {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            match Address::from_str(&s) {
+                Ok(a) => Ok(Self(a)),
+                Err(e) => Err(D::Error::custom(format!(
+                    "error deserializing address: {}",
+                    e
+                ))),
+            }
+        } else {
+            Address::deserialize(deserializer).map(Self)
+        }
+    }
+}
+
+/// Serialize tokens as human readable string.
+pub fn serialize_tokens<S>(tokens: &TokenAmount, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    if serializer.is_human_readable() {
+        tokens.atto().to_str_radix(10).serialize(serializer)
+    } else {
+        tokens.serialize(serializer)
+    }
+}
+
+/// Deserialize tokens from human readable decimal format.
+pub fn deserialize_tokens<'de, D>(deserializer: D) -> Result<TokenAmount, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    if deserializer.is_human_readable() {
+        let s = String::deserialize(deserializer)?;
+        match BigInt::from_str_radix(&s, 10) {
+            Ok(a) => Ok(TokenAmount::from_atto(a)),
+            Err(e) => Err(D::Error::custom(format!(
+                "error deserializing tokens: {}",
+                e
+            ))),
+        }
+    } else {
+        TokenAmount::deserialize(deserializer)
+    }
+}

--- a/fendermint/vm/genesis/src/lib.rs
+++ b/fendermint/vm/genesis/src/lib.rs
@@ -14,6 +14,9 @@ use num_traits::Num;
 use serde::de::Error;
 use serde::{de, Deserialize, Serialize, Serializer};
 
+#[cfg(feature = "arb")]
+mod arb;
+
 /// Wrapper around [`Address`] to provide human readable serialization in JSON format.
 ///
 /// An alternative would be the `serde_with` crate.
@@ -168,80 +171,6 @@ pub struct Genesis {
     pub base_fee: TokenAmount,
     pub validators: Vec<Validator>,
     pub accounts: Vec<Actor>,
-}
-
-#[cfg(feature = "arb")]
-mod arb {
-    use crate::{
-        Account, Actor, ActorAddr, ActorMeta, Genesis, Multisig, Power, Validator, ValidatorKey,
-    };
-    use fendermint_testing::arb::{ArbAddress, ArbTokenAmount};
-    use fvm_shared::version::NetworkVersion;
-    use quickcheck::{Arbitrary, Gen};
-    use rand::{rngs::StdRng, SeedableRng};
-
-    impl Arbitrary for ActorMeta {
-        fn arbitrary(g: &mut Gen) -> Self {
-            if bool::arbitrary(g) {
-                ActorMeta::Account(Account {
-                    owner: ActorAddr(ArbAddress::arbitrary(g).0),
-                })
-            } else {
-                let n = u64::arbitrary(g) % 4 + 2;
-                let signers = (0..n)
-                    .map(|_| ActorAddr(ArbAddress::arbitrary(g).0))
-                    .collect();
-                let threshold = u64::arbitrary(g) % n + 1;
-                ActorMeta::MultiSig(Multisig {
-                    signers,
-                    threshold,
-                    vesting_duration: u64::arbitrary(g),
-                    vesting_start: u64::arbitrary(g),
-                })
-            }
-        }
-    }
-
-    impl Arbitrary for Actor {
-        fn arbitrary(g: &mut Gen) -> Self {
-            Self {
-                meta: ActorMeta::arbitrary(g),
-                balance: ArbTokenAmount::arbitrary(g).0,
-            }
-        }
-    }
-
-    impl Arbitrary for ValidatorKey {
-        fn arbitrary(g: &mut Gen) -> Self {
-            let mut rng = StdRng::seed_from_u64(u64::arbitrary(g));
-            let sk = libsecp256k1::SecretKey::random(&mut rng);
-            let pk = libsecp256k1::PublicKey::from_secret_key(&sk);
-            Self::new(pk)
-        }
-    }
-
-    impl Arbitrary for Validator {
-        fn arbitrary(g: &mut Gen) -> Self {
-            Self {
-                public_key: ValidatorKey::arbitrary(g),
-                power: Power(u64::arbitrary(g)),
-            }
-        }
-    }
-
-    impl Arbitrary for Genesis {
-        fn arbitrary(g: &mut Gen) -> Self {
-            let nv = usize::arbitrary(g) % 10 + 1;
-            let na = usize::arbitrary(g) % 10;
-            Self {
-                network_name: String::arbitrary(g),
-                network_version: NetworkVersion::new(*g.choose(&[18u32]).unwrap()),
-                base_fee: ArbTokenAmount::arbitrary(g).0,
-                validators: (0..nv).map(|_| Arbitrary::arbitrary(g)).collect(),
-                accounts: (0..na).map(|_| Arbitrary::arbitrary(g)).collect(),
-            }
-        }
-    }
 }
 
 #[cfg(test)]

--- a/fendermint/vm/genesis/src/lib.rs
+++ b/fendermint/vm/genesis/src/lib.rs
@@ -3,19 +3,17 @@
 //! A Genesis data structure similar to [genesis.Template](https://github.com/filecoin-project/lotus/blob/v1.20.4/genesis/types.go)
 //! in Lotus, which is used to [initialize](https://github.com/filecoin-project/lotus/blob/v1.20.4/chain/gen/genesis/genesis.go) the state tree.
 
-use std::str::FromStr;
-
-use fvm_shared::bigint::BigInt;
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::{address::Address, econ::TokenAmount};
 use libsecp256k1::curve::Affine;
 use libsecp256k1::PublicKey;
-use num_traits::Num;
-use serde::de::Error;
-use serde::{de, Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "arb")]
 mod arb;
+mod encoding;
+
+use encoding::{deserialize_tokens, serialize_tokens};
 
 /// Wrapper around [`Address`] to provide human readable serialization in JSON format.
 ///
@@ -25,69 +23,6 @@ mod arb;
 ///       Not sure if anything but public key addresses make sense here. Consider using `PublicKey` instead of `Address`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ActorAddr(pub Address);
-
-impl Serialize for ActorAddr {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        if serializer.is_human_readable() {
-            self.0.to_string().serialize(serializer)
-        } else {
-            self.0.serialize(serializer)
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for ActorAddr {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        if deserializer.is_human_readable() {
-            let s = String::deserialize(deserializer)?;
-            match Address::from_str(&s) {
-                Ok(a) => Ok(Self(a)),
-                Err(e) => Err(D::Error::custom(format!(
-                    "error deserializing address: {}",
-                    e
-                ))),
-            }
-        } else {
-            Address::deserialize(deserializer).map(Self)
-        }
-    }
-}
-
-/// Serialize tokens as human readable string.
-fn serialize_tokens<S>(tokens: &TokenAmount, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    if serializer.is_human_readable() {
-        tokens.atto().to_str_radix(10).serialize(serializer)
-    } else {
-        tokens.serialize(serializer)
-    }
-}
-
-fn deserialize_tokens<'de, D>(deserializer: D) -> Result<TokenAmount, D::Error>
-where
-    D: de::Deserializer<'de>,
-{
-    if deserializer.is_human_readable() {
-        let s = String::deserialize(deserializer)?;
-        match BigInt::from_str_radix(&s, 10) {
-            Ok(a) => Ok(TokenAmount::from_atto(a)),
-            Err(e) => Err(D::Error::custom(format!(
-                "error deserializing tokens: {}",
-                e
-            ))),
-        }
-    } else {
-        TokenAmount::deserialize(deserializer)
-    }
-}
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Account {


### PR DESCRIPTION
Closes #57 

Adds a CLI command to create a new genesis file.

# Usage

```console
❯ cargo run -p fendermint_app -- genesis new --help
   ...
     Running `target/debug/fendermint genesis new --help`
Create a new Genesis file, with accounts and validators to be added later

Usage: fendermint genesis --genesis-file <GENESIS_FILE> new [OPTIONS] --network-name <NETWORK_NAME> --base-fee <BASE_FEE>

Options:
      --network-name <NETWORK_NAME>
          Name of the network and chain
      --network-version <NETWORK_VERSION>
          Network version, governs which set of built-in actors to use [default: 18]
      --base-fee <BASE_FEE>
          Base fee for running transactions
  -h, --help
          Print help
```

# Example

```console
❯ cargo run -p fendermint_app -- genesis --genesis-file ./genesis.json new --network-name test --base-fee 1000
❯ cat genesis.json
{
  "network_name": "test",
  "network_version": 18,
  "base_fee": "1000",
  "validators": [],
  "accounts": []
}                                                                                                                                                                                                           
```