### PR TITLE
FM-93: Save full state params

### DIFF
--- a/fendermint/vm/genesis/src/lib.rs
+++ b/fendermint/vm/genesis/src/lib.rs
@@ -16,7 +16,7 @@ use fendermint_vm_encoding::IsHumanReadable;
 mod arb;
 
 /// Unix timestamp (in seconds).
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Timestamp(pub u64);
 
 impl Timestamp {

--- a/fendermint/vm/interpreter/src/fvm/genesis.rs
+++ b/fendermint/vm/interpreter/src/fvm/genesis.rs
@@ -3,7 +3,7 @@
 
 use async_trait::async_trait;
 use fendermint_vm_actor_interface::{cron, eam, init, system};
-use fendermint_vm_genesis::{ActorMeta, Genesis, Validator};
+use fendermint_vm_genesis::{ActorMeta, Genesis, Timestamp, Validator};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::version::NetworkVersion;
@@ -15,6 +15,7 @@ use super::state::FvmGenesisState;
 use super::FvmMessageInterpreter;
 
 pub struct FvmGenesisOutput {
+    pub timestamp: Timestamp,
     pub network_version: NetworkVersion,
     pub base_fee: TokenAmount,
     pub circ_supply: TokenAmount,
@@ -57,6 +58,7 @@ where
         // store them in the IPC actors; or in case of a snapshot restore them
         // from the state.
         let output = FvmGenesisOutput {
+            timestamp: genesis.timestamp,
             network_version: genesis.network_version,
             circ_supply: circ_supply(&genesis),
             base_fee: genesis.base_fee,

--- a/fendermint/vm/interpreter/src/fvm/state/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/exec.rs
@@ -20,6 +20,7 @@ use crate::Timestamp;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FvmStateParams {
     pub state_root: Cid,
+    pub timestamp: Timestamp,
     pub network_version: NetworkVersion,
     pub base_fee: TokenAmount,
     pub circ_supply: TokenAmount,
@@ -42,7 +43,6 @@ where
         blockstore: DB,
         multi_engine: &MultiEngine,
         block_height: ChainEpoch,
-        block_timestamp: Timestamp,
         params: FvmStateParams,
     ) -> anyhow::Result<Self> {
         let nc = NetworkConfig::new(params.network_version);
@@ -50,7 +50,7 @@ where
         // TODO: Configure:
         // * circ_supply; by default it's for Filecoin
         // * base_fee; by default it's zero
-        let mut mc = nc.for_epoch(block_height, block_timestamp.0, params.state_root);
+        let mut mc = nc.for_epoch(block_height, params.timestamp.0, params.state_root);
         mc.set_base_fee(params.base_fee);
         mc.set_circulating_supply(params.circ_supply);
 
@@ -92,8 +92,13 @@ where
         self.executor.flush()
     }
 
-    /// The currently executing block height.
+    /// The height of the currently executing block.
     pub fn block_height(&self) -> ChainEpoch {
         self.executor.context().epoch
+    }
+
+    /// The timestamp of the currently executing block.
+    pub fn timestamp(&self) -> Timestamp {
+        Timestamp(self.executor.context().timestamp)
     }
 }


### PR DESCRIPTION
Part of #93 

The PR changes the application to save the full `FvmStateParams` record rather than just the state hash, at each block height. The record also gets a `timestamp` field that contains the genesis timestamp in the beginning, and the block timestamp later.