### PR TITLE
FM-93: Call query

### DIFF
--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -405,8 +405,13 @@ where
             ));
         }
 
-        let state = FvmQueryState::new(db, state_params.state_root)
-            .context("error creating query state")?;
+        let state = FvmQueryState::new(
+            db,
+            self.multi_engine.clone(),
+            block_height.try_into()?,
+            state_params,
+        )
+        .context("error creating query state")?;
 
         let qry = (request.path, request.data.to_vec());
 

--- a/fendermint/vm/interpreter/src/fvm/store/mod.rs
+++ b/fendermint/vm/interpreter/src/fvm/store/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use cid::Cid;
+use fvm::EMPTY_ARR_CID;
 use fvm_ipld_blockstore::Blockstore;
 
 #[cfg(test)]
@@ -23,7 +24,11 @@ where
         self.0.get(k)
     }
 
-    fn put_keyed(&self, _k: &Cid, _block: &[u8]) -> anyhow::Result<()> {
+    fn put_keyed(&self, k: &Cid, block: &[u8]) -> anyhow::Result<()> {
+        // The FVM inserts this each time to make sure it exists.
+        if *k == *EMPTY_ARR_CID {
+            return self.0.put_keyed(k, block);
+        }
         panic!("never intended to use put on the read-only blockstore")
     }
 }


### PR DESCRIPTION
Closes #93 

Introduces an `FvmQuery::Call(Message)` variant that executes a query in read-only mode. It doesn't require signature, so we can execute from the point of view of any account.