### PR TITLE
FM-77: RPC client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1476,7 +1476,6 @@ dependencies = [
  "fvm_ipld_encoding",
  "fvm_shared",
  "libsecp256k1",
- "serde",
  "tendermint",
  "tendermint-rpc",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,6 +1473,7 @@ dependencies = [
  "fendermint_vm_message",
  "fvm_ipld_encoding",
  "fvm_shared",
+ "libsecp256k1",
  "tendermint",
  "tendermint-rpc",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,6 +1416,7 @@ dependencies = [
  "dirs",
  "fendermint_abci",
  "fendermint_rocksdb",
+ "fendermint_rpc",
  "fendermint_storage",
  "fendermint_vm_actor_interface",
  "fendermint_vm_genesis",
@@ -1459,6 +1460,22 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror",
+]
+
+[[package]]
+name = "fendermint_rpc"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cid",
+ "fendermint_vm_actor_interface",
+ "fendermint_vm_message",
+ "fvm_ipld_encoding",
+ "fvm_shared",
+ "tendermint",
+ "tendermint-rpc",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,6 +1468,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.21.0",
+ "bytes",
  "cid",
  "fendermint_vm_actor_interface",
  "fendermint_vm_message",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1476,6 +1476,7 @@ dependencies = [
  "fvm_ipld_encoding",
  "fvm_shared",
  "libsecp256k1",
+ "serde",
  "tendermint",
  "tendermint-rpc",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,6 +1475,7 @@ dependencies = [
  "fendermint_vm_message",
  "fvm_ipld_encoding",
  "fvm_shared",
+ "hex",
  "libsecp256k1",
  "tendermint",
  "tendermint-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["fendermint/abci", "fendermint/app", "fendermint/rocksdb", "fendermint/storage", "fendermint/testing", "fendermint/vm/*"]
+members = ["fendermint/abci", "fendermint/app", "fendermint/rocksdb", "fendermint/rpc", "fendermint/storage", "fendermint/testing", "fendermint/vm/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -31,6 +31,7 @@ tracing-subscriber = { workspace = true }
 fendermint_abci = { path = "../abci" }
 fendermint_storage = { path = "../storage" }
 fendermint_rocksdb = { path = "../rocksdb" }
+fendermint_rpc = { path = "../rpc" }
 fendermint_vm_actor_interface = { path = "../vm/actor_interface" }
 fendermint_vm_interpreter = { path = "../vm/interpreter", features = ["bundle"] }
 fendermint_vm_message = { path = "../vm/message", features = ["secp256k1"] }

--- a/fendermint/app/src/cmd/rpc.rs
+++ b/fendermint/app/src/cmd/rpc.rs
@@ -4,17 +4,16 @@
 use std::path::PathBuf;
 
 use anyhow::Context;
-use base64::Engine;
-use bytes::Bytes;
+use fendermint_rpc::response::{decode_fevm_create, decode_fevm_invoke};
 use fendermint_vm_message::chain::ChainMessage;
-use fvm_ipld_encoding::{BytesDe, RawBytes};
+use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::MethodNum;
 use serde::Serialize;
 use serde_json::json;
+use tendermint::abci::response::DeliverTx;
 use tendermint::block::Height;
-use tendermint_rpc::endpoint::broadcast;
 use tendermint_rpc::v0_37::Client;
 
 use fendermint_rpc::message::{GasParams, MessageFactory};
@@ -27,7 +26,6 @@ use crate::{
     cmd::to_b64,
     options::rpc::{RpcArgs, RpcCommands, RpcQueryCommands},
 };
-use anyhow::anyhow;
 
 use super::key::read_secret_key;
 
@@ -125,12 +123,8 @@ async fn fevm_create(
         mf.fevm_create(contract_bytes, constructor_args.clone(), v, g)
     })?;
 
-    broadcast_and_print(client, data, args.broadcast_mode, |data| {
-        Some(
-            parse_data(data)
-                .and_then(parse_create_return)
-                .map(create_return_to_json),
-        )
+    broadcast_and_print(client, data, args.broadcast_mode, |dtx| {
+        Some(decode_fevm_create(dtx).map(create_return_to_json))
     })
     .await
 }
@@ -147,16 +141,8 @@ async fn fevm_invoke(
         mf.fevm_invoke(*contract, method.clone(), method_args.clone(), v, g)
     })?;
 
-    broadcast_and_print(client, data, args.broadcast_mode, |data| {
-        Some(
-            parse_data(data)
-                .and_then(|data| {
-                    fvm_ipld_encoding::from_slice::<BytesDe>(&data)
-                        .map(|bz| bz.0)
-                        .map_err(|e| anyhow!("failed to deserialize bytes: {e}"))
-                })
-                .map(|bz| serde_json::Value::String(hex::encode(bz))),
-        )
+    broadcast_and_print(client, data, args.broadcast_mode, |dtx| {
+        Some(decode_fevm_invoke(dtx).map(|bz| serde_json::Value::String(hex::encode(bz))))
     })
     .await
 }
@@ -169,40 +155,40 @@ async fn broadcast_and_print<F>(
     parse_data: F,
 ) -> anyhow::Result<()>
 where
-    F: FnOnce(&Bytes) -> Option<anyhow::Result<serde_json::Value>>,
+    F: FnOnce(&DeliverTx) -> Option<anyhow::Result<serde_json::Value>>,
 {
     match mode {
-        BroadcastMode::Async => print_json(
+        BroadcastMode::Async => print_response(
             client.inner().broadcast_tx_async(data).await?,
             |_| None,
             parse_data,
         ),
-        BroadcastMode::Sync => print_json(
+        BroadcastMode::Sync => print_response(
             client.inner().broadcast_tx_sync(data).await?,
             |_| None,
             parse_data,
         ),
-        BroadcastMode::Commit => print_json(
+        BroadcastMode::Commit => print_response(
             client.inner().broadcast_tx_commit(data).await?,
-            |r: &broadcast::tx_commit::Response| Some(&r.deliver_tx.data),
+            |r| Some(&r.deliver_tx),
             parse_data,
         ),
     }
 }
 
 /// Display some value as JSON.
-fn print_json<T, G, F>(value: T, get_data: G, parse_data: F) -> anyhow::Result<()>
+fn print_response<T, G, F>(value: T, get_tx: G, parse_data: F) -> anyhow::Result<()>
 where
     T: Serialize,
-    G: FnOnce(&T) -> Option<&Bytes>,
-    F: FnOnce(&Bytes) -> Option<anyhow::Result<serde_json::Value>>,
+    G: FnOnce(&T) -> Option<&DeliverTx>,
+    F: FnOnce(&DeliverTx) -> Option<anyhow::Result<serde_json::Value>>,
 {
     let response = serde_json::to_value(&value)?;
     let output = {
-        let return_data = match get_data(&value) {
+        let return_data = match get_tx(&value) {
             None => None,
-            Some(bz) if bz.is_empty() => None,
-            Some(bz) => match parse_data(bz) {
+            Some(dtx) if dtx.data.is_empty() => None,
+            Some(dtx) => match parse_data(dtx) {
                 None => None,
                 Some(Ok(return_json)) => Some(return_json),
                 Some(Err(e)) => Some(json!({
@@ -235,22 +221,6 @@ where
     let message = f(&mut mf, args.value.clone(), gas_params)?;
     let data = MessageFactory::serialize(&message)?;
     Ok(data)
-}
-
-/// Parse what Tendermint returns in the `data` field of [`DeliverTx`] into bytes.
-/// It looks like somewhere along the way it replaces them with the bytes of a Base64 encoded string.
-fn parse_data(data: &Bytes) -> anyhow::Result<Vec<u8>> {
-    let b64 = String::from_utf8(data.to_vec()).context("error parsing data as base64 string")?;
-    let data = base64::engine::general_purpose::STANDARD
-        .decode(&b64)
-        .context("error parsing base64 to bytes")?;
-    Ok(data)
-}
-
-/// Parse what Tendermint returns in the `data` field of `DeliverTx` as `CreateReturn`.
-fn parse_create_return(data: Vec<u8>) -> anyhow::Result<CreateReturn> {
-    fvm_ipld_encoding::from_slice::<eam::CreateReturn>(&data)
-        .map_err(|e| anyhow!("error parsing as CreateReturn: {e}"))
 }
 
 fn create_return_to_json(ret: CreateReturn) -> serde_json::Value {

--- a/fendermint/app/src/cmd/rpc.rs
+++ b/fendermint/app/src/cmd/rpc.rs
@@ -45,7 +45,7 @@ cmd! {
       RpcCommands::Transfer { args, to } => {
         transfer(client, args, to).await
       },
-      RpcCommands::Transact { args, to, method_number, params } => {
+      RpcCommands::Transaction { args, to, method_number, params } => {
         transact(client, args, to, method_number, params.clone()).await
       },
       RpcCommands::Fevm { args, command } => match command {

--- a/fendermint/app/src/cmd/rpc.rs
+++ b/fendermint/app/src/cmd/rpc.rs
@@ -6,21 +6,23 @@ use std::path::PathBuf;
 use anyhow::Context;
 use base64::Engine;
 use bytes::Bytes;
-use fendermint_vm_actor_interface::eam::{self, CreateReturn};
-use fendermint_vm_actor_interface::evm;
-use fendermint_vm_interpreter::fvm::{FvmMessage, FvmQuery};
-use fendermint_vm_message::chain::ChainMessage;
-use fendermint_vm_message::query::ActorState;
-use fendermint_vm_message::signed::SignedMessage;
+use fendermint_rpc::query::QueryClient;
 use fvm_ipld_encoding::{BytesDe, BytesSer, RawBytes};
 use fvm_shared::address::Address;
-use fvm_shared::{ActorID, MethodNum, METHOD_SEND};
+use fvm_shared::{MethodNum, METHOD_SEND};
 use libsecp256k1::PublicKey;
 use serde::Serialize;
 use serde_json::json;
 use tendermint::block::Height;
 use tendermint_rpc::endpoint::broadcast;
-use tendermint_rpc::{endpoint::abci_query::AbciQuery, v0_37::Client, HttpClient, Scheme, Url};
+use tendermint_rpc::{v0_37::Client, HttpClient};
+
+use fendermint_rpc::client::{http_client, FendermintClient};
+use fendermint_vm_actor_interface::eam::{self, CreateReturn};
+use fendermint_vm_actor_interface::evm;
+use fendermint_vm_interpreter::fvm::FvmMessage;
+use fendermint_vm_message::chain::ChainMessage;
+use fendermint_vm_message::signed::SignedMessage;
 
 use crate::cmd;
 use crate::options::rpc::{BroadcastMode, RpcFevmCommands, TransArgs};
@@ -32,14 +34,13 @@ use anyhow::anyhow;
 
 use super::key::read_secret_key;
 
-// TODO: We should probably make a client interface for the operations we commonly do.
-
 cmd! {
   RpcArgs(self) {
     let client = http_client(self.url.clone(), self.proxy_url.clone())?;
     match &self.command {
       RpcCommands::Query { height, command } => {
         let height = Height::try_from(*height)?;
+        let client = FendermintClient::new(client);
         query(client, height, command).await
       },
       RpcCommands::Transfer { args, to } => {
@@ -60,38 +61,37 @@ cmd! {
   }
 }
 
+/// Run an ABCI query and print the results on STDOUT.
 async fn query(
-    client: HttpClient,
+    client: FendermintClient,
     height: Height,
     command: &RpcQueryCommands,
 ) -> anyhow::Result<()> {
     match command {
-        RpcQueryCommands::Ipld { cid } => {
-            abci_query_print(client, height, FvmQuery::Ipld(*cid), |res| {
-                Ok(to_b64(&res.value))
-            })
-            .await
-        }
+        RpcQueryCommands::Ipld { cid } => match client.ipld(cid).await? {
+            Some(data) => println!("{}", to_b64(&data)),
+            None => eprintln!("CID not found"),
+        },
         RpcQueryCommands::ActorState { address } => {
-            abci_query_print(client, height, FvmQuery::ActorState(*address), |res| {
-                let state: ActorState =
-                    fvm_ipld_encoding::from_slice(&res.value).context("failed to decode state")?;
-                let id: ActorID =
-                    fvm_ipld_encoding::from_slice(&res.key).context("failed to decode ID")?;
+            match client.actor_state(address, height).await? {
+                Some((id, state)) => {
+                    let out = json! ({
+                      "id": id,
+                      "state": state,
+                    });
 
-                let out = json! ({
-                  "id": id,
-                  "state": state,
-                });
+                    // Print JSON as a single line - we can display it nicer with `jq` if needed.
+                    let json = serde_json::to_string(&out)?;
 
-                // Print JSON as a single line - we can display it nicer with `jq` if needed.
-                let json = serde_json::to_string(&out)?;
-
-                Ok(json)
-            })
-            .await
+                    println!("{}", json)
+                }
+                None => {
+                    eprintln!("actor not found")
+                }
+            }
         }
-    }
+    };
+    Ok(())
 }
 
 /// Execute token transfer through RPC and print the response to STDOUT as JSON.
@@ -251,74 +251,6 @@ fn transaction_payload(
     let chain = ChainMessage::Signed(Box::new(signed));
     let data = fvm_ipld_encoding::to_vec(&chain)?;
     Ok(data)
-}
-
-/// Fetch the query result from the server and print something to STDOUT.
-async fn abci_query_print<F>(
-    client: HttpClient,
-    height: Height,
-    query: FvmQuery,
-    render: F,
-) -> anyhow::Result<()>
-where
-    F: FnOnce(AbciQuery) -> anyhow::Result<String>,
-{
-    let data = fvm_ipld_encoding::to_vec(&query).context("failed to encode query")?;
-    let res: AbciQuery = client.abci_query(None, data, Some(height), false).await?;
-    if res.code.is_ok() {
-        let output = render(res)?;
-        println!("{}", output);
-    } else {
-        eprintln!("query returned non-zero exit code: {}", res.code.value());
-    }
-    Ok(())
-}
-
-// Retrieve the proxy URL with precedence:
-// 1. If supplied, that's the proxy URL used.
-// 2. If not supplied, but environment variable HTTP_PROXY or HTTPS_PROXY are
-//    supplied, then use the appropriate variable for the URL in question.
-//
-// Copied from `tendermint_rpc`.
-fn get_http_proxy_url(url_scheme: Scheme, proxy_url: Option<Url>) -> anyhow::Result<Option<Url>> {
-    match proxy_url {
-        Some(u) => Ok(Some(u)),
-        None => match url_scheme {
-            Scheme::Http => std::env::var("HTTP_PROXY").ok(),
-            Scheme::Https => std::env::var("HTTPS_PROXY")
-                .ok()
-                .or_else(|| std::env::var("HTTP_PROXY").ok()),
-            _ => {
-                if std::env::var("HTTP_PROXY").is_ok() || std::env::var("HTTPS_PROXY").is_ok() {
-                    tracing::warn!(
-                        "Ignoring HTTP proxy environment variables for non-HTTP client connection"
-                    );
-                }
-                None
-            }
-        }
-        .map(|u| u.parse::<Url>().map_err(|e| anyhow!(e)))
-        .transpose(),
-    }
-}
-
-fn http_client(url: Url, proxy_url: Option<Url>) -> anyhow::Result<HttpClient> {
-    let proxy_url = get_http_proxy_url(url.scheme(), proxy_url)?;
-    let client = match proxy_url {
-        Some(proxy_url) => {
-            tracing::debug!(
-                "Using HTTP client with proxy {} to submit request to {}",
-                proxy_url,
-                url
-            );
-            HttpClient::new_with_proxy(url, proxy_url)?
-        }
-        None => {
-            tracing::debug!("Using HTTP client to submit request to: {}", url);
-            HttpClient::new(url)?
-        }
-    };
-    Ok(client)
 }
 
 /// Parse what Tendermint returns in the `data` field of [`DeliverTx`] into bytes.

--- a/fendermint/app/src/cmd/rpc.rs
+++ b/fendermint/app/src/cmd/rpc.rs
@@ -1,23 +1,24 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::future::Future;
 use std::path::PathBuf;
+use std::pin::Pin;
 
 use anyhow::Context;
 use async_trait::async_trait;
 use fendermint_rpc::client::BoundFendermintClient;
-use fendermint_rpc::response::{decode_fevm_create, decode_fevm_invoke};
-use fendermint_rpc::tx::{BoundClient, TxAsync, TxClient, TxCommit, TxSync};
+use fendermint_rpc::tx::{
+    AsyncResponse, BoundClient, CommitResponse, SyncResponse, TxAsync, TxClient, TxCommit, TxSync,
+};
 use fendermint_vm_message::chain::ChainMessage;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::MethodNum;
-use serde::Serialize;
 use serde_json::json;
 use tendermint::abci::response::DeliverTx;
 use tendermint::block::Height;
-use tendermint_rpc::v0_37::Client;
 use tendermint_rpc::HttpClient;
 
 use fendermint_rpc::message::{GasParams, MessageFactory};
@@ -36,16 +37,16 @@ use super::key::read_secret_key;
 cmd! {
   RpcArgs(self) {
     let client = FendermintClient::new_http(self.url.clone(), self.proxy_url.clone())?;
-    match &self.command {
+    match self.command.clone() {
       RpcCommands::Query { height, command } => {
-        let height = Height::try_from(*height)?;
+        let height = Height::try_from(height)?;
         query(client, height, command).await
       },
       RpcCommands::Transfer { args, to } => {
         transfer(client, args, to).await
       },
       RpcCommands::Transact { args, to, method_number, params } => {
-        transact(client, args, to, *method_number, params.clone()).await
+        transact(client, args, to, method_number, params.clone()).await
       },
       RpcCommands::Fevm { args, command } => match command {
         RpcFevmCommands::Create { contract, constructor_args } => {
@@ -63,15 +64,15 @@ cmd! {
 async fn query(
     client: FendermintClient,
     height: Height,
-    command: &RpcQueryCommands,
+    command: RpcQueryCommands,
 ) -> anyhow::Result<()> {
     match command {
-        RpcQueryCommands::Ipld { cid } => match client.ipld(cid).await? {
+        RpcQueryCommands::Ipld { cid } => match client.ipld(&cid).await? {
             Some(data) => println!("{}", to_b64(&data)),
             None => eprintln!("CID not found"),
         },
         RpcQueryCommands::ActorState { address } => {
-            match client.actor_state(address, height).await? {
+            match client.actor_state(&address, height).await? {
                 Some((id, state)) => {
                     let out = json! ({
                       "id": id,
@@ -92,143 +93,135 @@ async fn query(
     Ok(())
 }
 
+/// Create a client, make a call to Tendermint with a closure, then maybe extract some JSON
+/// depending on the return value, finally print the result in JSON.
+async fn broadcast_and_print<F, T, G>(
+    client: FendermintClient,
+    args: TransArgs,
+    f: F,
+    g: G,
+) -> anyhow::Result<()>
+where
+    F: FnOnce(
+        TransClient,
+        TokenAmount,
+        GasParams,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<BroadcastResponse<T>>> + Send>>,
+    G: FnOnce(T) -> serde_json::Value,
+    T: Sync + Send,
+{
+    let client = TransClient::new(client, &args)?;
+    let gas_params = gas_params(&args);
+    let res = f(client, args.value, gas_params).await?;
+    let json = match res {
+        BroadcastResponse::Async(res) => json!({"response": res.response}),
+        BroadcastResponse::Sync(res) => json!({"response": res.response}),
+        BroadcastResponse::Commit(res) => {
+            let return_data = res.return_data.map(g).unwrap_or(serde_json::Value::Null);
+            json!({"response": res.response, "return_data": return_data})
+        }
+    };
+    print_json(json)
+}
+
 /// Execute token transfer through RPC and print the response to STDOUT as JSON.
-async fn transfer(client: FendermintClient, args: &TransArgs, to: &Address) -> anyhow::Result<()> {
-    let data = message_payload(args, |mf, v, g| mf.transfer(*to, v, g))?;
-    broadcast_and_print(client, data, args.broadcast_mode, |_| None).await
+async fn transfer(client: FendermintClient, args: TransArgs, to: Address) -> anyhow::Result<()> {
+    broadcast_and_print(
+        client,
+        args,
+        |mut client, value, gas_params| {
+            Box::pin(async move { client.transfer(to, value, gas_params).await })
+        },
+        |_| serde_json::Value::Null,
+    )
+    .await
 }
 
 /// Execute a transaction through RPC and print the response to STDOUT as JSON.
+///
+/// If there was any data returned it's rendered in hexadecimal format.
 async fn transact(
     client: FendermintClient,
-    args: &TransArgs,
-    to: &Address,
+    args: TransArgs,
+    to: Address,
     method_num: MethodNum,
     params: RawBytes,
 ) -> anyhow::Result<()> {
-    let data = message_payload(args, |mf, v, g| {
-        mf.transaction(*to, method_num, params, v, g)
-    })?;
-    broadcast_and_print(client, data, args.broadcast_mode, |_| None).await
+    broadcast_and_print(
+        client,
+        args,
+        |mut client, value, gas_params| {
+            Box::pin(async move {
+                client
+                    .transaction(to, method_num, params, value, gas_params)
+                    .await
+            })
+        },
+        |data| serde_json::Value::String(hex::encode(&data)),
+    )
+    .await
 }
 
 /// Deploy an EVM contract through RPC and print the response to STDOUT as JSON.
+///
+/// The returned EVM contract addresses are included as a JSON object.
 async fn fevm_create(
     client: FendermintClient,
-    args: &TransArgs,
-    contract: &PathBuf,
-    constructor_args: &RawBytes,
+    args: TransArgs,
+    contract: PathBuf,
+    constructor_args: RawBytes,
 ) -> anyhow::Result<()> {
     let contract_hex = std::fs::read_to_string(contract).context("failed to read contract")?;
     let contract_bytes = hex::decode(contract_hex).context("failed to parse contract from hex")?;
     let contract_bytes = RawBytes::from(contract_bytes);
 
-    let data = message_payload(args, |mf, v, g| {
-        mf.fevm_create(contract_bytes, constructor_args.clone(), v, g)
-    })?;
-
-    broadcast_and_print(client, data, args.broadcast_mode, |dtx| {
-        Some(decode_fevm_create(dtx).map(create_return_to_json))
-    })
+    broadcast_and_print(
+        client,
+        args,
+        |mut client, value, gas_params| {
+            Box::pin(async move {
+                client
+                    .fevm_create(contract_bytes, constructor_args, value, gas_params)
+                    .await
+            })
+        },
+        create_return_to_json,
+    )
     .await
 }
 
 /// Deploy an EVM contract through RPC and print the response to STDOUT as JSON.
 async fn fevm_invoke(
     client: FendermintClient,
-    args: &TransArgs,
-    contract: &Address,
-    method: &RawBytes,
-    method_args: &RawBytes,
+    args: TransArgs,
+    contract: Address,
+    method: RawBytes,
+    method_args: RawBytes,
 ) -> anyhow::Result<()> {
-    let data = message_payload(args, |mf, v, g| {
-        mf.fevm_invoke(*contract, method.clone(), method_args.clone(), v, g)
-    })?;
-
-    broadcast_and_print(client, data, args.broadcast_mode, |dtx| {
-        Some(decode_fevm_invoke(dtx).map(|bz| serde_json::Value::String(hex::encode(bz))))
-    })
+    broadcast_and_print(
+        client,
+        args,
+        |mut client, value, gas_params| {
+            Box::pin(async move {
+                client
+                    .fevm_invoke(contract, method, method_args, value, gas_params)
+                    .await
+            })
+        },
+        |data| serde_json::Value::String(hex::encode(&data)),
+    )
     .await
 }
 
-/// Broadcast a transaction to tendermint and print the results to STDOUT as JSON.
-async fn broadcast_and_print<F>(
-    client: FendermintClient,
-    data: Vec<u8>,
-    mode: BroadcastMode,
-    parse_data: F,
-) -> anyhow::Result<()>
-where
-    F: FnOnce(&DeliverTx) -> Option<anyhow::Result<serde_json::Value>>,
-{
-    match mode {
-        BroadcastMode::Async => print_response(
-            client.inner().broadcast_tx_async(data).await?,
-            |_| None,
-            parse_data,
-        ),
-        BroadcastMode::Sync => print_response(
-            client.inner().broadcast_tx_sync(data).await?,
-            |_| None,
-            parse_data,
-        ),
-        BroadcastMode::Commit => print_response(
-            client.inner().broadcast_tx_commit(data).await?,
-            |r| Some(&r.deliver_tx),
-            parse_data,
-        ),
-    }
-}
-
-/// Display some value as JSON.
-fn print_response<T, G, F>(value: T, get_tx: G, parse_data: F) -> anyhow::Result<()>
-where
-    T: Serialize,
-    G: FnOnce(&T) -> Option<&DeliverTx>,
-    F: FnOnce(&DeliverTx) -> Option<anyhow::Result<serde_json::Value>>,
-{
-    let response = serde_json::to_value(&value)?;
-    let output = {
-        let return_data = match get_tx(&value) {
-            None => None,
-            Some(dtx) if dtx.data.is_empty() => None,
-            Some(dtx) => match parse_data(dtx) {
-                None => None,
-                Some(Ok(return_json)) => Some(return_json),
-                Some(Err(e)) => Some(json!({
-                    "error": format!("error parsing return data: {e}")
-                })),
-            },
-        };
-        match return_data {
-            Some(return_data) => json!({"response": response, "return_data": return_data}),
-            None => json!({ "response": response }),
-        }
-    };
-    // Using "jsonline"; use `jq` to format.
-    let json = serde_json::to_string(&output)?;
+/// Print JSON as "jsonline"; use `jq` to format.
+fn print_json(value: serde_json::Value) -> anyhow::Result<()> {
+    let json = serde_json::to_string(&value)?;
     println!("{}", json);
     Ok(())
 }
 
-fn message_payload<F>(args: &TransArgs, f: F) -> anyhow::Result<Vec<u8>>
-where
-    F: FnOnce(&mut MessageFactory, TokenAmount, GasParams) -> anyhow::Result<ChainMessage>,
-{
-    let sk = read_secret_key(&args.secret_key)?;
-    let mut mf = MessageFactory::new(sk, args.sequence)?;
-    let gas_params = GasParams {
-        gas_fee_cap: args.gas_fee_cap.clone(),
-        gas_limit: args.gas_limit,
-        gas_premium: args.gas_premium.clone(),
-    };
-    let message = f(&mut mf, args.value.clone(), gas_params)?;
-    let data = MessageFactory::serialize(&message)?;
-    Ok(data)
-}
-
+/// Print all the various addresses we can use to refer to an EVM contract.
 fn create_return_to_json(ret: CreateReturn) -> serde_json::Value {
-    // Print all the various addresses we can use to refer to an EVM contract.
     // The only reference I can point to about how to use them are the integration tests:
     // https://github.com/filecoin-project/ref-fvm/pull/1507
     // IIRC to call the contract we need to use the `actor_address` or the `delegated_address` in `to`.
@@ -242,8 +235,14 @@ fn create_return_to_json(ret: CreateReturn) -> serde_json::Value {
     })
 }
 
+pub enum BroadcastResponse<T> {
+    Async(AsyncResponse<T>),
+    Sync(SyncResponse<T>),
+    Commit(CommitResponse<T>),
+}
+
 impl fendermint_rpc::tx::BroadcastMode for BroadcastMode {
-    type Response<T> = serde_json::Value;
+    type Response<T> = BroadcastResponse<T>;
 }
 
 struct TransClient {
@@ -272,27 +271,32 @@ impl BoundClient for TransClient {
 
 #[async_trait]
 impl TxClient<BroadcastMode> for TransClient {
-    async fn perform<F, T>(&self, msg: ChainMessage, f: F) -> anyhow::Result<serde_json::Value>
+    async fn perform<F, T>(&self, msg: ChainMessage, f: F) -> anyhow::Result<BroadcastResponse<T>>
     where
         F: FnOnce(&DeliverTx) -> anyhow::Result<T> + Sync + Send,
-        T: Serialize,
+        T: Sync + Send,
     {
         match self.broadcast_mode {
             BroadcastMode::Async => {
                 let res = TxClient::<TxAsync>::perform(&self.inner, msg, f).await?;
-                let json = serde_json::to_value(res)?;
-                Ok(json)
+                Ok(BroadcastResponse::Async(res))
             }
             BroadcastMode::Sync => {
                 let res = TxClient::<TxSync>::perform(&self.inner, msg, f).await?;
-                let json = serde_json::to_value(res)?;
-                Ok(json)
+                Ok(BroadcastResponse::Sync(res))
             }
             BroadcastMode::Commit => {
                 let res = TxClient::<TxCommit>::perform(&self.inner, msg, f).await?;
-                let json = serde_json::to_value(res)?;
-                Ok(json)
+                Ok(BroadcastResponse::Commit(res))
             }
         }
+    }
+}
+
+fn gas_params(args: &TransArgs) -> GasParams {
+    GasParams {
+        gas_limit: args.gas_limit,
+        gas_fee_cap: args.gas_fee_cap.clone(),
+        gas_premium: args.gas_premium.clone(),
     }
 }

--- a/fendermint/app/src/cmd/rpc.rs
+++ b/fendermint/app/src/cmd/rpc.rs
@@ -31,7 +31,7 @@ use super::key::read_secret_key;
 
 cmd! {
   RpcArgs(self) {
-    let client = FendermintClient::new(self.url.clone(), self.proxy_url.clone())?;
+    let client = FendermintClient::new_http(self.url.clone(), self.proxy_url.clone())?;
     match &self.command {
       RpcCommands::Query { height, command } => {
         let height = Height::try_from(*height)?;

--- a/fendermint/app/src/options/rpc.rs
+++ b/fendermint/app/src/options/rpc.rs
@@ -50,7 +50,7 @@ pub enum RpcCommands {
         args: TransArgs,
     },
     /// Send a message (a.k.a. transaction) to an actor.
-    Transact {
+    Transaction {
         /// Address of the actor to send the message to.
         #[arg(long, short, value_parser = parse_address)]
         to: Address,

--- a/fendermint/app/src/options/rpc.rs
+++ b/fendermint/app/src/options/rpc.rs
@@ -31,7 +31,7 @@ pub struct RpcArgs {
     pub command: RpcCommands,
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand, Debug, Clone)]
 pub enum RpcCommands {
     /// Send an ABCI query.
     Query {
@@ -72,7 +72,7 @@ pub enum RpcCommands {
     },
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand, Debug, Clone)]
 pub enum RpcQueryCommands {
     /// Get raw IPLD content; print it as base64 string.
     Ipld {
@@ -88,7 +88,7 @@ pub enum RpcQueryCommands {
     },
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand, Debug, Clone)]
 pub enum RpcFevmCommands {
     /// Deploy an EVM contract from source; print the results as JSON.
     Create {
@@ -114,7 +114,7 @@ pub enum RpcFevmCommands {
 }
 
 /// Arguments common to transactions and transfers.
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 pub struct TransArgs {
     /// Amount of tokens to send, in atto.
     #[arg(long, short, value_parser = parse_token_amount, default_value = "0")]

--- a/fendermint/rpc/Cargo.toml
+++ b/fendermint/rpc/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "fendermint_rpc"
+description = "Utilities working with the tendermint_rpc library to provide an API facade for Fendermint"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tendermint = { workspace = true }
+tendermint-rpc = { workspace = true }
+tracing = { workspace = true }
+
+cid = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+fvm_shared = { workspace = true }
+
+fendermint_vm_actor_interface = { path = "../vm/actor_interface" }
+fendermint_vm_message = { path = "../vm/message", features = ["secp256k1"] }

--- a/fendermint/rpc/Cargo.toml
+++ b/fendermint/rpc/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
+hex = { workspace = true }
 libsecp256k1 = { workspace = true }
 tendermint = { workspace = true }
 tendermint-rpc = { workspace = true }

--- a/fendermint/rpc/Cargo.toml
+++ b/fendermint/rpc/Cargo.toml
@@ -11,7 +11,6 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
-hex = { workspace = true }
 libsecp256k1 = { workspace = true }
 tendermint = { workspace = true }
 tendermint-rpc = { workspace = true }

--- a/fendermint/rpc/Cargo.toml
+++ b/fendermint/rpc/Cargo.toml
@@ -9,6 +9,8 @@ license.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+base64 = { workspace = true }
+bytes = { workspace = true }
 libsecp256k1 = { workspace = true }
 tendermint = { workspace = true }
 tendermint-rpc = { workspace = true }

--- a/fendermint/rpc/Cargo.toml
+++ b/fendermint/rpc/Cargo.toml
@@ -12,7 +12,6 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
 libsecp256k1 = { workspace = true }
-serde = { workspace = true }
 tendermint = { workspace = true }
 tendermint-rpc = { workspace = true }
 tracing = { workspace = true }

--- a/fendermint/rpc/Cargo.toml
+++ b/fendermint/rpc/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
 libsecp256k1 = { workspace = true }
+serde = { workspace = true }
 tendermint = { workspace = true }
 tendermint-rpc = { workspace = true }
 tracing = { workspace = true }

--- a/fendermint/rpc/Cargo.toml
+++ b/fendermint/rpc/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+libsecp256k1 = { workspace = true }
 tendermint = { workspace = true }
 tendermint-rpc = { workspace = true }
 tracing = { workspace = true }

--- a/fendermint/rpc/src/client.rs
+++ b/fendermint/rpc/src/client.rs
@@ -40,7 +40,7 @@ fn get_http_proxy_url(url_scheme: Scheme, proxy_url: Option<Url>) -> anyhow::Res
 }
 
 /// Create a Tendermint HTTP client.
-pub fn http_client(url: Url, proxy_url: Option<Url>) -> anyhow::Result<HttpClient> {
+fn http_client(url: Url, proxy_url: Option<Url>) -> anyhow::Result<HttpClient> {
     let proxy_url = get_http_proxy_url(url.scheme(), proxy_url)?;
     let client = match proxy_url {
         Some(proxy_url) => {
@@ -65,8 +65,13 @@ pub struct FendermintClient {
 }
 
 impl FendermintClient {
-    pub fn new(inner: HttpClient) -> Self {
-        Self { inner }
+    pub fn new(url: Url, proxy_url: Option<Url>) -> anyhow::Result<Self> {
+        let inner = http_client(url, proxy_url)?;
+        Ok(Self { inner })
+    }
+
+    pub fn inner(&self) -> &HttpClient {
+        &self.inner
     }
 }
 

--- a/fendermint/rpc/src/client.rs
+++ b/fendermint/rpc/src/client.rs
@@ -192,7 +192,7 @@ where
         let return_data = if response.deliver_tx.code.is_err() {
             None
         } else {
-            let return_data = f(&response.deliver_tx).context("error decoding deliver tx")?;
+            let return_data = f(&response.deliver_tx).context("error decoding deliver_tx")?;
             Some(return_data)
         };
         let response = CommitResponse {

--- a/fendermint/rpc/src/client.rs
+++ b/fendermint/rpc/src/client.rs
@@ -1,0 +1,83 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use anyhow::{anyhow, Context};
+use async_trait::async_trait;
+use tendermint::block::Height;
+use tendermint_rpc::v0_37::Client;
+use tendermint_rpc::{endpoint::abci_query::AbciQuery, HttpClient, Scheme, Url};
+
+use fendermint_vm_message::query::FvmQuery;
+
+use crate::query::QueryClient;
+
+// Retrieve the proxy URL with precedence:
+// 1. If supplied, that's the proxy URL used.
+// 2. If not supplied, but environment variable HTTP_PROXY or HTTPS_PROXY are
+//    supplied, then use the appropriate variable for the URL in question.
+//
+// Copied from `tendermint_rpc`.
+fn get_http_proxy_url(url_scheme: Scheme, proxy_url: Option<Url>) -> anyhow::Result<Option<Url>> {
+    match proxy_url {
+        Some(u) => Ok(Some(u)),
+        None => match url_scheme {
+            Scheme::Http => std::env::var("HTTP_PROXY").ok(),
+            Scheme::Https => std::env::var("HTTPS_PROXY")
+                .ok()
+                .or_else(|| std::env::var("HTTP_PROXY").ok()),
+            _ => {
+                if std::env::var("HTTP_PROXY").is_ok() || std::env::var("HTTPS_PROXY").is_ok() {
+                    tracing::warn!(
+                        "Ignoring HTTP proxy environment variables for non-HTTP client connection"
+                    );
+                }
+                None
+            }
+        }
+        .map(|u| u.parse::<Url>().map_err(|e| anyhow!(e)))
+        .transpose(),
+    }
+}
+
+/// Create a Tendermint HTTP client.
+pub fn http_client(url: Url, proxy_url: Option<Url>) -> anyhow::Result<HttpClient> {
+    let proxy_url = get_http_proxy_url(url.scheme(), proxy_url)?;
+    let client = match proxy_url {
+        Some(proxy_url) => {
+            tracing::debug!(
+                "Using HTTP client with proxy {} to submit request to {}",
+                proxy_url,
+                url
+            );
+            HttpClient::new_with_proxy(url, proxy_url)?
+        }
+        None => {
+            tracing::debug!("Using HTTP client to submit request to: {}", url);
+            HttpClient::new(url)?
+        }
+    };
+    Ok(client)
+}
+
+/// Unauthenticated Fendermint client.
+pub struct FendermintClient {
+    inner: HttpClient,
+}
+
+impl FendermintClient {
+    pub fn new(inner: HttpClient) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl QueryClient for FendermintClient {
+    /// Run an ABCI query.
+    async fn perform(&self, query: FvmQuery, height: Option<Height>) -> anyhow::Result<AbciQuery> {
+        let data = fvm_ipld_encoding::to_vec(&query).context("failed to encode query")?;
+
+        let res = self.inner.abci_query(None, data, height, false).await?;
+
+        Ok(res)
+    }
+}

--- a/fendermint/rpc/src/lib.rs
+++ b/fendermint/rpc/src/lib.rs
@@ -4,3 +4,4 @@
 pub mod client;
 pub mod message;
 pub mod query;
+pub mod response;

--- a/fendermint/rpc/src/lib.rs
+++ b/fendermint/rpc/src/lib.rs
@@ -5,3 +5,4 @@ pub mod client;
 pub mod message;
 pub mod query;
 pub mod response;
+pub mod tx;

--- a/fendermint/rpc/src/lib.rs
+++ b/fendermint/rpc/src/lib.rs
@@ -1,0 +1,5 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+pub mod client;
+pub mod query;

--- a/fendermint/rpc/src/lib.rs
+++ b/fendermint/rpc/src/lib.rs
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 pub mod client;
+pub mod message;
 pub mod query;

--- a/fendermint/rpc/src/message.rs
+++ b/fendermint/rpc/src/message.rs
@@ -1,0 +1,118 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use fendermint_vm_actor_interface::{eam, evm};
+use fendermint_vm_message::{chain::ChainMessage, signed::SignedMessage};
+use fvm_ipld_encoding::{BytesSer, RawBytes};
+use fvm_shared::{address::Address, econ::TokenAmount, MethodNum, METHOD_SEND};
+use libsecp256k1::{PublicKey, SecretKey};
+
+/// Factory methods for signed transaction payload construction.
+pub struct MessageFactory {
+    sk: SecretKey,
+    addr: Address,
+    sequence: u64,
+}
+
+impl MessageFactory {
+    pub fn new(sk: SecretKey, sequence: u64) -> anyhow::Result<Self> {
+        let pk = PublicKey::from_secret_key(&sk);
+        let addr = Address::new_secp256k1(&pk.serialize())?;
+        Ok(Self { sk, addr, sequence })
+    }
+
+    /// Serialize a [`ChainMessage`] for inclusion in a Tendermint transaction.
+    pub fn serialize(message: &ChainMessage) -> anyhow::Result<Vec<u8>> {
+        Ok(fvm_ipld_encoding::to_vec(message)?)
+    }
+
+    /// Transfer tokens to another account.
+    pub fn transfer(
+        &mut self,
+        to: Address,
+        value: TokenAmount,
+        gas_params: GasParams,
+    ) -> anyhow::Result<ChainMessage> {
+        self.transaction(to, METHOD_SEND, Default::default(), value, gas_params)
+    }
+
+    /// Send a message to an actor.
+    pub fn transaction(
+        &mut self,
+        to: Address,
+        method_num: MethodNum,
+        params: RawBytes,
+        value: TokenAmount,
+        gas_params: GasParams,
+    ) -> anyhow::Result<ChainMessage> {
+        let message = fvm_shared::message::Message {
+            version: Default::default(), // TODO: What does this do?
+            from: self.addr,
+            to,
+            sequence: self.sequence,
+            value,
+            method_num,
+            params,
+            gas_limit: gas_params.gas_limit,
+            gas_fee_cap: gas_params.gas_fee_cap,
+            gas_premium: gas_params.gas_premium,
+        };
+        self.sequence += 1;
+        let signed = SignedMessage::new_secp256k1(message, &self.sk)?;
+        let chain = ChainMessage::Signed(Box::new(signed));
+        Ok(chain)
+    }
+
+    /// Deploy a FEVM contract.
+    pub fn fevm_create(
+        &mut self,
+        contract: RawBytes,
+        constructor_args: RawBytes,
+        value: TokenAmount,
+        gas_params: GasParams,
+    ) -> anyhow::Result<ChainMessage> {
+        let initcode = [contract.to_vec(), constructor_args.to_vec()].concat();
+        let initcode = RawBytes::serialize(BytesSer(&initcode))?;
+        let message = self.transaction(
+            eam::EAM_ACTOR_ADDR,
+            eam::Method::CreateExternal as u64,
+            initcode,
+            value,
+            gas_params,
+        )?;
+        Ok(message)
+    }
+
+    /// Invoke a method on a FEVM contract.
+    pub fn fevm_invoke(
+        &mut self,
+        contract: Address,
+        method: RawBytes,
+        method_args: RawBytes,
+        value: TokenAmount,
+        gas_params: GasParams,
+    ) -> anyhow::Result<ChainMessage> {
+        let calldata = [method.to_vec(), method_args.to_vec()].concat();
+        let calldata = RawBytes::serialize(BytesSer(&calldata))?;
+        let message = self.transaction(
+            contract,
+            evm::Method::InvokeContract as u64,
+            calldata,
+            value,
+            gas_params,
+        )?;
+        Ok(message)
+    }
+}
+
+pub struct GasParams {
+    /// Maximum amount of gas that can be charged.
+    pub gas_limit: u64,
+    /// Price of gas.
+    ///
+    /// Any discrepancy between this and the base fee is paid for
+    /// by the validator who puts the transaction into the block.
+    pub gas_fee_cap: TokenAmount,
+    /// Gas premium.
+    pub gas_premium: TokenAmount,
+}

--- a/fendermint/rpc/src/query.rs
+++ b/fendermint/rpc/src/query.rs
@@ -1,0 +1,68 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use anyhow::{anyhow, Context};
+use async_trait::async_trait;
+use tendermint::block::Height;
+use tendermint_rpc::endpoint::abci_query::AbciQuery;
+
+use cid::Cid;
+use fvm_shared::ActorID;
+use fvm_shared::{address::Address, error::ExitCode};
+
+use fendermint_vm_message::query::{ActorState, FvmQuery};
+
+/// Fendermint client for submitting queries.
+#[async_trait]
+pub trait QueryClient {
+    /// Query the contents of a CID from the IPLD store.
+    async fn ipld(&self, cid: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
+        let res = self.perform(FvmQuery::Ipld(*cid), None).await?;
+        extract(res, |res| Ok(res.value))
+    }
+
+    /// Query the the state of an actor.
+    async fn actor_state(
+        &self,
+        address: &Address,
+        height: Height,
+    ) -> anyhow::Result<Option<(ActorID, ActorState)>> {
+        let res = self
+            .perform(FvmQuery::ActorState(*address), Some(height))
+            .await?;
+
+        extract(res, |res| {
+            let state: ActorState =
+                fvm_ipld_encoding::from_slice(&res.value).context("failed to decode state")?;
+
+            let id: ActorID =
+                fvm_ipld_encoding::from_slice(&res.key).context("failed to decode ID")?;
+
+            Ok((id, state))
+        })
+    }
+
+    /// Run an ABCI query.
+    async fn perform(&self, query: FvmQuery, height: Option<Height>) -> anyhow::Result<AbciQuery>;
+}
+
+/// Extract some value from the query result, unless it's not found or other error.
+fn extract<T, F>(res: AbciQuery, f: F) -> anyhow::Result<Option<T>>
+where
+    F: FnOnce(AbciQuery) -> anyhow::Result<T>,
+{
+    if is_not_found(&res) {
+        Ok(None)
+    } else if res.code.is_err() {
+        Err(anyhow!(
+            "query returned non-zero exit code: {}",
+            res.code.value()
+        ))
+    } else {
+        f(res).map(Some)
+    }
+}
+
+fn is_not_found(res: &AbciQuery) -> bool {
+    res.code.value() == ExitCode::USR_NOT_FOUND.value()
+}

--- a/fendermint/rpc/src/response.rs
+++ b/fendermint/rpc/src/response.rs
@@ -32,8 +32,12 @@ pub fn decode_fevm_create(deliver_tx: &DeliverTx) -> anyhow::Result<CreateReturn
 
 /// Parse what Tendermint returns in the `data` field of [`DeliverTx`] as raw ABI return value.
 pub fn decode_fevm_invoke(deliver_tx: &DeliverTx) -> anyhow::Result<Vec<u8>> {
+    if deliver_tx.data.is_empty() {
+        // I'm not sure when it happens that the code indicates success but the data is empty, but it does.
+        return Ok(Vec::new());
+    }
     let data = decode_data(&deliver_tx.data)?;
     fvm_ipld_encoding::from_slice::<BytesDe>(&data)
         .map(|bz| bz.0)
-        .map_err(|e| anyhow!("failed to deserialize bytes: {e}"))
+        .map_err(|e| anyhow!("failed to deserialize bytes returned by FEVM: {e}"))
 }

--- a/fendermint/rpc/src/response.rs
+++ b/fendermint/rpc/src/response.rs
@@ -1,0 +1,34 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+use anyhow::{anyhow, Context};
+use base64::Engine;
+use bytes::Bytes;
+use fendermint_vm_actor_interface::eam::{self, CreateReturn};
+use fvm_ipld_encoding::BytesDe;
+use tendermint::abci::response::DeliverTx;
+
+/// Parse what Tendermint returns in the `data` field of [`DeliverTx`] into bytes.
+/// Somewhere along the way it replaces them with the bytes of a Base64 encoded string,
+/// and `tendermint_rpc` does not undo that wrapping.
+pub fn decode_data(data: &Bytes) -> anyhow::Result<Vec<u8>> {
+    let b64 = String::from_utf8(data.to_vec()).context("error parsing data as base64 string")?;
+    let data = base64::engine::general_purpose::STANDARD
+        .decode(&b64)
+        .context("error parsing base64 to bytes")?;
+    Ok(data)
+}
+
+/// Parse what Tendermint returns in the `data` field of [`DeliverTx`] as [`CreateReturn`].
+pub fn decode_fevm_create(deliver_tx: &DeliverTx) -> anyhow::Result<CreateReturn> {
+    let data = decode_data(&deliver_tx.data)?;
+    fvm_ipld_encoding::from_slice::<eam::CreateReturn>(&data)
+        .map_err(|e| anyhow!("error parsing as CreateReturn: {e}"))
+}
+
+/// Parse what Tendermint returns in the `data` field of [`DeliverTx`] as raw ABI return value.
+pub fn decode_fevm_invoke(deliver_tx: &DeliverTx) -> anyhow::Result<Vec<u8>> {
+    let data = decode_data(&deliver_tx.data)?;
+    fvm_ipld_encoding::from_slice::<BytesDe>(&data)
+        .map(|bz| bz.0)
+        .map_err(|e| anyhow!("failed to deserialize bytes: {e}"))
+}

--- a/fendermint/rpc/src/response.rs
+++ b/fendermint/rpc/src/response.rs
@@ -18,6 +18,11 @@ pub fn decode_data(data: &Bytes) -> anyhow::Result<Vec<u8>> {
     Ok(data)
 }
 
+/// Parse what Tendermint returns in the `data` field of [`DeliverTx`] as raw bytes.
+pub fn decode_bytes(deliver_tx: &DeliverTx) -> anyhow::Result<Vec<u8>> {
+    decode_data(&deliver_tx.data)
+}
+
 /// Parse what Tendermint returns in the `data` field of [`DeliverTx`] as [`CreateReturn`].
 pub fn decode_fevm_create(deliver_tx: &DeliverTx) -> anyhow::Result<CreateReturn> {
     let data = decode_data(&deliver_tx.data)?;

--- a/fendermint/rpc/src/tx.rs
+++ b/fendermint/rpc/src/tx.rs
@@ -8,7 +8,6 @@ use fendermint_vm_actor_interface::eam::CreateReturn;
 use fendermint_vm_message::chain::ChainMessage;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::econ::TokenAmount;
-use serde::Serialize;
 use tendermint::abci::response::DeliverTx;
 
 use fvm_shared::address::Address;
@@ -95,28 +94,25 @@ pub trait TxClient<M: BroadcastMode>: BoundClient {
     async fn perform<F, T>(&self, msg: ChainMessage, f: F) -> anyhow::Result<M::Response<T>>
     where
         F: FnOnce(&DeliverTx) -> anyhow::Result<T> + Sync + Send,
-        T: Serialize;
+        T: Sync + Send;
 }
 
 pub struct TxAsync;
 pub struct TxSync;
 pub struct TxCommit;
 
-#[derive(Serialize, Debug)]
 pub struct AsyncResponse<T> {
     /// Response from Tendermint.
     pub response: tx_async::Response,
     pub return_data: PhantomData<T>,
 }
 
-#[derive(Serialize, Debug)]
 pub struct SyncResponse<T> {
     /// Response from Tendermint.
     pub response: tx_sync::Response,
     pub return_data: PhantomData<T>,
 }
 
-#[derive(Serialize, Debug)]
 pub struct CommitResponse<T> {
     /// Response from Tendermint.
     pub response: tx_commit::Response,

--- a/fendermint/rpc/src/tx.rs
+++ b/fendermint/rpc/src/tx.rs
@@ -1,0 +1,132 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::marker::PhantomData;
+
+use async_trait::async_trait;
+use fendermint_vm_actor_interface::eam::CreateReturn;
+use fendermint_vm_message::chain::ChainMessage;
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::econ::TokenAmount;
+use tendermint::abci::response::DeliverTx;
+
+use fvm_shared::address::Address;
+use fvm_shared::MethodNum;
+use tendermint_rpc::endpoint::broadcast::{tx_async, tx_commit, tx_sync};
+
+use crate::message::{GasParams, MessageFactory};
+use crate::response::{decode_bytes, decode_fevm_create, decode_fevm_invoke};
+
+/// Abstracting away what the return value is based on whether
+/// we broadcast transactions in sync, async or commit mode.
+pub trait BroadcastMode {
+    type Response<T>;
+}
+
+pub trait BoundClient {
+    fn message_factory_mut(&mut self) -> &mut MessageFactory;
+}
+
+/// Fendermint client for submitting transactions.
+#[async_trait]
+pub trait TxClient<M: BroadcastMode>: BoundClient {
+    /// Transfer tokens to another account.
+    async fn transfer(
+        &mut self,
+        to: Address,
+        value: TokenAmount,
+        gas_params: GasParams,
+    ) -> anyhow::Result<M::Response<()>> {
+        let mf = self.message_factory_mut();
+        let msg = mf.transfer(to, value, gas_params)?;
+        let fut = self.perform(msg, |_| Ok(()));
+        let res = fut.await?;
+        Ok(res)
+    }
+
+    /// Send a message to an actor.
+    async fn transaction(
+        &mut self,
+        to: Address,
+        method_num: MethodNum,
+        params: RawBytes,
+        value: TokenAmount,
+        gas_params: GasParams,
+    ) -> anyhow::Result<M::Response<Vec<u8>>> {
+        let mf = self.message_factory_mut();
+        let msg = mf.transaction(to, method_num, params, value, gas_params)?;
+        let fut = self.perform(msg, decode_bytes);
+        let res = fut.await?;
+        Ok(res)
+    }
+
+    /// Deploy a FEVM contract.
+    async fn fevm_create(
+        &mut self,
+        contract: RawBytes,
+        constructor_args: RawBytes,
+        value: TokenAmount,
+        gas_params: GasParams,
+    ) -> anyhow::Result<M::Response<CreateReturn>> {
+        let mf = self.message_factory_mut();
+        let msg = mf.fevm_create(contract, constructor_args, value, gas_params)?;
+        let fut = self.perform(msg, decode_fevm_create);
+        let res = fut.await?;
+        Ok(res)
+    }
+
+    /// Invoke a method on a FEVM contract.
+    async fn fevm_invoke(
+        &mut self,
+        contract: Address,
+        method: RawBytes,
+        method_args: RawBytes,
+        value: TokenAmount,
+        gas_params: GasParams,
+    ) -> anyhow::Result<M::Response<Vec<u8>>> {
+        let mf = self.message_factory_mut();
+        let msg = mf.fevm_invoke(contract, method, method_args, value, gas_params)?;
+        let fut = self.perform(msg, decode_fevm_invoke);
+        let res = fut.await?;
+        Ok(res)
+    }
+
+    async fn perform<F, T>(&self, msg: ChainMessage, f: F) -> anyhow::Result<M::Response<T>>
+    where
+        F: FnOnce(&DeliverTx) -> anyhow::Result<T> + Sync + Send;
+}
+
+pub struct TxAsync;
+pub struct TxSync;
+pub struct TxCommit;
+
+pub struct AsyncResponse<T> {
+    /// Response from Tendermint.
+    pub response: tx_async::Response,
+    pub return_data: PhantomData<T>,
+}
+
+pub struct SyncResponse<T> {
+    /// Response from Tendermint.
+    pub response: tx_sync::Response,
+    pub return_data: PhantomData<T>,
+}
+
+pub struct CommitResponse<T> {
+    /// Response from Tendermint.
+    pub response: tx_commit::Response,
+    /// Parsed return data, if the response indicates success.
+    pub return_data: Option<T>,
+}
+
+impl BroadcastMode for TxAsync {
+    type Response<T> = AsyncResponse<T>;
+}
+
+impl BroadcastMode for TxSync {
+    type Response<T> = SyncResponse<T>;
+}
+
+impl BroadcastMode for TxCommit {
+    type Response<T> = CommitResponse<T>;
+}

--- a/fendermint/rpc/src/tx.rs
+++ b/fendermint/rpc/src/tx.rs
@@ -8,6 +8,7 @@ use fendermint_vm_actor_interface::eam::CreateReturn;
 use fendermint_vm_message::chain::ChainMessage;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::econ::TokenAmount;
+use serde::Serialize;
 use tendermint::abci::response::DeliverTx;
 
 use fvm_shared::address::Address;
@@ -93,25 +94,29 @@ pub trait TxClient<M: BroadcastMode>: BoundClient {
 
     async fn perform<F, T>(&self, msg: ChainMessage, f: F) -> anyhow::Result<M::Response<T>>
     where
-        F: FnOnce(&DeliverTx) -> anyhow::Result<T> + Sync + Send;
+        F: FnOnce(&DeliverTx) -> anyhow::Result<T> + Sync + Send,
+        T: Serialize;
 }
 
 pub struct TxAsync;
 pub struct TxSync;
 pub struct TxCommit;
 
+#[derive(Serialize, Debug)]
 pub struct AsyncResponse<T> {
     /// Response from Tendermint.
     pub response: tx_async::Response,
     pub return_data: PhantomData<T>,
 }
 
+#[derive(Serialize, Debug)]
 pub struct SyncResponse<T> {
     /// Response from Tendermint.
     pub response: tx_sync::Response,
     pub return_data: PhantomData<T>,
 }
 
+#[derive(Serialize, Debug)]
 pub struct CommitResponse<T> {
     /// Response from Tendermint.
     pub response: tx_commit::Response,


### PR DESCRIPTION
Closes #77 

Created a `fendermint_rpc` crate and moved over a lot of the functionality from `fendermint_app::cmd::rpc`. 

It contains the following:
* `QueryClient` trait to perform `ipld` and `actor_state` queries, parsing into the right return values
* `TxClient` trait to perform `transfer`, `transaction`, `fevm_create` and `fevm_invoke` commands parsing into the expected return types depending on what `BroadcastMode` is chosen
* `FendermintClient` which doesn't have keys, so it can only do queries
* `BoundFendermintClient` which is bound to keys and maintains sequences via `MessageFactory`
* `MessageFactory` to just construct payload without making any calls

Allowing `TxClient` to support multiple modes made it a bit complicated because the command line makes the broadcast mode a runtime value, while `TxClient` is static.


TODO: 
- [x] Check if the examples in `running.md` still work.