### PR TITLE
FM-95: Automated smoke test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
           profile: minimal
           target: wasm32-unknown-unknown
           toolchain: ${{ matrix.rust }}
-          components: rustfmt,clippy
+          components: rustfmt,clippy,make
 
       # Protobuf compiler required by libp2p-core
       - name: Install Protoc

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,9 @@ jobs:
           - rust: nightly
             make:
               name: Lint
+          - rust: nightly
+            make:
+              name: End-to-end
 
     env:
       RUST_BACKTRACE: full

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,8 @@ jobs:
             task: lint
           - name: Test
             task: test
+          - name: End-to-End
+            task: e2e
         exclude:
           - rust: nightly
             make:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,10 @@ jobs:
           profile: minimal
           target: wasm32-unknown-unknown
           toolchain: ${{ matrix.rust }}
-          components: rustfmt,clippy,make
+          components: rustfmt,clippy
+
+      - name: Install Cargo Make
+        uses: davidB/rust-cargo-make@v1
 
       # Protobuf compiler required by libp2p-core
       - name: Install Protoc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5626,6 +5626,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "smoke-test"
+version = "0.1.0"
+
+[[package]]
 name = "socket2"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["fendermint/abci", "fendermint/app", "fendermint/rocksdb", "fendermint/rpc", "fendermint/storage", "fendermint/testing", "fendermint/vm/*"]
+members = ["fendermint/abci", "fendermint/app", "fendermint/rocksdb", "fendermint/rpc", "fendermint/storage", "fendermint/testing", "fendermint/testing/*-test", "fendermint/vm/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,17 +25,20 @@ RUN --mount=type=cache,target=$RUSTUP_HOME,from=rust,source=$RUSTUP_HOME \
 # Runner
 FROM debian:bullseye-slim
 
-WORKDIR /app
-ENV HOME=/app
+ENV FM_HOME_DIR=/fendermint
+ENV HOME=$FM_HOME_DIR
+WORKDIR $FM_HOME_DIR
 
-ENV FM_ABCI__HOST=0.0.0.0
-
-ARG BUILTIN_ACTORS_BUNDLE
-COPY ${BUILTIN_ACTORS_BUNDLE} $HOME/.fendermint/bundle.car
-COPY --from=builder /app/fendermint/app/config $HOME/.fendermint/config
-COPY --from=builder /app/output/bin/fendermint /usr/local/bin/fendermint
+EXPOSE 26658
 
 ENTRYPOINT ["fendermint"]
 CMD ["run"]
 
-EXPOSE 26658
+STOPSIGNAL SIGTERM
+
+ENV FM_ABCI__HOST=0.0.0.0
+
+ARG BUILTIN_ACTORS_BUNDLE
+COPY ${BUILTIN_ACTORS_BUNDLE} $FM_HOME_DIR/bundle.car
+COPY --from=builder /app/fendermint/app/config $FM_HOME_DIR/config
+COPY --from=builder /app/output/bin/fendermint /usr/local/bin/fendermint

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,9 @@
 # Builder
 FROM rust:1.68 as builder
 
-RUN <<EOF
-    set -e
-
-    apt-get update
-    apt-get install -y build-essential clang cmake
-
-    rm -rf /var/lib/apt/lists/*
-EOF
+RUN apt-get update && \
+  apt-get install -y build-essential clang cmake && \
+  rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,10 @@ build:
 
 # Using --release for testing because wasm can otherwise be slow.
 test: $(BUILTIN_ACTORS_BUNDLE)
-	FM_BUILTIN_ACTORS_BUNDLE=$(BUILTIN_ACTORS_BUNDLE) cargo test --release
+	FM_BUILTIN_ACTORS_BUNDLE=$(BUILTIN_ACTORS_BUNDLE) cargo test --release --exclude smoke-test
+
+e2e: docker-build
+	cd fendermint/testing/smoke-test && cargo make
 
 clean:
 	cargo clean

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ check-clippy:
 
 docker-build: $(BUILTIN_ACTORS_BUNDLE) $(FENDERMINT_CODE)
 	cp $(BUILTIN_ACTORS_BUNDLE) ./bundle.car
+	DOCKER_BUILDKIT=1 \
 	docker build \
 		--build-arg BUILTIN_ACTORS_BUNDLE=bundle.car \
 		-t fendermint:latest .

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build:
 
 # Using --release for testing because wasm can otherwise be slow.
 test: $(BUILTIN_ACTORS_BUNDLE)
-	FM_BUILTIN_ACTORS_BUNDLE=$(BUILTIN_ACTORS_BUNDLE) cargo test --release --exclude smoke-test
+	FM_BUILTIN_ACTORS_BUNDLE=$(BUILTIN_ACTORS_BUNDLE) cargo test --release --workspace --exclude smoke-test
 
 e2e: docker-build
 	cd fendermint/testing/smoke-test && cargo make

--- a/docs/running.md
+++ b/docs/running.md
@@ -1,9 +1,10 @@
 # Running Fendermint
 
 The commands are all executed by the `fendermint` binary, which is produced from the `fendermint_app` crate,
-so we have two ways to run the program:
-* `./target/debug/fendermint <args>` (or wherever it's been installed)
-* `cargo run -p fendermint_app -- <args>`
+so we have many ways to run the program:
+* `fendermint <args>`, after running `cargo install fendermint_app`
+* `./target/debug/fendermint <args>`, after running `cargo build --release`
+* `cargo run -p fendermint_app --release -- <args>`
 
 ## Genesis
 
@@ -26,7 +27,7 @@ mkdir test-network
 First, create a new `genesis.json` file devoid of accounts and validators. The `--base-fee` here is completely arbitrary.
 
 ```shell
-cargo run -p fendermint_app -- genesis --genesis-file test-network/genesis.json new --network-name test --base-fee 1000
+cargo run -p fendermint_app -- genesis --genesis-file test-network/genesis.json new --network-name test --base-fee 1000 --timestamp 1680101412
 ```
 
 We can check what the contents look like:

--- a/fendermint/app/src/options/mod.rs
+++ b/fendermint/app/src/options/mod.rs
@@ -30,7 +30,12 @@ pub enum LogLevel {
 #[command(version)]
 pub struct Options {
     /// Set a custom directory for data and configuration files.
-    #[arg(short = 'd', long, default_value = "~/.fendermint")]
+    #[arg(
+        short = 'd',
+        long,
+        default_value = "~/.fendermint",
+        env = "FM_HOME_DIR"
+    )]
     pub home_dir: PathBuf,
 
     /// Optionally override the default configuration.

--- a/fendermint/testing/smoke-test/.gitignore
+++ b/fendermint/testing/smoke-test/.gitignore
@@ -1,0 +1,1 @@
+test-data

--- a/fendermint/testing/smoke-test/Cargo.toml
+++ b/fendermint/testing/smoke-test/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "smoke-test"
+description = "Provides some end-to-end integration testing between Fendermint and a full Tendermint node."
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/fendermint/testing/smoke-test/Makefile.toml
+++ b/fendermint/testing/smoke-test/Makefile.toml
@@ -1,26 +1,59 @@
 [env]
+NETWORK_NAME = "smoke"
 TM_CONTAINER_NAME = "smoke-tendermint"
+FM_CONTAINER_NAME = "smoke-fendermint"
 TM_DOCKER_IMAGE = "tendermint/tendermint:v0.37.0-rc2"
 FM_DOCKER_IMAGE = "fendermint:latest"
 TEST_DATA_DIR = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/fendermint/testing/smoke-test/test-data"
+TEST_SCRIPTS_DIR = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/fendermint/testing/smoke-test/scripts"
+ACTORS_BUNDLE = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/../builtin-actors/output/bundle.car"
 HOST_RPC_PORT = 26657
-CARGO_MAKE_WAIT_MILLISECONDS = 3500
+CARGO_MAKE_WAIT_MILLISECONDS = 5000
 
 # smoke-test infrastructure:
-# cargo install cargo-make     - install `cargo make`
-
-[tasks.probe]
-env = { "CONTAINER_NAME" = "${TM_CONTAINER_NAME}" }
-script = """
-UID=$(id -u)
-echo $UID $CONTAINER_NAME
-echo ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}
-"""
-
+# cargo install cargo-make
+# cargo make
 
 [tasks.default]
 clear = true
-dependencies = ["tendermint-init", "wait", "tendermint-stop", "tendermint-rm"]
+run_task = { name = [
+  "setup",
+  "test",
+], fork = true, cleanup_task = "teardown" }
+
+
+[tasks.setup]
+dependencies = [
+  "test-data-dir",
+  "network-create",
+  "tendermint-init",
+  "fendermint-init",
+  "fendermint-start",
+  "tendermint-start",
+  "wait",
+]
+
+[tasks.test]
+dependencies = ["simplecoin-example"]
+
+[tasks.teardown]
+# `dependencies` doesn't seem to work with `cleanup_task`.
+run_task = { name = [
+  "tendermint-stop",
+  "tendermint-rm",
+  "fendermint-stop",
+  "fendermint-rm",
+  "network-rm",
+  "test-data-dir-rm",
+] }
+
+
+[tasks.simplecoin-example]
+script = """
+cd ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}
+cargo run -p fendermint_rpc --release --example simplecoin -- \
+  --secret-key fendermint/testing/smoke-test/test-data/fendermint/keys/alice.sk
+"""
 
 
 [tasks.test-data-dir]
@@ -29,21 +62,23 @@ mkdir -p ${TEST_DATA_DIR}/fendermint;
 mkdir -p ${TEST_DATA_DIR}/tendermint;
 """
 
+[tasks.test-data-dir-rm]
+script = """
+rm -rf ${TEST_DATA_DIR}
+"""
+
 
 [tasks.tendermint-pull]
 command = "docker"
 args = ["pull", "${TM_DOCKER_IMAGE}"]
 
-
 [tasks.tendermint-init]
 extend = "tendermint-run"
 env = { "CMD" = "init", "FLAGS" = "-it" }
 
-
 [tasks.tendermint-start]
+extend = "tendermint-run"
 env = { "CMD" = "start", "FLAGS" = "-d" }
-dependencies = ["docker-up-stop-old", "docker-up-rm-old"]
-
 
 [tasks.tendermint-run]
 script = """
@@ -52,53 +87,75 @@ docker run \
   --rm \
   --name ${TM_CONTAINER_NAME} \
   --user $(id -u) \
+  --network ${NETWORK_NAME} \
   --publish 26657:${HOST_RPC_PORT} \
-  --volume ${TEST_DATA_DIR}/tendermint:/tendermint ${TM_DOCKER_IMAGE} \
+  --volume ${TEST_DATA_DIR}/tendermint:/tendermint \
+  --env TM_PROXY_APP=tcp://${FM_CONTAINER_NAME}:26658 \
+  --env TM_PEX=false \
+  ${TM_DOCKER_IMAGE} \
   ${CMD}
 """
-dependencies = ["tendermint-pull", "test-data-dir"]
+dependencies = ["tendermint-pull", "test-data-dir", "network-create"]
 
 
-[tasks.fendermint-new-genesis]
+[tasks.fendermint-init]
 extend = "fendermint-run"
-env = { "CMD" = "genesis --genesis-file /data/fendermint/genesis.json new --network-name smoke --base-fee 1000  --timestamp 1680101412", "FLAGS" = "-it" }
+env = { "ENTRY" = "/scripts/init.sh", "FLAGS" = "-it" }
 
+[tasks.fendermint-start]
+extend = "fendermint-run"
+env = { "ENTRY" = "fendermint", "CMD" = "run", "FLAGS" = "-d" }
 
 [tasks.fendermint-run]
 script = """
 docker run \
   ${FLAGS} \
   --rm \
-  --name ${TM_CONTAINER_NAME} \
+  --name ${FM_CONTAINER_NAME} \
+  --init \
   --user $(id -u) \
-  --volume ${TEST_DATA_DIR}:/data ${FM_DOCKER_IMAGE} \
+  --network ${NETWORK_NAME} \
+  --volume ${TEST_DATA_DIR}:/data \
+  --volume ${TEST_SCRIPTS_DIR}:/scripts \
+  --env FM_DATA_DIR=/data/fendermint/data \
+  --entrypoint ${ENTRY} \
+  ${FM_DOCKER_IMAGE} \
   ${CMD}
 """
+dependencies = ["test-data-dir", "network-create"]
 
+[tasks.network-create]
+command = "docker"
+args = ["network", "create", "${NETWORK_NAME}"]
+ignore_errors = true
 
-[tasks.test]
-args = ["run", "--all-features", "--", "-v"]
-
+[tasks.network-rm]
+command = "docker"
+args = ["network", "rm", "${NETWORK_NAME}"]
+ignore_errors = true
 
 [tasks.tendermint-rm]
 extend = "docker-rm"
 env = { "CONTAINER_NAME" = "${TM_CONTAINER_NAME}" }
 
-
 [tasks.tendermint-stop]
 extend = "docker-stop"
 env = { "CONTAINER_NAME" = "${TM_CONTAINER_NAME}" }
 
+[tasks.fendermint-rm]
+extend = "docker-rm"
+env = { "CONTAINER_NAME" = "${FM_CONTAINER_NAME}" }
+
+[tasks.fendermint-stop]
+extend = "docker-stop"
+env = { "CONTAINER_NAME" = "${FM_CONTAINER_NAME}" }
 
 [tasks.docker-stop]
 command = "docker"
 args = ["stop", "${CONTAINER_NAME}"]
 ignore_errors = true
-private = true
-
 
 [tasks.docker-rm]
 command = "docker"
 args = ["rm", "--force", "${CONTAINER_NAME}"]
 ignore_errors = true
-private = true

--- a/fendermint/testing/smoke-test/Makefile.toml
+++ b/fendermint/testing/smoke-test/Makefile.toml
@@ -74,7 +74,7 @@ args = ["pull", "${TM_DOCKER_IMAGE}"]
 
 [tasks.tendermint-init]
 extend = "tendermint-run"
-env = { "CMD" = "init", "FLAGS" = "-it" }
+env = { "CMD" = "init", "FLAGS" = "-a STDOUT -a STDERR" }
 
 [tasks.tendermint-start]
 extend = "tendermint-run"
@@ -100,7 +100,7 @@ dependencies = ["tendermint-pull", "test-data-dir", "network-create"]
 
 [tasks.fendermint-init]
 extend = "fendermint-run"
-env = { "ENTRY" = "/scripts/init.sh", "FLAGS" = "-it" }
+env = { "ENTRY" = "/scripts/init.sh", "FLAGS" = "-a STDOUT -a STDERR" }
 
 [tasks.fendermint-start]
 extend = "fendermint-run"

--- a/fendermint/testing/smoke-test/Makefile.toml
+++ b/fendermint/testing/smoke-test/Makefile.toml
@@ -1,0 +1,104 @@
+[env]
+TM_CONTAINER_NAME = "smoke-tendermint"
+TM_DOCKER_IMAGE = "tendermint/tendermint:v0.37.0-rc2"
+FM_DOCKER_IMAGE = "fendermint:latest"
+TEST_DATA_DIR = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/fendermint/testing/smoke-test/test-data"
+HOST_RPC_PORT = 26657
+CARGO_MAKE_WAIT_MILLISECONDS = 3500
+
+# smoke-test infrastructure:
+# cargo install cargo-make     - install `cargo make`
+
+[tasks.probe]
+env = { "CONTAINER_NAME" = "${TM_CONTAINER_NAME}" }
+script = """
+UID=$(id -u)
+echo $UID $CONTAINER_NAME
+echo ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}
+"""
+
+
+[tasks.default]
+clear = true
+dependencies = ["tendermint-init", "wait", "tendermint-stop", "tendermint-rm"]
+
+
+[tasks.test-data-dir]
+script = """
+mkdir -p ${TEST_DATA_DIR}/fendermint;
+mkdir -p ${TEST_DATA_DIR}/tendermint;
+"""
+
+
+[tasks.tendermint-pull]
+command = "docker"
+args = ["pull", "${TM_DOCKER_IMAGE}"]
+
+
+[tasks.tendermint-init]
+extend = "tendermint-run"
+env = { "CMD" = "init", "FLAGS" = "-it" }
+
+
+[tasks.tendermint-start]
+env = { "CMD" = "start", "FLAGS" = "-d" }
+dependencies = ["docker-up-stop-old", "docker-up-rm-old"]
+
+
+[tasks.tendermint-run]
+script = """
+docker run \
+  ${FLAGS} \
+  --rm \
+  --name ${TM_CONTAINER_NAME} \
+  --user $(id -u) \
+  --publish 26657:${HOST_RPC_PORT} \
+  --volume ${TEST_DATA_DIR}/tendermint:/tendermint ${TM_DOCKER_IMAGE} \
+  ${CMD}
+"""
+dependencies = ["tendermint-pull", "test-data-dir"]
+
+
+[tasks.fendermint-new-genesis]
+extend = "fendermint-run"
+env = { "CMD" = "genesis --genesis-file /data/fendermint/genesis.json new --network-name smoke --base-fee 1000  --timestamp 1680101412", "FLAGS" = "-it" }
+
+
+[tasks.fendermint-run]
+script = """
+docker run \
+  ${FLAGS} \
+  --rm \
+  --name ${TM_CONTAINER_NAME} \
+  --user $(id -u) \
+  --volume ${TEST_DATA_DIR}:/data ${FM_DOCKER_IMAGE} \
+  ${CMD}
+"""
+
+
+[tasks.test]
+args = ["run", "--all-features", "--", "-v"]
+
+
+[tasks.tendermint-rm]
+extend = "docker-rm"
+env = { "CONTAINER_NAME" = "${TM_CONTAINER_NAME}" }
+
+
+[tasks.tendermint-stop]
+extend = "docker-stop"
+env = { "CONTAINER_NAME" = "${TM_CONTAINER_NAME}" }
+
+
+[tasks.docker-stop]
+command = "docker"
+args = ["stop", "${CONTAINER_NAME}"]
+ignore_errors = true
+private = true
+
+
+[tasks.docker-rm]
+command = "docker"
+args = ["rm", "--force", "${CONTAINER_NAME}"]
+ignore_errors = true
+private = true

--- a/fendermint/testing/smoke-test/scripts/init.sh
+++ b/fendermint/testing/smoke-test/scripts/init.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Create test artifacts, which is basically the Tendermint genesis file.
+
+KEYS_DIR=/data/fendermint/keys
+GENESIS_FILE=/data/fendermint/genesis.json
+
+# Create a genesis file
+fendermint genesis --genesis-file $GENESIS_FILE new --network-name smoke --base-fee 1000  --timestamp 1680101412
+
+# Create test keys
+mkdir -p $KEYS_DIR
+for NAME in alice bob charlie dave; do
+  fendermint key gen --out-dir $KEYS_DIR --name $NAME;
+done
+
+# Create an account
+fendermint \
+  genesis --genesis-file $GENESIS_FILE \
+  add-account --public-key $KEYS_DIR/alice.pk \
+              --balance 1000000000000000000
+
+# Create a multisig account
+fendermint \
+  genesis --genesis-file $GENESIS_FILE \
+  add-multisig  --public-key $KEYS_DIR/bob.pk \
+                --public-key $KEYS_DIR/charlie.pk \
+                --public-key $KEYS_DIR/dave.pk \
+                --threshold 2 --vesting-start 0 --vesting-duration 1000000 \
+                --balance 3000000000000000000
+
+# Add a validator
+fendermint \
+  genesis --genesis-file $GENESIS_FILE \
+  add-validator --public-key $KEYS_DIR/bob.pk --power 1
+
+# Convert FM genesis to TM
+fendermint \
+  genesis --genesis-file $GENESIS_FILE \
+  into-tendermint --out /data/tendermint/config/genesis.json
+
+# Convert FM validator key to TM
+fendermint \
+  key into-tendermint --secret-key $KEYS_DIR/bob.sk \
+    --out /data/tendermint/config/priv_validator_key.json

--- a/fendermint/testing/smoke-test/src/lib.rs
+++ b/fendermint/testing/smoke-test/src/lib.rs
@@ -1,0 +1,10 @@
+//! Run some tests against a pair of Fendermint and Tendermint docker containers running locally.
+//!
+//! Example:
+//!
+//! ```
+//! cd fendermint/testing/smoke-test
+//! cargo make
+//! ```
+//!
+//! Make sure you installed cargo-make by running `cargo install cargo-make` first.

--- a/fendermint/testing/smoke-test/src/lib.rs
+++ b/fendermint/testing/smoke-test/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 //! Run some tests against a pair of Fendermint and Tendermint docker containers running locally.
 //!
 //! Example:

--- a/fendermint/testing/smoke-test/src/lib.rs
+++ b/fendermint/testing/smoke-test/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Example:
 //!
-//! ```
+//! ```text
 //! cd fendermint/testing/smoke-test
 //! cargo make
 //! ```

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.69"
+channel = "stable"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Closes #95 

Adds a `fendermint/testing/smoke-test` crate with [cargo-make](https://github.com/sagiegurari/cargo-make) that sets up Fendermint and Tendermint as docker containers and runs the simplecoin example.