### PR TITLE
FM-56: Add validator

### DIFF
--- a/fendermint/app/src/cmd/mod.rs
+++ b/fendermint/app/src/cmd/mod.rs
@@ -67,6 +67,7 @@ pub async fn exec(opts: &Options) -> anyhow::Result<()> {
                 GenesisCommands::New(args) => args.exec(genesis_file),
                 GenesisCommands::AddAccount(args) => args.exec(genesis_file),
                 GenesisCommands::AddMultisig(args) => args.exec(genesis_file),
+                GenesisCommands::AddValidator(args) => args.exec(genesis_file),
             }
         }
     };

--- a/fendermint/app/src/options.rs
+++ b/fendermint/app/src/options.rs
@@ -60,6 +60,8 @@ pub enum GenesisCommands {
     AddAccount(GenesisAddAccountArgs),
     /// Add a multi-sig account to the genesis file.
     AddMultisig(GenesisAddMultisigArgs),
+    /// Add a validator to the genesis file.
+    AddValidator(GenesisAddValidatorArgs),
 }
 
 #[derive(Args, Debug)]
@@ -125,6 +127,16 @@ pub struct GenesisAddMultisigArgs {
     /// Linear unlock start block height.
     #[arg(long, short = 's')]
     pub vesting_start: u64,
+}
+
+#[derive(Args, Debug)]
+pub struct GenesisAddValidatorArgs {
+    /// Path to the Secp256k1 public key exported in base64 format.
+    #[arg(long, short)]
+    pub public_key: PathBuf,
+    /// Voting power.
+    #[arg(long, short = 'v')]
+    pub power: u64,
 }
 
 fn parse_network_version(s: &str) -> Result<NetworkVersion, String> {


### PR DESCRIPTION
Closes consensus-shipyard/ipc-monorepo#260 

Adds CLI command to splice validators into the genesis file.

# Usage

```console
❯ cargo run -p fendermint_app -- genesis add-validator --help
    Finished dev [unoptimized + debuginfo] target(s) in 0.34s
     Running `target/debug/fendermint genesis add-validator --help`
Add a validator to the genesis file

Usage: fendermint genesis --genesis-file <GENESIS_FILE> add-validator --public-key <PUBLIC_KEY> --power <POWER>

Options:
  -p, --public-key <PUBLIC_KEY>  Path to the Secp256k1 public key exported in base64 format
  -v, --power <POWER>            Voting power
  -h, --help                     Print help

```