### PR TITLE
FM-58: Start the App and TM

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -338,6 +338,8 @@ AiImfwVC/LeFJN9bB612aCtjbCYWuilf2SorSUXez/QE
 
 #### Start Tendermint
 
+Tendermint can be configured via `~/.tendermint/config/config.toml`; see the default settings [here](https://docs.tendermint.com/v0.34/tendermint-core/configuration.html).
+
 Now we are ready to start Tendermint and let it connect to the Fendermint Application.
 
 ```shell
@@ -349,3 +351,67 @@ If we need to restart the application from scratch, we can erase all Tendermint 
 ```shell
 tendermint unsafe-reset-all
 ```
+
+If all goes well, we will see block created in the Fendermint Application log as well the Tendermint log:
+
+<details>
+  <summary>Application log</summary>
+
+```console
+$ rm -rf ~/.fendermint/data/rocksdb && cargo run -p fendermint_app --release -- --log-level debug run
+...
+2023-03-30T11:51:34.239909Z DEBUG tower_abci::server: new request request=Info(Info { version: "v0.37.0-rc2", block_version: 11, p2p_version: 8, abci_version: "1.0.0" })
+...
+2023-03-30T11:51:34.240250Z DEBUG tower_abci::server: flushing response response=Ok(Info(Info { data: "fendermint", version: "0.1.0", app_version: 0, last_block_height: block::Height(0), last_block_app_hash: AppHash(0171A0E402203AAAC8F10B0E837FDF2546C98BF164972B07B49196E25322711E3C4807CF8AD8) }))
+2023-03-30T11:51:34.240914Z DEBUG tower_abci::server: new request request=InitChain(...)
+...
+2023-03-30T11:51:34.295133Z  INFO fendermint_app::app: init chain state_root="bafy2bzaceaurow7dd2zs2zek7jb44x4jumraubzy5fyjya5edgxnc32nhap76" app_hash="0171A0E4022029175BE31EB32D648AFA43CE5F89A3220A0738E9709C03A419AED16F4D381FFF"
+2023-03-30T11:51:34.295665Z DEBUG tower_abci::server: flushing response response=Ok(InitChain(...))
+...
+2023-03-30T11:51:35.365180Z DEBUG tower_abci::server: new request request=BeginBlock(...)
+...
+2023-03-30T11:51:35.365662Z DEBUG fendermint_app::app: begin block height=1
+2023-03-30T11:51:42.552711Z DEBUG fendermint_app::app: initialized exec state
+2023-03-30T11:51:42.553013Z DEBUG tower_abci::server: flushing response response=Ok(BeginBlock(...))
+...
+2023-03-30T11:51:42.560459Z DEBUG tower_abci::server: flushing response response=Ok(Commit(...))
+...
+2023-03-30T11:51:42.606102Z DEBUG tower_abci::server: new request request=BeginBlock(...)
+...
+2023-03-30T11:51:42.606359Z DEBUG fendermint_app::app: begin block height=2
+2023-03-30T11:51:42.606623Z DEBUG fendermint_app::app: initialized exec state
+...
+```
+</details>
+
+
+<details>
+  <summary>Tendermint log</summary>
+
+```console
+$ tendermint unsafe-reset-all && tendermint start
+...
+I[2023-03-30|12:51:34.240] ABCI Handshake App Info                      module=consensus height=0 hash=0171A0E402203AAAC8F10B0E837FDF2546C98BF164972B07B49196E25322711E3C4807CF8AD8 software-version=0.1.0 protocol-version=0
+I[2023-03-30|12:51:34.240] ABCI Replay Blocks                           module=consensus appHeight=0 storeHeight=0 stateHeight=0
+I[2023-03-30|12:51:34.299] Completed ABCI Handshake - Tendermint and App are synced module=consensus appHeight=0 appHash=0171A0E402203AAAC8F10B0E837FDF2546C98BF164972B07B49196E25322711E3C4807CF8AD8
+...
+I[2023-03-30|12:51:35.335] received proposal                            module=consensus proposal="Proposal{1/0 (9FD634BC038D3CA4FC885E8530CD56B1693739AEBACBF404AAB5DDA5ADC8D180:1:756F1391A4CF, -1) 2BC2F835CBC1 @ 2023-03-30T11:51:35.327328663Z}"
+I[2023-03-30|12:51:35.339] received complete proposal block             module=consensus height=1 hash=9FD634BC038D3CA4FC885E8530CD56B1693739AEBACBF404AAB5DDA5ADC8D180
+I[2023-03-30|12:51:35.357] finalizing commit of block                   module=consensus height=1 hash=9FD634BC038D3CA4FC885E8530CD56B1693739AEBACBF404AAB5DDA5ADC8D180 root=0171A0E4022029175BE31EB32D648AFA43CE5F89A3220A0738E9709C03A419AED16F4D381FFF num_txs=0
+I[2023-03-30|12:51:38.316] Timed out                                    module=consensus dur=3s height=1 round=0 step=RoundStepPropose
+I[2023-03-30|12:51:42.553] executed block                               module=state height=1 num_valid_txs=0 num_invalid_txs=0
+I[2023-03-30|12:51:42.560] committed state                              module=state height=1 num_txs=0 app_hash=0171A0E4022029175BE31EB32D648AFA43CE5F89A3220A0738E9709C03A419AED16F4D381FFF
+I[2023-03-30|12:51:42.564] Timed out                                    module=consensus dur=-6.207267593s height=2 round=0 step=RoundStepNewHeight
+I[2023-03-30|12:51:42.567] indexed block                                module=txindex height=1
+I[2023-03-30|12:51:42.577] received proposal                            module=consensus proposal="Proposal{2/0 (5D2D09F6829D7F0481E597CEAE87DCFA5665987B0B7D57C05B302BEB8DB95406:1:4D3E5565CA22, -1) 693D8DF9C36E @ 2023-03-30T11:51:42.570865715Z}"
+I[2023-03-30|12:51:42.581] received complete proposal block             module=consensus height=2 hash=5D2D09F6829D7F0481E597CEAE87DCFA5665987B0B7D57C05B302BEB8DB95406
+I[2023-03-30|12:51:42.598] finalizing commit of block                   module=consensus height=2 hash=5D2D09F6829D7F0481E597CEAE87DCFA5665987B0B7D57C05B302BEB8DB95406 root=0171A0E4022029175BE31EB32D648AFA43CE5F89A3220A0738E9709C03A419AED16F4D381FFF num_txs=0
+I[2023-03-30|12:51:42.607] executed block                               module=state height=2 num_valid_txs=0 num_invalid_txs=0
+I[2023-03-30|12:51:42.612] committed state                              module=state height=2 num_txs=0 app_hash=0171A0E4022029175BE31EB32D648AFA43CE5F89A3220A0738E9709C03A419AED16F4D381FFF
+I[2023-03-30|12:51:42.618] indexed block                                module=txindex height=2
+...
+```
+</details>
+
+Note that the first block execution is very slow because we have to load the Wasm engine, as indicated by the first proposal having a timeout,
+but after that the blocks come in fast, one per second.

--- a/docs/running.md
+++ b/docs/running.md
@@ -176,6 +176,9 @@ Now, start the application.
 cargo run -p fendermint_app --release -- run
 ```
 
+It is important to use the `--release` option, otherwise it will take too long to load the Wasm actor modules and
+Tendermint will issue a timeout (by default we have 3 seconds to execute requests).
+
 With the default `--log-level info` we can see that the application is listening:
 
 ```console
@@ -183,6 +186,12 @@ With the default `--log-level info` we can see that the application is listening
 2023-03-29T09:17:28.549700Z  INFO fendermint::cmd::run: opening database path="/home/aakoshh/.fendermint/data/rocksdb"
 2023-03-29T09:17:28.879916Z  INFO tower_abci::server: starting ABCI server addr="127.0.0.1:26658"
 2023-03-29T09:17:28.880023Z  INFO tower_abci::server: bound tcp listener local_addr=127.0.0.1:26658
+```
+
+If we need to restart the application from scratch, we can do so by erasing all RocksDB state:
+
+```shell
+rm -rf ~/.fendermint/data/rocksdb
 ```
 
 ### Run Tendermint
@@ -333,4 +342,10 @@ Now we are ready to start Tendermint and let it connect to the Fendermint Applic
 
 ```shell
 tendermint start
+```
+
+If we need to restart the application from scratch, we can erase all Tendermint state like so:
+
+```shell
+tendermint unsafe-reset-all
 ```

--- a/docs/running.md
+++ b/docs/running.md
@@ -173,7 +173,7 @@ cp ../builtin-actors/output/bundle.car ~/.fendermint/bundle.car
 Now, start the application.
 
 ```shell
-cargo run -p fendermint_app -- run
+cargo run -p fendermint_app --release -- run
 ```
 
 With the default `--log-level info` we can see that the application is listening:

--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -9,3 +9,7 @@ host = "127.0.0.1"
 # The default port where Tendermint is going to connect to the application.
 port = 26658
 bound = 1
+
+[db]
+# Keep unlimited history by default.
+state_hist_size = 0

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -108,18 +108,19 @@ where
         db: DB,
         actor_bundle_path: PathBuf,
         app_namespace: S::Namespace,
-        hist_namespace: S::Namespace,
+        state_hist_namespace: S::Namespace,
+        state_hist_size: u64,
         interpreter: I,
     ) -> Self {
         Self {
             db: Arc::new(db),
             actor_bundle_path,
             namespace: app_namespace,
-            state_hist: KVCollection::new(hist_namespace),
+            state_hist: KVCollection::new(state_hist_namespace),
+            state_hist_size,
             interpreter: Arc::new(interpreter),
             exec_state: Arc::new(Mutex::new(None)),
             check_state: Arc::new(tokio::sync::Mutex::new(None)),
-            state_hist_size: 24 * 60 * 60,
         }
     }
 }
@@ -133,6 +134,7 @@ where
     fn clone_db(&self) -> DB {
         self.db.as_ref().clone()
     }
+
     /// Get the last committed state.
     fn committed_state(&self) -> AppState {
         let tx = self.db.read();

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -70,6 +70,14 @@ fn open_db(settings: &Settings, ns: &Namespaces) -> anyhow::Result<RocksDb> {
         path = path.to_string_lossy().into_owned(),
         "opening database"
     );
-    let db = RocksDb::open_cf(path, &RocksDbConfig::default(), ns.values().iter())?;
+    let db = RocksDb::open(path, &RocksDbConfig::default())?;
+
+    // Filter names first, then create, which is just a way to catch duplicates.
+    let mut names = ns.values();
+    names.retain(|name| !db.has_cf_handle(name));
+    for name in names {
+        db.new_cf_handle(name)?;
+    }
+
     Ok(db)
 }

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -28,6 +28,7 @@ cmd! {
             settings.builtin_actors_bundle(),
             ns.app,
             ns.state_hist,
+            settings.db.state_hist_size,
             interpreter,
         );
 

--- a/fendermint/app/src/settings.rs
+++ b/fendermint/app/src/settings.rs
@@ -20,12 +20,21 @@ impl AbciSettings {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct DbSettings {
+    /// Length of the app state history to keep in the database before pruning; 0 means unlimited.
+    ///
+    /// This affects how long we can go back in state queries.
+    pub state_hist_size: u64,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct Settings {
     /// Home directory configured on the CLI, to which all paths in settings can be set relative.
     home_dir: PathBuf,
     data_dir: PathBuf,
     builtin_actors_bundle: PathBuf,
     pub abci: AbciSettings,
+    pub db: DbSettings,
 }
 
 impl Settings {

--- a/fendermint/rocksdb/src/rocks/mod.rs
+++ b/fendermint/rocksdb/src/rocks/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use rocksdb::{
-    ColumnFamilyDescriptor, OptimisticTransactionDB, Options, WriteBatchWithTransaction,
+    ColumnFamilyDescriptor, ErrorKind, OptimisticTransactionDB, Options, WriteBatchWithTransaction,
 };
 use std::{path::Path, sync::Arc};
 
@@ -34,15 +34,12 @@ impl RocksDb {
     where
         P: AsRef<Path>,
     {
-        let db_opts = config.into();
-        Ok(Self {
-            db: Arc::new(OptimisticTransactionDB::open(&db_opts, path)?),
-            options: db_opts,
-        })
+        let cfs = Self::list_cf(&path, config)?;
+        Self::open_cf(&path, config, cfs.iter())
     }
 
     /// Open all column families with the same config.
-    pub fn open_cf<P, I, N>(path: P, config: &RocksDbConfig, cfs: I) -> Result<Self, Error>
+    fn open_cf<P, I, N>(path: P, config: &RocksDbConfig, cfs: I) -> Result<Self, Error>
     where
         P: AsRef<Path>,
         I: Iterator<Item = N>,
@@ -59,6 +56,22 @@ impl RocksDb {
             db: Arc::new(db),
             options: db_opts,
         })
+    }
+
+    /// List existing column families in a database.
+    ///
+    /// These need to be passed to `open_cf` when we are reopening the database.
+    /// If the database doesn't exist, the method returns an empty list.
+    fn list_cf<P>(path: P, config: &RocksDbConfig) -> Result<Vec<String>, Error>
+    where
+        P: AsRef<Path>,
+    {
+        let db_opts: rocksdb::Options = config.into();
+        match OptimisticTransactionDB::<rocksdb::MultiThreaded>::list_cf(&db_opts, path) {
+            Ok(cfs) => Ok(cfs),
+            Err(e) if e.kind() == ErrorKind::IOError => Ok(Vec::new()),
+            Err(e) => Err(Error::Database(e)),
+        }
     }
 
     pub fn get_statistics(&self) -> Option<String> {
@@ -113,11 +126,16 @@ impl RocksDb {
         self.db.flush().map_err(|e| Error::Other(e.to_string()))
     }
 
+    /// Check if a column family exists
+    pub fn has_cf_handle<'a>(&self, name: &'a str) -> bool {
+        self.db.cf_handle(name).is_some()
+    }
+
     /// Create a new column family, using the default options.
     ///
     /// Returns error if it already exists.
     pub fn new_cf_handle<'a>(&self, name: &'a str) -> Result<&'a str, Error> {
-        if self.db.cf_handle(name).is_some() {
+        if self.has_cf_handle(name) {
             return Err(Error::Other(format!(
                 "column family '{name}' already exists"
             )));

--- a/fendermint/rocksdb/src/rocks/mod.rs
+++ b/fendermint/rocksdb/src/rocks/mod.rs
@@ -127,7 +127,7 @@ impl RocksDb {
     }
 
     /// Check if a column family exists
-    pub fn has_cf_handle<'a>(&self, name: &'a str) -> bool {
+    pub fn has_cf_handle(&self, name: &str) -> bool {
         self.db.cf_handle(name).is_some()
     }
 

--- a/fendermint/vm/interpreter/src/fvm/check.rs
+++ b/fendermint/vm/interpreter/src/fvm/check.rs
@@ -8,7 +8,7 @@ use fvm_shared::{address::Address, error::ExitCode};
 
 use crate::CheckInterpreter;
 
-use super::{FvmCheckState, FvmMessage, FvmMessageInterpreter};
+use super::{state::FvmCheckState, FvmMessage, FvmMessageInterpreter};
 
 /// Transaction check results are expressed by the exit code, so that hopefully
 /// they would result in the same error code if they were applied.

--- a/fendermint/vm/interpreter/src/fvm/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/exec.rs
@@ -10,7 +10,7 @@ use fvm_shared::BLOCK_GAS_LIMIT;
 
 use crate::ExecInterpreter;
 
-use super::{FvmExecState, FvmMessage, FvmMessageInterpreter};
+use super::{state::FvmExecState, FvmMessage, FvmMessageInterpreter};
 
 /// The return value extended with some things from the message that
 /// might not be available to the caller, because of the message lookups

--- a/fendermint/vm/interpreter/src/fvm/mod.rs
+++ b/fendermint/vm/interpreter/src/fvm/mod.rs
@@ -7,7 +7,7 @@ mod exec;
 mod externs;
 mod genesis;
 mod query;
-mod state;
+pub mod state;
 mod store;
 
 #[cfg(any(test, feature = "bundle"))]
@@ -18,8 +18,6 @@ pub use exec::FvmApplyRet;
 pub use fendermint_vm_message::query::FvmQuery;
 pub use genesis::FvmGenesisOutput;
 pub use query::FvmQueryRet;
-pub use state::empty_state_tree;
-pub use state::{FvmCheckState, FvmExecState, FvmGenesisState, FvmQueryState};
 
 pub type FvmMessage = fvm_shared::message::Message;
 

--- a/fendermint/vm/interpreter/src/fvm/mod.rs
+++ b/fendermint/vm/interpreter/src/fvm/mod.rs
@@ -18,6 +18,7 @@ pub use exec::FvmApplyRet;
 pub use fendermint_vm_message::query::FvmQuery;
 pub use genesis::FvmGenesisOutput;
 pub use query::FvmQueryRet;
+pub use state::empty_state_tree;
 pub use state::{FvmCheckState, FvmExecState, FvmGenesisState, FvmQueryState};
 
 pub type FvmMessage = fvm_shared::message::Message;

--- a/fendermint/vm/interpreter/src/fvm/state/check.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/check.rs
@@ -21,22 +21,22 @@ impl<DB> FvmCheckState<DB>
 where
     DB: Blockstore + 'static,
 {
-    pub fn new(blockstore: DB, initial_state_root: Cid) -> anyhow::Result<Self> {
+    pub fn new(blockstore: DB, state_root: Cid) -> anyhow::Result<Self> {
         // Sanity check that the blockstore contains the supplied state root.
         if !blockstore
-            .has(&initial_state_root)
+            .has(&state_root)
             .context("failed to load initial state-root")?
         {
             return Err(anyhow!(
                 "blockstore doesn't have the initial state-root {}",
-                initial_state_root
+                state_root
             ));
         }
 
         // Create a new state tree from the supplied root.
         let state_tree = {
             let bstore = ReadOnlyBlockstore::new(blockstore);
-            StateTree::new_from_root(bstore, &initial_state_root)?
+            StateTree::new_from_root(bstore, &state_root)?
         };
 
         let state = Self { state_tree };

--- a/fendermint/vm/interpreter/src/fvm/state/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/exec.rs
@@ -4,7 +4,7 @@
 use cid::Cid;
 use fvm::{
     call_manager::DefaultCallManager,
-    engine::{EngineConfig, EnginePool},
+    engine::MultiEngine,
     executor::{ApplyKind, ApplyRet, DefaultExecutor, Executor},
     machine::{DefaultMachine, Machine, NetworkConfig},
     DefaultKernel,
@@ -30,6 +30,7 @@ where
 {
     pub fn new(
         blockstore: DB,
+        multi_engine: &MultiEngine,
         block_height: ChainEpoch,
         block_timestamp: Timestamp,
         network_version: NetworkVersion,
@@ -46,8 +47,11 @@ where
         mc.set_base_fee(base_fee);
         mc.set_circulating_supply(circ_supply);
 
-        let ec = EngineConfig::from(&nc);
-        let engine = EnginePool::new_default(ec)?;
+        // Creating a new machine every time is prohibitively slow.
+        // let ec = EngineConfig::from(&nc);
+        // let engine = EnginePool::new_default(ec)?;
+
+        let engine = multi_engine.get(&nc)?;
         let machine = DefaultMachine::new(&mc, blockstore, FendermintExterns)?;
         let executor = DefaultExecutor::new(engine, machine)?;
 

--- a/fendermint/vm/interpreter/src/fvm/state/genesis.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/genesis.rs
@@ -16,6 +16,12 @@ use fvm_shared::{clock::ChainEpoch, econ::TokenAmount, state::StateTreeVersion, 
 use num_traits::Zero;
 use serde::Serialize;
 
+/// Create an empty state tree.
+pub fn empty_state_tree<DB: Blockstore>(store: DB) -> anyhow::Result<StateTree<DB>> {
+    let state_tree = StateTree::new(store, StateTreeVersion::V5)?;
+    Ok(state_tree)
+}
+
 /// A state we create for the execution of genesis initialisation.
 pub struct FvmGenesisState<DB>
 where
@@ -53,9 +59,7 @@ where
             }
         };
         let manifest = Manifest::load(&store, &manifest_data_cid, manifest_version)?;
-
-        // Create an empty state tree.
-        let state_tree = StateTree::new(store, StateTreeVersion::V5)?;
+        let state_tree = empty_state_tree(store)?;
 
         let state = Self {
             manifest_data_cid,

--- a/fendermint/vm/interpreter/src/fvm/state/mod.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/mod.rs
@@ -7,6 +7,6 @@ mod genesis;
 mod query;
 
 pub use check::FvmCheckState;
-pub use exec::FvmExecState;
+pub use exec::{FvmExecState, FvmStateParams};
 pub use genesis::{empty_state_tree, FvmGenesisState};
 pub use query::FvmQueryState;

--- a/fendermint/vm/interpreter/src/fvm/state/mod.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/mod.rs
@@ -8,5 +8,5 @@ mod query;
 
 pub use check::FvmCheckState;
 pub use exec::FvmExecState;
-pub use genesis::FvmGenesisState;
+pub use genesis::{empty_state_tree, FvmGenesisState};
 pub use query::FvmQueryState;


### PR DESCRIPTION
Part of #58 

Fixed some problems with the application:
* When opening the DB the first time we must not pass any column families, we must create them after open. On subsequent opens we must pass all existing column families. The PR changes `RocksDB::open` to use the `list_cf` method to figure out what exists and pass it back, then we call `new_cf_handle` for anything that does not `has_cf_handle`.
* Initialize the application state during `App::new` so the initial `info` request does not fail. 
* Cache the wasm engine otherwise it will take a very long time to execute blocks, not just the first one.