### PR TITLE
CLI/RPC: Change the JSON output to be pretty printed.

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -430,7 +430,7 @@ which we saw in the `genesis.json` file earlier.
 
 ```shell
 cargo run -p fendermint_app --release -- \
-  rpc query actor-state --address f1jqqlnr5b56rnmc34ywp7p7i2lg37ty23s2bmg4y | jq
+  rpc query actor-state --address f1jqqlnr5b56rnmc34ywp7p7i2lg37ty23s2bmg4y
 ```
 
 The state is printed to STDOUT as JSON:
@@ -474,13 +474,13 @@ For example we can send 1000 tokens from Alice to Bob:
 ```shell
 BOB_ADDR=$(cargo run -p fendermint_app --release -- key address --public-key test-network/keys/bob.pk)
 cargo run -p fendermint_app --release -- \
-  rpc transfer --secret-key test-network/keys/alice.sk --to $BOB_ADDR --sequence 0 --value 1000 | jq
+  rpc transfer --secret-key test-network/keys/alice.sk --to $BOB_ADDR --sequence 0 --value 1000
 ```
 
 The `transfer` command waits for the commit results of the transaction:
 
 ```console
-$ cargo run -p fendermint_app --release -- rpc transfer --secret-key test-network/keys/alice.sk --to $BOB_ADDR --sequence 0 --value 1000 | jq
+$ cargo run -p fendermint_app --release -- rpc transfer --secret-key test-network/keys/alice.sk --to $BOB_ADDR --sequence 0 --value 1000
     Finished dev [unoptimized + debuginfo] target(s) in 0.40s
      Running `target/debug/fendermint rpc transfer --secret-key test-network/keys/alice.sk --to f1kgtzp5nuob3gdccagivcgns7e25be2c2rqozilq --sequence 0 --value 1000`
 {
@@ -545,7 +545,7 @@ Say we want to deploy the `SimpleCoin` contract from that directory.
 CONTRACT=../builtin-actors/actors/evm/tests/contracts/SimpleCoin.bin
 cargo run -p fendermint_app --release -- \
   rpc fevm --secret-key test-network/keys/alice.sk --sequence 0 \
-    create --contract $CONTRACT | jq
+    create --contract $CONTRACT
 ```
 
 The output shows what addresses have been assigned to the created contract,

--- a/fendermint/app/src/cmd/rpc.rs
+++ b/fendermint/app/src/cmd/rpc.rs
@@ -17,6 +17,7 @@ use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::MethodNum;
+use serde::Serialize;
 use serde_json::json;
 use tendermint::abci::response::DeliverTx;
 use tendermint::block::Height;
@@ -79,11 +80,7 @@ async fn query(
                       "id": id,
                       "state": state,
                     });
-
-                    // Print JSON as a single line - we can display it nicer with `jq` if needed.
-                    let json = serde_json::to_string(&out)?;
-
-                    println!("{}", json)
+                    print_json(&out)?;
                 }
                 None => {
                     eprintln!("actor not found")
@@ -122,7 +119,7 @@ where
             json!({"response": res.response, "return_data": return_data})
         }
     };
-    print_json(json)
+    print_json(&json)
 }
 
 /// Execute token transfer through RPC and print the response to STDOUT as JSON.
@@ -215,9 +212,12 @@ async fn fevm_invoke(
     .await
 }
 
-/// Print JSON as "jsonline"; use `jq` to format.
-fn print_json(value: serde_json::Value) -> anyhow::Result<()> {
-    let json = serde_json::to_string(&value)?;
+/// Print out pretty-printed JSON.
+///
+/// People can use `jq` to turn it into compact form if they want to save the results to a `.jsonline`
+/// file, but the default of having human readable output seems more useful.
+fn print_json<T: Serialize>(value: &T) -> anyhow::Result<()> {
+    let json = serde_json::to_string_pretty(&value)?;
     println!("{}", json);
     Ok(())
 }


### PR DESCRIPTION
Human readable output seems more useful at this point for demoing the solution. 

It maybe better UX for anyone trying to use the CLI to automation some workflow to have to install `jq` rather than for anyone not having `jq` to get unreadable JSON one liners.