### PR TITLE
FM-86: Invoke contract CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,6 +1497,7 @@ dependencies = [
  "anyhow",
  "cid",
  "fendermint_vm_genesis",
+ "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
@@ -1721,6 +1722,44 @@ dependencies = [
  "byteorder",
  "ff",
  "thiserror",
+]
+
+[[package]]
+name = "frc42_dispatch"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4dc594c941eba1d5a9474f595c6d0f9d752fa333b672755bbe7c23d30f64282"
+dependencies = [
+ "frc42_hasher",
+ "frc42_macros",
+ "fvm_ipld_encoding",
+ "fvm_sdk",
+ "fvm_shared",
+ "thiserror",
+]
+
+[[package]]
+name = "frc42_hasher"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6caf7fa3028536d11b1ff94a63bd1d60926ff7366b25b2a94d07bd23190f459"
+dependencies = [
+ "fvm_sdk",
+ "fvm_shared",
+ "thiserror",
+]
+
+[[package]]
+name = "frc42_macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c57201a8c3c26b41c4234a0f68b123ec2c33c958d31d09a3a780c345256e7928"
+dependencies = [
+ "blake2b_simd",
+ "frc42_hasher",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1957,6 +1996,21 @@ dependencies = [
  "once_cell",
  "serde",
  "sha2 0.10.6",
+ "thiserror",
+]
+
+[[package]]
+name = "fvm_sdk"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fef17308967cceb1d22f05003d60adb0d5b9ba53e34ace4ae04701eb7e6af02"
+dependencies = [
+ "cid",
+ "fvm_ipld_encoding",
+ "fvm_shared",
+ "lazy_static",
+ "log",
+ "num-traits",
  "thiserror",
 ]
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -528,7 +528,7 @@ $ target/release/fendermint rpc query actor-state --address $(target/release/fen
 Great, Alice's nonce was correctly increased as well.
 
 
-## Deploy FEVM Contract
+## Create FEVM Contract
 
 When we want to deploy a smart contract to the FVM, the currently supported way is by deploying EVM contracts to FEVM.
 
@@ -558,4 +558,17 @@ $ cargo run -p fendermint_app --release -- \
   "eth_address": "91ddff6e0c588a8f50ad433f2a258104302f703b",
   "robust_address": "f2rd3cu2jokusukudmbwotuu4rvoebm45qnze7e6q"
 }
+```
+
+## Invoke FEVM Contract
+
+Now taht we have a contract deployed, we can call it. The following is just based on on the example in [fvm-bench](https://github.com/filecoin-project/fvm-bench). Normally we'd try to
+
+```console
+$ cargo run -p fendermint_app --release -- \
+              rpc fevm --secret-key test-network/keys/alice.sk --sequence 1 \
+                invoke --contract f410fsho763qmlcfi6ufnim7sujmbaqyc64b3pzpa7bq  \
+                       --method f8b2cb4f --method-args 000000000000000000000000ff00000000000000000000000000000000000064 \
+          | jq .return_data
+"0000000000000000000000000000000000000000000000000000000000002710"
 ```

--- a/fendermint/app/src/options/rpc.rs
+++ b/fendermint/app/src/options/rpc.rs
@@ -99,6 +99,18 @@ pub enum RpcFevmCommands {
         #[arg(long, short, value_parser = parse_raw_bytes, default_value = "")]
         constructor_args: RawBytes,
     },
+    /// Call an EVM contract; print the results as JSON with the return data rendered in hexadecimal format.
+    Invoke {
+        /// Either the actor ID based or the EAM delegated address of the contract to call.
+        #[arg(long, short)]
+        contract: Address,
+        /// ABI encoded method hash, expected to be in hexadecimal format.
+        #[arg(long, short, value_parser = parse_raw_bytes)]
+        method: RawBytes,
+        /// ABI encoded call arguments passed to the EVM, expected to be in hexadecimal format.
+        #[arg(long, short, value_parser = parse_raw_bytes, default_value = "")]
+        method_args: RawBytes,
+    },
 }
 
 /// Arguments common to transactions and transfers.

--- a/fendermint/vm/actor_interface/Cargo.toml
+++ b/fendermint/vm/actor_interface/Cargo.toml
@@ -19,5 +19,6 @@ fvm_shared = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_ipld_hamt = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
+frc42_dispatch = "3.0.1-alpha.1"
 
 fendermint_vm_genesis = { path = "../genesis" }

--- a/fendermint/vm/actor_interface/src/evm.rs
+++ b/fendermint/vm/actor_interface/src/evm.rs
@@ -1,0 +1,17 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use fvm_shared::METHOD_CONSTRUCTOR;
+
+define_code!(EVM { code_id: 14 });
+
+#[repr(u64)]
+pub enum Method {
+    Constructor = METHOD_CONSTRUCTOR,
+    Resurrect = 2,
+    GetBytecode = 3,
+    GetBytecodeHash = 4,
+    GetStorageAt = 5,
+    InvokeContractDelegate = 6,
+    InvokeContract = frc42_dispatch::method_hash!("InvokeEVM"),
+}

--- a/fendermint/vm/actor_interface/src/lib.rs
+++ b/fendermint/vm/actor_interface/src/lib.rs
@@ -36,6 +36,7 @@ macro_rules! define_singleton {
 pub mod account;
 pub mod cron;
 pub mod eam;
+pub mod evm;
 pub mod init;
 pub mod multisig;
 pub mod system;


### PR DESCRIPTION
Closes #86 

Adds a `fevm invoke` method to pass raw ABI values to contracts.

# Usage

```console
❯ cargo run -p fendermint_app --release -- rpc fevm invoke --help
    Finished release [optimized] target(s) in 0.84s
     Running `target/release/fendermint rpc fevm invoke --help`
Call an EVM contract; print the results as JSON with the return data rendered in hexadecimal format

Usage: fendermint rpc fevm --secret-key <SECRET_KEY> --sequence <SEQUENCE> invoke [OPTIONS] --contract <CONTRACT> --method <METHOD>

Options:
  -c, --contract <CONTRACT>        Either the actor ID based or the EAM delegated address of the contract to call
  -m, --method <METHOD>            ABI encoded method hash, expected to be in hexadecimal format
  -m, --method-args <METHOD_ARGS>  ABI encoded call arguments passed to the EVM, expected to be in hexadecimal format [default: ]
  -h, --help                       Print help

```