### PR TITLE
FM-79: CLI command to deploy FEVM contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,6 +1409,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.0",
+ "bytes",
  "cid",
  "clap 4.2.1",
  "config 0.13.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,6 +1502,7 @@ dependencies = [
  "fvm_shared",
  "paste",
  "serde",
+ "serde_tuple",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,6 +1416,7 @@ dependencies = [
  "fendermint_abci",
  "fendermint_rocksdb",
  "fendermint_storage",
+ "fendermint_vm_actor_interface",
  "fendermint_vm_genesis",
  "fendermint_vm_interpreter",
  "fendermint_vm_message",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ async-stm = "0.2"
 async-trait = "0.1"
 base64 = "0.21"
 blake2b_simd = "1.0"
+bytes = "1.4"
 clap = { version = "4.1", features = ["derive", "env"] }
 config = "0.13"
 dirs = "5.0"

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -30,6 +30,7 @@ tracing-subscriber = { workspace = true }
 fendermint_abci = { path = "../abci" }
 fendermint_storage = { path = "../storage" }
 fendermint_rocksdb = { path = "../rocksdb" }
+fendermint_vm_actor_interface = { path = "../vm/actor_interface" }
 fendermint_vm_interpreter = { path = "../vm/interpreter", features = ["bundle"] }
 fendermint_vm_message = { path = "../vm/message", features = ["secp256k1"] }
 fendermint_vm_genesis = { path = "../vm/genesis" }

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
+bytes = { workspace = true }
 clap = { workspace = true }
 config = { workspace = true }
 dirs = { workspace = true }

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -465,7 +465,15 @@ where
                 ChainMessageApplyRet::Signed(Err(InvalidSignature(d))) => {
                     invalid_deliver_tx(AppError::InvalidSignature, d)
                 }
-                ChainMessageApplyRet::Signed(Ok(ret)) => to_deliver_tx(ret),
+                ChainMessageApplyRet::Signed(Ok(ret)) => {
+                    tracing::info!(
+                        from = ret.from.to_string(),
+                        to = ret.to.to_string(),
+                        method_num = ret.method_num,
+                        "tx delivered"
+                    );
+                    to_deliver_tx(ret)
+                }
             },
         };
 

--- a/fendermint/app/src/options/rpc.rs
+++ b/fendermint/app/src/options/rpc.rs
@@ -43,16 +43,14 @@ pub enum RpcCommands {
     },
     /// Transfer tokens between accounts.
     Transfer {
-        #[command(flatten)]
-        args: TransArgs,
         /// Address of the actor to send the message to.
         #[arg(long, short, value_parser = parse_address)]
         to: Address,
+        #[command(flatten)]
+        args: TransArgs,
     },
     /// Send a message (a.k.a. transaction) to an actor.
     Transact {
-        #[command(flatten)]
-        args: TransArgs,
         /// Address of the actor to send the message to.
         #[arg(long, short, value_parser = parse_address)]
         to: Address,
@@ -62,13 +60,15 @@ pub enum RpcCommands {
         /// Raw IPLD byte parameters to pass to the method, in hexadecimal format.
         #[arg(long, short, value_parser = parse_raw_bytes)]
         params: RawBytes,
+        #[command(flatten)]
+        args: TransArgs,
     },
     /// Subcommands related to FEVM.
     Fevm {
-        #[command(flatten)]
-        args: TransArgs,
         #[command(subcommand)]
         command: RpcFevmCommands,
+        #[command(flatten)]
+        args: TransArgs,
     },
 }
 

--- a/fendermint/app/src/options/rpc.rs
+++ b/fendermint/app/src/options/rpc.rs
@@ -45,17 +45,30 @@ pub enum RpcCommands {
     Transfer {
         #[command(flatten)]
         args: TransArgs,
+        /// Address of the actor to send the message to.
+        #[arg(long, short, value_parser = parse_address)]
+        to: Address,
     },
     /// Send a message (a.k.a. transaction) to an actor.
     Transact {
         #[command(flatten)]
         args: TransArgs,
+        /// Address of the actor to send the message to.
+        #[arg(long, short, value_parser = parse_address)]
+        to: Address,
         /// Method number to invoke on the actor.
         #[arg(long, short)]
         method_number: MethodNum,
         /// Raw IPLD byte parameters to pass to the method, in hexadecimal format.
         #[arg(long, short, value_parser = parse_raw_bytes)]
         params: RawBytes,
+    },
+    /// Subcommands related to FEVM.
+    Fevm {
+        #[command(flatten)]
+        args: TransArgs,
+        #[command(subcommand)]
+        command: RpcFevmCommands,
     },
 }
 
@@ -75,18 +88,28 @@ pub enum RpcQueryCommands {
     },
 }
 
+#[derive(Subcommand, Debug)]
+pub enum RpcFevmCommands {
+    /// Deploy an EVM contract from source; print the results as JSON.
+    Create {
+        /// Path to a compiled Solidity contract, expected to be in hexadecimal format.
+        #[arg(long, short)]
+        contract: PathBuf,
+        /// ABI encoded constructor arguments passed to the EVM, expected to be in hexadecimal format.
+        #[arg(long, short, value_parser = parse_raw_bytes, default_value = "")]
+        constructor_args: RawBytes,
+    },
+}
+
 /// Arguments common to transactions and transfers.
 #[derive(Args, Debug)]
 pub struct TransArgs {
-    /// Path to the secret key of the sender to sign the transaction.
-    #[arg(long, short)]
-    pub secret_key: PathBuf,
-    /// Address of the actor to send the message to.
-    #[arg(long, short, value_parser = parse_address)]
-    pub to: Address,
     /// Amount of tokens to send, in atto.
     #[arg(long, short, value_parser = parse_token_amount, default_value = "0")]
     pub value: TokenAmount,
+    /// Path to the secret key of the sender to sign the transaction.
+    #[arg(long, short)]
+    pub secret_key: PathBuf,
     /// Sender account nonce.
     #[arg(long, short = 'n')]
     pub sequence: u64,

--- a/fendermint/app/src/tmconv.rs
+++ b/fendermint/app/src/tmconv.rs
@@ -60,14 +60,18 @@ pub fn to_deliver_tx(ret: FvmApplyRet) -> response::DeliverTx {
     let gas_wanted: i64 = ret.gas_limit.try_into().unwrap_or(i64::MAX);
     let gas_used: i64 = receipt.gas_used.try_into().unwrap_or(i64::MAX);
 
-    let data = receipt.return_data.to_vec().into();
+    let data: bytes::Bytes = receipt.return_data.to_vec().into();
     let events = to_events("message", ret.apply_ret.events);
 
     response::DeliverTx {
         code,
         data,
         log: Default::default(),
-        info: Default::default(),
+        info: ret
+            .apply_ret
+            .failure_info
+            .map(|i| i.to_string())
+            .unwrap_or_default(),
         gas_wanted,
         gas_used,
         events,

--- a/fendermint/vm/actor_interface/Cargo.toml
+++ b/fendermint/vm/actor_interface/Cargo.toml
@@ -12,6 +12,7 @@ license.workspace = true
 anyhow = { workspace = true }
 paste = { workspace = true }
 serde = { workspace = true }
+serde_tuple = { workspace = true }
 
 cid = { workspace = true }
 fvm_shared = { workspace = true }

--- a/fendermint/vm/actor_interface/src/cron.rs
+++ b/fendermint/vm/actor_interface/src/cron.rs
@@ -7,7 +7,7 @@ use fvm_shared::METHOD_CONSTRUCTOR;
 
 define_singleton!(CRON { id: 3, code_id: 3 });
 
-/// Cron actor methods available
+/// Cron actor methods available.
 #[repr(u64)]
 pub enum Method {
     Constructor = METHOD_CONSTRUCTOR,

--- a/fendermint/vm/actor_interface/src/eam.rs
+++ b/fendermint/vm/actor_interface/src/eam.rs
@@ -1,7 +1,18 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use fvm_shared::METHOD_CONSTRUCTOR;
+
 define_singleton!(EAM {
     id: 10,
     code_id: 15
 });
+
+/// Ethereum Address Manager actor methods available.
+#[repr(u64)]
+pub enum Method {
+    Constructor = METHOD_CONSTRUCTOR,
+    Create = 2,
+    Create2 = 3,
+    CreateExternal = 4,
+}

--- a/fendermint/vm/actor_interface/src/eam.rs
+++ b/fendermint/vm/actor_interface/src/eam.rs
@@ -1,7 +1,11 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fvm_shared::METHOD_CONSTRUCTOR;
+use fvm_ipld_encoding::{
+    strict_bytes,
+    tuple::{Deserialize_tuple, Serialize_tuple},
+};
+use fvm_shared::{address::Address, ActorID, METHOD_CONSTRUCTOR};
 
 define_singleton!(EAM {
     id: 10,
@@ -15,4 +19,27 @@ pub enum Method {
     Create = 2,
     Create2 = 3,
     CreateExternal = 4,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EthAddress(#[serde(with = "strict_bytes")] pub [u8; 20]);
+
+impl EthAddress {
+    /// Returns an EVM-form ID address from actor ID.
+    ///
+    /// This is copied from the `evm` actor library.
+    pub fn from_id(id: u64) -> EthAddress {
+        let mut bytes = [0u8; 20];
+        bytes[0] = 0xff;
+        bytes[12..].copy_from_slice(&id.to_be_bytes());
+        EthAddress(bytes)
+    }
+}
+
+/// Helper to read return value from contract creation.
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct CreateReturn {
+    pub actor_id: ActorID,
+    pub robust_address: Option<Address>,
+    pub eth_address: EthAddress,
 }

--- a/fendermint/vm/interpreter/src/fvm/state/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/exec.rs
@@ -76,6 +76,7 @@ where
     }
 
     pub fn execute_message(&mut self, msg: Message, kind: ApplyKind) -> anyhow::Result<ApplyRet> {
+        // TODO: We could preserve the message length by changing the input type.
         let raw_length = fvm_ipld_encoding::to_vec(&msg).map(|bz| bz.len())?;
         self.executor.execute_message(msg, kind, raw_length)
     }


### PR DESCRIPTION
Closes #79 

Adds a `fevm create` command to deploy an EVM contract from source. It prints out the different addresses assigned by the EAM actor to help call the contract.

# Usage

```console
 ./target/release/fendermint rpc fevm --help
Subcommands related to FEVM

Usage: fendermint rpc fevm [OPTIONS] --secret-key <SECRET_KEY> --sequence <SEQUENCE> <COMMAND>

Commands:
  create
          Deploy an EVM contract from source; print the results as JSON
  help
          Print this message or the help of the given subcommand(s)

Options:
  -v, --value <VALUE>
          Amount of tokens to send, in atto
          
          [default: 0]

  -s, --secret-key <SECRET_KEY>
          Path to the secret key of the sender to sign the transaction

  -n, --sequence <SEQUENCE>
          Sender account nonce

      --gas-limit <GAS_LIMIT>
          Maximum amount of gas that can be charged
          
          [default: 10000000000]

      --gas-fee-cap <GAS_FEE_CAP>
          Price of gas.
          
          Any discrepancy between this and the base fee is paid for by the validator who puts the transaction into the block.
          
          [default: 0]

      --gas-premium <GAS_PREMIUM>
          Gas premium
          
          [default: 0]

  -b, --broadcast-mode <BROADCAST_MODE>
          Whether to wait for the results from Tendermint or not
          
          [default: commit]

          Possible values:
          - async:  Do no wait for the results
          - sync:   Wait for the result of `check_tx`
          - commit: Wait for the result of `deliver_tx`

  -h, --help
          Print help (see a summary with '-h')
```

```console
❯ ./target/release/fendermint rpc fevm create --help
Deploy an EVM contract from source; print the results as JSON

Usage: fendermint rpc fevm --secret-key <SECRET_KEY> --sequence <SEQUENCE> create [OPTIONS] --contract <CONTRACT>

Options:
  -c, --contract <CONTRACT>
          Path to a compiled Solidity contract, expected to be in hexadecimal format
  -c, --constructor-args <CONSTRUCTOR_ARGS>
          ABI encoded constructor arguments passed to the EVM, expected to be in hexadecimal format [default: ]
  -h, --help
          Print help
```

# Takeaways

Tendermint seems to re-encode the `data` field as Base64, but `tendermint-rs` does not undo this, so we encounter the following:
1. The EAM actor returns `CreateReturn` which is encoded into the `ApplyRet::return_data` as an IPLD byte vector
2. We put those bytes into `DeliverTx::data`
3. `tower_abci` turns that into protobuf
4. Tendermint reads the protobuf
5. Tendermint turns the data into JSON; while doing so (I guess) turns `data` into a `Base64` string, and _takes the bytes of that_.
6. `tendermint_rpc` parses the JSON as `DeliverTx`, but _does not parse as Base64_ of the `data` field
7. The CLI looks at the bytes in `data` and fails to parse as `CreateReturn`. 