### PR TITLE
FM-58: Use WAL 

### DIFF
--- a/fendermint/rocksdb/src/blockstore.rs
+++ b/fendermint/rocksdb/src/blockstore.rs
@@ -8,11 +8,11 @@ use crate::RocksDb;
 
 impl Blockstore for RocksDb {
     fn get(&self, k: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
-        self.read(k.to_bytes()).map_err(Into::into)
+        Ok(self.read(k.to_bytes())?)
     }
 
     fn put_keyed(&self, k: &Cid, block: &[u8]) -> anyhow::Result<()> {
-        self.write(k.to_bytes(), block).map_err(Into::into)
+        Ok(self.write(k.to_bytes(), block)?)
     }
 
     fn put_many_keyed<D, I>(&self, blocks: I) -> anyhow::Result<()>
@@ -30,6 +30,10 @@ impl Blockstore for RocksDb {
         // This function is used in `fvm_ipld_car::load_car`
         // It reduces time cost of loading mainnet snapshot
         // by ~10% by not writing to WAL(write ahead log).
-        Ok(self.db.write_without_wal(batch)?)
+        // Ok(self.db.write_without_wal(batch)?)
+
+        // For some reason with the `write_without_wal` version if I restart the application
+        // it doesn't find the manifest root.
+        Ok(self.db.write(batch)?)
     }
 }


### PR DESCRIPTION
Fixes #71 

During testing it turned out that I when I restart the Application and reconnect to it from Tendermint, the Application crashes because it cannot find the manifest root CID in the block store. It's weird because on the first start some additional debug logs clearly show that it is written and subsequently successfully retrieved as well. I also added a test to verify that I can reopen a database that has the actor bundle imported and the manifest can be restored. 

My only hunch was that maybe somehow the disabling of the WAL during bulk writes can result in this particular key being lost upon a restart. I don't understand why; I don't see anything special in Forest that would deal with this, although IIRC it might be single threaded where I switched to multi-threaded. Maybe the abrupt stop with Ctrl+C? 

Telling the code not to bypass the WAL made the problem go away. I only changed `put_many`, not `bulk_write`; the latter isn't used at the moment, and I thought we could test it more thoroughly.