### PR TITLE
CHORE: Make docker build faster on CI

### DIFF
--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -3,7 +3,12 @@
 # This file assumes that we use `make build` to build the binary,
 # rather than the builder-runner pattern.
 
-FROM debian:bullseye-slim
+# Matching base image as the CI runner `runs-on` so the outside build is usable in the container.
+FROM ubuntu:latest
+
+RUN apt-get update && \
+  apt-get install -y libstdc++6 && \
+  rm -rf /var/lib/apt/lists/*
 
 ENV FM_HOME_DIR=/fendermint
 ENV HOME=$FM_HOME_DIR

--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+
+# This file assumes that we use `make build` to build the binary,
+# rather than the builder-runner pattern.
+
+FROM debian:bullseye-slim
+
+ENV FM_HOME_DIR=/fendermint
+ENV HOME=$FM_HOME_DIR
+WORKDIR $FM_HOME_DIR
+
+EXPOSE 26658
+
+ENTRYPOINT ["fendermint"]
+CMD ["run"]
+
+STOPSIGNAL SIGTERM
+
+ENV FM_ABCI__HOST=0.0.0.0
+
+COPY fendermint/app/config $FM_HOME_DIR/config
+COPY docker/.artifacts/bundle.car $FM_HOME_DIR/bundle.car
+COPY docker/.artifacts/fendermint /usr/local/bin/fendermint

--- a/docker/local.Dockerfile
+++ b/docker/local.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Builder
-FROM rust:1.68 as builder
+FROM rust:1.69 as builder
 
 RUN apt-get update && \
   apt-get install -y build-essential clang cmake && \
@@ -33,7 +33,8 @@ STOPSIGNAL SIGTERM
 
 ENV FM_ABCI__HOST=0.0.0.0
 
-ARG BUILTIN_ACTORS_BUNDLE
-COPY ${BUILTIN_ACTORS_BUNDLE} $FM_HOME_DIR/bundle.car
+# We could build the actor bundles in the `builder` as well,
+# but we should be able to copy it from somewhere.
+COPY ./docker/.artifacts/bundle.car $FM_HOME_DIR/bundle.car
 COPY --from=builder /app/fendermint/app/config $FM_HOME_DIR/config
 COPY --from=builder /app/output/bin/fendermint /usr/local/bin/fendermint

--- a/docs/running.md
+++ b/docs/running.md
@@ -2,8 +2,8 @@
 
 The commands are all executed by the `fendermint` binary, which is produced from the `fendermint_app` crate,
 so we have many ways to run the program:
-* `fendermint <args>`, after running `cargo install fendermint_app`
-* `./target/debug/fendermint <args>`, after running `cargo build --release`
+* `fendermint <args>`, after running `cargo install --path fendermint/app`
+* `./target/release/fendermint <args>`, after running `cargo build --release`
 * `cargo run -p fendermint_app --release -- <args>`
 
 ## Genesis


### PR DESCRIPTION
The end-to-end test takes 45 minutes, of which 20 minutes is building docker, and 15 minutes is building the simplecoin example. The PR tries to speed it up by building the app on the CI server, not inside the docker image, so that it can take advantage of sccache. Locally it will use the other pattern, although the builtin actors are still built on the machine.