### PR TITLE
FM-58: Change CLI opts

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -104,7 +104,7 @@ cargo run -p fendermint_app -- \
 Check that all three of the signatories have been added:
 
 ```console
-cat test-network/genesis.json | jq .accounts[1]
+$ cat test-network/genesis.json | jq .accounts[1]
 {
   "meta": {
     "Multisig": {
@@ -137,7 +137,7 @@ done
 Check that all of them are present:
 
 ```console
-❯ cat test-network/genesis.json | jq .validators
+$ cat test-network/genesis.json | jq .validators
 [
   {
     "public_key": "BE5Juk793ZAg/7Ojj4bzOmIFGpwLhET1vg2ROihUJFkqGC63X6tOBnky31kw7wPqL0tvbPrtLM2O+SooUhiV1Mo=",
@@ -161,3 +161,49 @@ Check that all of them are present:
 The public keys are spliced in as they were, in base64 format, which is how they would appear in Tendermint's
 own genesis file format. Note that here we don't have the option to use `Address`, because we have to return
 these as actual `PublicKey` types to Tendermint through ABCI, not as a hash of a key.
+
+
+### Run the application
+
+Now we are ready to start our Fendermint _Application_, which will listen to requests coming from Tendermint
+through the ABCI interface.
+
+First, let's make sure we have put all the necessary files in an easy to remember place under `~/.fendermint`.
+
+```shell
+mkdir -p ~/.fendermint/data
+cp -r ./fendermint/app/config ~/.fendermint/config
+```
+
+We will need the actor bundle to load. We can configure its location via environment variables, but the default
+configuration will look for it at `~/.fendermint/bundle.car`, so we might as well put it there.
+
+```shell
+make actor-bundle
+cp ../builtin-actors/output/bundle.car ~/.fendermint/bundle.car
+```
+
+Now, start the application.
+
+```shell
+cargo run -p fendermint_app -- run
+```
+
+The `-dd` flag enables `INFO` level logging; we can see that the application is listening:
+
+```console
+2023-03-29T09:17:28.548878Z  INFO fendermint::cmd: reading configuration path="/home/aakoshh/.fendermint/config"
+2023-03-29T09:17:28.549700Z  INFO fendermint::cmd::run: opening database path="/home/aakoshh/.fendermint/data/rocksdb"
+2023-03-29T09:17:28.879916Z  INFO tower_abci::server: starting ABCI server addr="127.0.0.1:26658"
+2023-03-29T09:17:28.880023Z  INFO tower_abci::server: bound tcp listener local_addr=127.0.0.1:26658
+```
+
+### Run Tendermint
+
+First, follow the instructions in [getting started with Tendermint](./tendermint.md) to install the binary,
+then initialize a genesis file for Tendermint at `~/.tendermint`.
+
+```shell
+rm -rf ~/.tendermint
+tendermint init
+```

--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -1,7 +1,11 @@
-data_dir = "~/.fendermint/data"
-builtin_actors_bundle = "~/.fendermint/bundle.car"
+# Data directory relative to the `--home-dir`, unless given as an absolute path.
+data_dir = "data"
+# Builtin actor bunlde path relative to the `--home-dir`, unless given as an absolute path.
+builtin_actors_bundle = "bundle.car"
 
 [abci]
+# Only accept connections from Tendermint, assumed to be running locally.
 host = "127.0.0.1"
+# The default port where Tendermint is going to connect to the application.
 port = 26658
 bound = 1

--- a/fendermint/app/src/cmd/mod.rs
+++ b/fendermint/app/src/cmd/mod.rs
@@ -83,6 +83,10 @@ fn settings(opts: &Options) -> anyhow::Result<Settings> {
         None => return Err(anyhow!("could not find a config directory to use")),
     };
 
+    tracing::info!(
+        path = config_dir.to_string_lossy().into_owned(),
+        "reading configuration"
+    );
     let settings = Settings::new(config_dir, &opts.mode).context("error parsing settings")?;
 
     Ok(settings)

--- a/fendermint/app/src/cmd/mod.rs
+++ b/fendermint/app/src/cmd/mod.rs
@@ -3,11 +3,9 @@
 
 //! CLI command implementations.
 
-use std::path::PathBuf;
-
 use crate::{
     options::{Commands, GenesisCommands, Options},
-    settings::{expand_tilde, Settings},
+    settings::Settings,
 };
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
@@ -76,32 +74,18 @@ pub async fn exec(opts: &Options) -> anyhow::Result<()> {
 
 /// Try to parse the settings in the configuration directory.
 fn settings(opts: &Options) -> anyhow::Result<Settings> {
-    let config_dir = match find_config_dir(opts) {
-        Some(d) if d.is_dir() => d,
-        Some(d) if d.exists() => return Err(anyhow!("config '{d:?}' is a not a directory")),
-        Some(d) => return Err(anyhow!("config '{d:?}' does not exist")),
-        None => return Err(anyhow!("could not find a config directory to use")),
+    let config_dir = match opts.config_dir() {
+        d if !d.exists() => return Err(anyhow!("'{d:?}' does not exist")),
+        d if !d.is_dir() => return Err(anyhow!("'{d:?}' is a not a directory")),
+        d => d,
     };
 
     tracing::info!(
         path = config_dir.to_string_lossy().into_owned(),
         "reading configuration"
     );
-    let settings = Settings::new(config_dir, &opts.mode).context("error parsing settings")?;
+    let settings =
+        Settings::new(&config_dir, &opts.home_dir, &opts.mode).context("error parsing settings")?;
 
     Ok(settings)
-}
-
-/// Return the configured config directory, or a default, if they exist.
-fn find_config_dir(opts: &Options) -> Option<PathBuf> {
-    if let Some(config_dir) = &opts.config_dir {
-        return Some(config_dir.clone());
-    }
-    for d in &["./config", "~/.fendermint/config"] {
-        let p = expand_tilde(PathBuf::from(d));
-        if p.is_dir() {
-            return Some(p);
-        }
-    }
-    None
 }

--- a/fendermint/app/src/main.rs
+++ b/fendermint/app/src/main.rs
@@ -15,11 +15,12 @@ async fn main() {
     let opts = Options::parse();
 
     // Log events to stdout.
-    let subscriber = FmtSubscriber::builder()
-        .with_max_level(opts.tracing_level())
-        .finish();
+    if let Some(level) = opts.tracing_level() {
+        let subscriber = FmtSubscriber::builder().with_max_level(level).finish();
 
-    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+        tracing::subscriber::set_global_default(subscriber)
+            .expect("setting default subscriber failed");
+    }
 
     if let Err(e) = cmd::exec(&opts).await {
         tracing::error!("failed to execute {:?}: {e:?}", opts);

--- a/fendermint/app/src/options.rs
+++ b/fendermint/app/src/options.rs
@@ -8,6 +8,8 @@ use num_traits::Num;
 
 use fvm_shared::{bigint::BigInt, econ::TokenAmount, version::NetworkVersion};
 
+use crate::settings::expand_tilde;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum LogLevel {
     Off,
@@ -21,11 +23,9 @@ pub enum LogLevel {
 #[derive(Parser, Debug)]
 #[command(version)]
 pub struct Options {
-    /// Set a custom directory for configuration files.
-    ///
-    /// By default the application will try to find where the config directory is.
-    #[arg(short, long, value_name = "DIR")]
-    pub config_dir: Option<PathBuf>,
+    /// Set a custom directory for data and configuration files.
+    #[arg(short = 'd', long, default_value = "~/.fendermint")]
+    pub home_dir: PathBuf,
 
     /// Optionally override the default configuration.
     #[arg(short, long, default_value = "dev")]
@@ -50,6 +50,10 @@ impl Options {
             LogLevel::Debug => Some(tracing::Level::DEBUG),
             LogLevel::Trace => Some(tracing::Level::TRACE),
         }
+    }
+
+    pub fn config_dir(&self) -> PathBuf {
+        expand_tilde(self.home_dir.join("config"))
     }
 }
 

--- a/fendermint/app/src/settings.rs
+++ b/fendermint/app/src/settings.rs
@@ -32,11 +32,7 @@ impl Settings {
     /// Load the default configuration from a directory,
     /// then potential overrides specific to the run mode,
     /// then overrides from the local environment.
-    pub fn new(
-        config_dir: &PathBuf,
-        home_dir: &PathBuf,
-        run_mode: &str,
-    ) -> Result<Self, ConfigError> {
+    pub fn new(config_dir: &Path, home_dir: &Path, run_mode: &str) -> Result<Self, ConfigError> {
         let c = Config::builder()
             .add_source(File::from(config_dir.join("default")))
             // Optional mode specific overrides, checked into git.

--- a/fendermint/app/src/settings.rs
+++ b/fendermint/app/src/settings.rs
@@ -21,6 +21,8 @@ impl AbciSettings {
 
 #[derive(Debug, Deserialize)]
 pub struct Settings {
+    /// Home directory configured on the CLI, to which all paths in settings can be set relative.
+    home_dir: PathBuf,
     data_dir: PathBuf,
     builtin_actors_bundle: PathBuf,
     pub abci: AbciSettings,
@@ -30,8 +32,12 @@ impl Settings {
     /// Load the default configuration from a directory,
     /// then potential overrides specific to the run mode,
     /// then overrides from the local environment.
-    pub fn new(config_dir: PathBuf, run_mode: &str) -> Result<Self, ConfigError> {
-        let s = Config::builder()
+    pub fn new(
+        config_dir: &PathBuf,
+        home_dir: &PathBuf,
+        run_mode: &str,
+    ) -> Result<Self, ConfigError> {
+        let c = Config::builder()
             .add_source(File::from(config_dir.join("default")))
             // Optional mode specific overrides, checked into git.
             .add_source(File::from(config_dir.join(run_mode)).required(false))
@@ -40,18 +46,34 @@ impl Settings {
             // Add in settings from the environment (with a prefix of FM)
             // e.g. `FM_DB_DATA_DIR=./foo/bar ./target/app` would set the database location.
             .add_source(Environment::with_prefix("fm"))
+            // Set the home directory based on what was passed to the CLI,
+            // so everything in the config can be relative to it.
+            // The `home_dir` key is not added to `default.toml` so there is no confusion
+            // about where it will be coming from.
+            .set_override("home_dir", home_dir.to_string_lossy().as_ref())?
             .build()?;
 
-        // You can deserialize (and thus freeze) the entire configuration as
-        s.try_deserialize()
+        // Deserialize (and thus freeze) the entire configuration.
+        c.try_deserialize()
+    }
+
+    /// Make the path relative to `--home-dir`, unless it's an absolute path, then expand any `~` in the beginning.
+    fn expand_path(&self, path: &PathBuf) -> PathBuf {
+        if path.starts_with("/") {
+            return path.clone();
+        }
+        if path.starts_with("~") {
+            return expand_tilde(path);
+        }
+        expand_tilde(self.home_dir.join(path))
     }
 
     pub fn data_dir(&self) -> PathBuf {
-        expand_tilde(&self.data_dir)
+        self.expand_path(&self.data_dir)
     }
 
     pub fn builtin_actors_bundle(&self) -> PathBuf {
-        expand_tilde(&self.builtin_actors_bundle)
+        self.expand_path(&self.builtin_actors_bundle)
     }
 }
 
@@ -86,8 +108,9 @@ mod tests {
 
     #[test]
     fn parse_default() {
+        let current_dir = PathBuf::from(".");
         let default_dir = PathBuf::from("config");
-        Settings::new(default_dir, "test").unwrap();
+        Settings::new(&default_dir, &current_dir, "test").unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Related to #58 

Makes the CLI options more intuitive and more like those of Tendermint:
* Added a `--log-level` option instead of counting the number of `-d`; added an `off` option as well, defaults to `info`.
* Added a `--home-dir` to set a directory which can be used as the root of all paths in the config file, unless they are absolute paths, or are based on `~` which is the user home directory; defaults to `~/.fendermint`. 
* Removed the `--config-dir` option. This way there is no confusion over where the config is, and then what paths are pointing at inside the config files.

# Usage
```console
❯ cargo run -p fendermint_app -- help
   Compiling fendermint_app v0.1.0 (/home/aakoshh/projects/consensuslab/fendermint/fendermint/app)
    Finished dev [unoptimized + debuginfo] target(s) in 29.89s
     Running `target/debug/fendermint help`
Usage: fendermint [OPTIONS] <COMMAND>

Commands:
  run      Run the [`App`], listening to ABCI requests from Tendermint
  keygen   Generate a new Secp256k1 key pair and export them to files in base64 format
  genesis  Subcommands related to the construction of Genesis files
  help     Print this message or the help of the given subcommand(s)

Options:
  -d, --home-dir <HOME_DIR>    Set a custom directory for data and configuration files [default: ~/.fendermint]
  -m, --mode <MODE>            Optionally override the default configuration [default: dev]
  -l, --log-level <LOG_LEVEL>  Set the logging level [default: info] [possible values: off, error, warn, info, debug, trace]
  -h, --help                   Print help
  -V, --version                Print version
```