### PR TITLE
FM-67: CLI convert secret key to Tendermint format

### DIFF
--- a/fendermint/app/src/cmd/genesis.rs
+++ b/fendermint/app/src/cmd/genesis.rs
@@ -18,7 +18,7 @@ use crate::options::{
     GenesisIntoTendermintArgs, GenesisNewArgs,
 };
 
-use super::keygen::b64_to_public;
+use super::key::b64_to_public;
 
 cmd! {
   GenesisNewArgs(self, genesis_file: PathBuf) {

--- a/fendermint/app/src/cmd/genesis.rs
+++ b/fendermint/app/src/cmd/genesis.rs
@@ -4,7 +4,6 @@
 use anyhow::{anyhow, Context};
 use fendermint_app::APP_VERSION;
 use fvm_shared::address::Address;
-use libsecp256k1::PublicKey;
 use std::path::PathBuf;
 
 use fendermint_vm_genesis::{
@@ -18,7 +17,7 @@ use crate::options::{
     GenesisIntoTendermintArgs, GenesisNewArgs,
 };
 
-use super::key::b64_to_public;
+use super::key::read_public_key;
 
 cmd! {
   GenesisNewArgs(self, genesis_file: PathBuf) {
@@ -135,12 +134,6 @@ fn add_validator(genesis_file: &PathBuf, args: &GenesisAddValidatorArgs) -> anyh
         genesis.validators.push(validator);
         Ok(genesis)
     })
-}
-
-fn read_public_key(public_key: &PathBuf) -> anyhow::Result<PublicKey> {
-    let b64 = std::fs::read_to_string(public_key).context("failed to read public key")?;
-    let pk = b64_to_public(&b64).context("public key from base64")?;
-    Ok(pk)
 }
 
 fn read_genesis(genesis_file: &PathBuf) -> anyhow::Result<Genesis> {

--- a/fendermint/app/src/cmd/key.rs
+++ b/fendermint/app/src/cmd/key.rs
@@ -7,10 +7,10 @@ use base64::Engine;
 use libsecp256k1::{PublicKey, SecretKey};
 use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 
-use crate::{cmd, options::KeygenArgs};
+use crate::{cmd, options::KeyGenArgs};
 
 cmd! {
-  KeygenArgs(self) {
+  KeyGenArgs(self) {
     let mut rng = ChaCha20Rng::from_entropy();
     let sk = SecretKey::random(&mut rng);
     let pk = PublicKey::from_secret_key(&sk);
@@ -52,7 +52,7 @@ mod tests {
     use fendermint_vm_genesis::ValidatorKey;
     use quickcheck_macros::quickcheck;
 
-    use crate::cmd::keygen::b64_to_public;
+    use crate::cmd::key::b64_to_public;
 
     use super::public_to_b64;
 

--- a/fendermint/app/src/cmd/mod.rs
+++ b/fendermint/app/src/cmd/mod.rs
@@ -60,6 +60,7 @@ pub async fn exec(opts: &Options) -> anyhow::Result<()> {
         Commands::Run(args) => args.exec(settings(opts)?),
         Commands::Key(sub) => match &sub.command {
             KeyCommands::Gen(args) => args.exec(()),
+            KeyCommands::IntoTendermint(args) => args.exec(()),
         },
         Commands::Genesis(sub) => {
             let genesis_file = sub.genesis_file.clone();

--- a/fendermint/app/src/cmd/mod.rs
+++ b/fendermint/app/src/cmd/mod.rs
@@ -4,14 +4,14 @@
 //! CLI command implementations.
 
 use crate::{
-    options::{Commands, GenesisCommands, Options},
+    options::{Commands, GenesisCommands, KeyCommands, Options},
     settings::Settings,
 };
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 
 pub mod genesis;
-pub mod keygen;
+pub mod key;
 pub mod run;
 
 #[async_trait]
@@ -58,10 +58,12 @@ macro_rules! cmd {
 pub async fn exec(opts: &Options) -> anyhow::Result<()> {
     let fut = match &opts.command {
         Commands::Run(args) => args.exec(settings(opts)?),
-        Commands::Keygen(args) => args.exec(()),
-        Commands::Genesis(gargs) => {
-            let genesis_file = gargs.genesis_file.clone();
-            match &gargs.command {
+        Commands::Key(sub) => match &sub.command {
+            KeyCommands::Gen(args) => args.exec(()),
+        },
+        Commands::Genesis(sub) => {
+            let genesis_file = sub.genesis_file.clone();
+            match &sub.command {
                 GenesisCommands::New(args) => args.exec(genesis_file),
                 GenesisCommands::AddAccount(args) => args.exec(genesis_file),
                 GenesisCommands::AddMultisig(args) => args.exec(genesis_file),

--- a/fendermint/app/src/options.rs
+++ b/fendermint/app/src/options.rs
@@ -71,6 +71,8 @@ pub enum Commands {
 pub enum KeyCommands {
     /// Generate a new Secp256k1 key pair and export them to files in base64 format.
     Gen(KeyGenArgs),
+    /// Convert a secret key file from base64 into the format expected by Tendermint.
+    IntoTendermint(KeyIntoTendermintArgs),
 }
 
 #[derive(Subcommand, Debug)]
@@ -104,6 +106,16 @@ pub struct KeyGenArgs {
     /// Directory to export the key files to; it must exist.
     #[arg(long, short, default_value = ".")]
     pub out_dir: PathBuf,
+}
+
+#[derive(Args, Debug)]
+pub struct KeyIntoTendermintArgs {
+    /// Path to the secret key we want to convert to Tendermint format.
+    #[arg(long, short)]
+    pub secret_key: PathBuf,
+    /// Output file name for the Tendermint private validator key JSON file.
+    #[arg(long, short)]
+    pub out: PathBuf,
 }
 
 #[derive(Args, Debug)]

--- a/fendermint/app/src/options.rs
+++ b/fendermint/app/src/options.rs
@@ -61,10 +61,16 @@ impl Options {
 pub enum Commands {
     /// Run the [`App`], listening to ABCI requests from Tendermint.
     Run(RunArgs),
-    /// Generate a new Secp256k1 key pair and export them to files in base64 format.
-    Keygen(KeygenArgs),
+    /// Subcommands related to the construction of signing keys.
+    Key(KeyArgs),
     /// Subcommands related to the construction of Genesis files.
     Genesis(GenesisArgs),
+}
+
+#[derive(Subcommand, Debug)]
+pub enum KeyCommands {
+    /// Generate a new Secp256k1 key pair and export them to files in base64 format.
+    Gen(KeyGenArgs),
 }
 
 #[derive(Subcommand, Debug)]
@@ -85,7 +91,13 @@ pub enum GenesisCommands {
 pub struct RunArgs;
 
 #[derive(Args, Debug)]
-pub struct KeygenArgs {
+pub struct KeyArgs {
+    #[command(subcommand)]
+    pub command: KeyCommands,
+}
+
+#[derive(Args, Debug)]
+pub struct KeyGenArgs {
     /// Name used to distinguish the files from other exported keys.
     #[arg(long, short)]
     pub name: String,


### PR DESCRIPTION
Closes #67

Adds CLI command to convert `.sk` files to the format Tendermint expects for private validator key files. 

# Usage

```console
$ cargo run -p fendermint_app -- key into-tendermint --help
   
Convert a secret key file from base64 into the format expected by Tendermint

Usage: fendermint key into-tendermint --secret-key <SECRET_KEY> --out <OUT>

Options:
  -s, --secret-key <SECRET_KEY>  Path to the secret key we want to convert to Tendermint format
  -o, --out <OUT>                Output file name for the Tendermint private validator key JSON file
  -h, --help                     Print help
```

# Note

I had to construct the JSON manually because the `tendermint-config` Rust library doesn't handle Secp256k1 keys, but hopefully it's all the same to Tendermint - otherwise why does it let us specify it in the consensus params?