### PR TITLE
FM-94: FEVM call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2308,6 +2308,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "libsecp256k1",
+ "serde",
  "tendermint",
  "tendermint-rpc",
  "tokio",

--- a/fendermint/app/src/cmd/rpc.rs
+++ b/fendermint/app/src/cmd/rpc.rs
@@ -10,7 +10,8 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use fendermint_rpc::client::BoundFendermintClient;
 use fendermint_rpc::tx::{
-    AsyncResponse, BoundClient, CommitResponse, SyncResponse, TxAsync, TxClient, TxCommit, TxSync,
+    AsyncResponse, BoundClient, CallClient, CommitResponse, SyncResponse, TxAsync, TxClient,
+    TxCommit, TxSync,
 };
 use fendermint_vm_message::chain::ChainMessage;
 use fvm_ipld_encoding::RawBytes;
@@ -28,7 +29,7 @@ use fendermint_rpc::{client::FendermintClient, query::QueryClient};
 use fendermint_vm_actor_interface::eam::{self, CreateReturn};
 
 use crate::cmd;
-use crate::options::rpc::{BroadcastMode, RpcFevmCommands, TransArgs};
+use crate::options::rpc::{BroadcastMode, FevmArgs, RpcFevmCommands, TransArgs};
 use crate::{
     cmd::to_b64,
     options::rpc::{RpcArgs, RpcCommands, RpcQueryCommands},
@@ -54,8 +55,12 @@ cmd! {
         RpcFevmCommands::Create { contract, constructor_args } => {
             fevm_create(client, args, contract, constructor_args).await
         }
-        RpcFevmCommands::Invoke { contract, method, method_args } => {
+        RpcFevmCommands::Invoke { args: FevmArgs { contract, method, method_args }} => {
             fevm_invoke(client, args, contract, method, method_args).await
+        }
+        RpcFevmCommands::Call { args: FevmArgs { contract, method, method_args }, height} => {
+        let height = Height::try_from(height)?;
+            fevm_call(client, args, contract, method, method_args, height).await
         }
       }
     }
@@ -188,7 +193,7 @@ async fn fevm_create(
     .await
 }
 
-/// Deploy an EVM contract through RPC and print the response to STDOUT as JSON.
+/// Invoke an EVM contract through RPC and print the response to STDOUT as JSON.
 async fn fevm_invoke(
     client: FendermintClient,
     args: TransArgs,
@@ -210,6 +215,35 @@ async fn fevm_invoke(
         |data| serde_json::Value::String(hex::encode(data)),
     )
     .await
+}
+
+/// Call an EVM contract through RPC and print the response to STDOUT as JSON.
+async fn fevm_call(
+    client: FendermintClient,
+    args: TransArgs,
+    contract: Address,
+    method: Bytes,
+    method_args: Bytes,
+    height: Height,
+) -> anyhow::Result<()> {
+    let calldata = Bytes::from([method, method_args].concat());
+    let mut client = TransClient::new(client, &args)?;
+    let gas_params = gas_params(&args);
+    let value = args.value;
+
+    let res = client
+        .inner
+        .fevm_call(contract, calldata, value, gas_params, Some(height))
+        .await?;
+
+    let return_data = res
+        .return_data
+        .map(|bz| serde_json::Value::String(hex::encode(bz)))
+        .unwrap_or(serde_json::Value::Null);
+
+    let json = json!({"response": res.response, "return_data": return_data});
+
+    print_json(&json)
 }
 
 /// Print out pretty-printed JSON.

--- a/fendermint/app/src/cmd/rpc.rs
+++ b/fendermint/app/src/cmd/rpc.rs
@@ -74,7 +74,7 @@ async fn query(
             None => eprintln!("CID not found"),
         },
         RpcQueryCommands::ActorState { address } => {
-            match client.actor_state(&address, Some(height)).await? {
+            match client.actor_state(&address, Some(height)).await?.value {
                 Some((id, state)) => {
                     let out = json! ({
                       "id": id,

--- a/fendermint/app/src/options/rpc.rs
+++ b/fendermint/app/src/options/rpc.rs
@@ -100,18 +100,33 @@ pub enum RpcFevmCommands {
         #[arg(long, short, value_parser = parse_bytes, default_value = "")]
         constructor_args: Bytes,
     },
-    /// Call an EVM contract; print the results as JSON with the return data rendered in hexadecimal format.
+    /// Invoke an EVM contract; print the results as JSON with the return data rendered in hexadecimal format.
     Invoke {
-        /// Either the actor ID based or the EAM delegated address of the contract to call.
-        #[arg(long, short)]
-        contract: Address,
-        /// ABI encoded method hash, expected to be in hexadecimal format.
-        #[arg(long, short, value_parser = parse_bytes)]
-        method: Bytes,
-        /// ABI encoded call arguments passed to the EVM, expected to be in hexadecimal format.
-        #[arg(long, short, value_parser = parse_bytes, default_value = "")]
-        method_args: Bytes,
+        #[command(flatten)]
+        args: FevmArgs,
     },
+    /// Call an EVM contract without a transaction; print the results as JSON with the return data rendered in hexadecimal format.
+    Call {
+        #[command(flatten)]
+        args: FevmArgs,
+        /// Block height to query; 0 means latest.
+        #[arg(long, short = 'b', default_value_t = 0)]
+        height: u64,
+    },
+}
+
+/// Arguments common to FEVM method calls.
+#[derive(Args, Debug, Clone)]
+pub struct FevmArgs {
+    /// Either the actor ID based or the EAM delegated address of the contract to call.
+    #[arg(long, short)]
+    pub contract: Address,
+    /// ABI encoded method hash, expected to be in hexadecimal format.
+    #[arg(long, short, value_parser = parse_bytes)]
+    pub method: Bytes,
+    /// ABI encoded call arguments passed to the EVM, expected to be in hexadecimal format.
+    #[arg(long, short, value_parser = parse_bytes, default_value = "")]
+    pub method_args: Bytes,
 }
 
 /// Arguments common to transactions and transfers.

--- a/fendermint/rpc/Cargo.toml
+++ b/fendermint/rpc/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
 libsecp256k1 = { workspace = true }
+serde = { workspace = true }
 tendermint = { workspace = true }
 tendermint-rpc = { workspace = true }
 tracing = { workspace = true }

--- a/fendermint/rpc/src/client.rs
+++ b/fendermint/rpc/src/client.rs
@@ -215,7 +215,8 @@ where
         let return_data = if response.deliver_tx.code.is_err() {
             None
         } else {
-            let return_data = f(&response.deliver_tx).context("error decoding deliver_tx")?;
+            let return_data =
+                f(&response.deliver_tx).context("error decoding data from deliver_tx in commit")?;
             Some(return_data)
         };
         let response = CommitResponse {

--- a/fendermint/rpc/src/message.rs
+++ b/fendermint/rpc/src/message.rs
@@ -48,6 +48,11 @@ impl MessageFactory {
         &self.addr
     }
 
+    /// Set the sequence to an arbitrary value.
+    pub fn set_sequence(&mut self, sequence: u64) {
+        self.sequence = sequence;
+    }
+
     /// Transfer tokens to another account.
     pub fn transfer(
         &mut self,

--- a/fendermint/rpc/src/query.rs
+++ b/fendermint/rpc/src/query.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
+use fvm_ipld_encoding::serde::Serialize;
 use fvm_shared::message::Message;
 use tendermint::block::Height;
 use tendermint::v0_37::abci::response;
@@ -16,6 +17,7 @@ use fendermint_vm_message::query::{ActorState, FvmQuery};
 
 use crate::response::encode_data;
 
+#[derive(Serialize, Debug, Clone)]
 /// The parsed value from a query, along with the height at which the query was performed.
 pub struct QueryResponse<T> {
     pub height: Height,

--- a/fendermint/rpc/src/query.rs
+++ b/fendermint/rpc/src/query.rs
@@ -3,7 +3,9 @@
 
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
+use fvm_shared::message::Message;
 use tendermint::block::Height;
+use tendermint::v0_37::abci::response;
 use tendermint_rpc::endpoint::abci_query::AbciQuery;
 
 use cid::Cid;
@@ -12,13 +14,21 @@ use fvm_shared::{address::Address, error::ExitCode};
 
 use fendermint_vm_message::query::{ActorState, FvmQuery};
 
+use crate::response::encode_data;
+
+/// The parsed value from a query, along with the height at which the query was performed.
+pub struct QueryResponse<T> {
+    pub height: Height,
+    pub value: T,
+}
+
 /// Fendermint client for submitting queries.
 #[async_trait]
 pub trait QueryClient: Send + Sync {
     /// Query the contents of a CID from the IPLD store.
     async fn ipld(&self, cid: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
         let res = self.perform(FvmQuery::Ipld(*cid), None).await?;
-        extract(res, |res| Ok(res.value))
+        extract_opt(res, |res| Ok(res.value))
     }
 
     /// Query the the state of an actor.
@@ -26,10 +36,10 @@ pub trait QueryClient: Send + Sync {
         &self,
         address: &Address,
         height: Option<Height>,
-    ) -> anyhow::Result<Option<(ActorID, ActorState)>> {
+    ) -> anyhow::Result<QueryResponse<Option<(ActorID, ActorState)>>> {
         let res = self.perform(FvmQuery::ActorState(*address), height).await?;
-
-        extract(res, |res| {
+        let height = res.height;
+        let value = extract_opt(res, |res| {
             let state: ActorState =
                 fvm_ipld_encoding::from_slice(&res.value).context("failed to decode state")?;
 
@@ -37,7 +47,30 @@ pub trait QueryClient: Send + Sync {
                 fvm_ipld_encoding::from_slice(&res.key).context("failed to decode ID")?;
 
             Ok((id, state))
-        })
+        })?;
+        Ok(QueryResponse { height, value })
+    }
+
+    /// Run a message in a read-only fashion.
+    async fn call(
+        &self,
+        message: Message,
+        height: Option<Height>,
+    ) -> anyhow::Result<QueryResponse<response::DeliverTx>> {
+        let res = self
+            .perform(FvmQuery::Call(Box::new(message)), height)
+            .await?;
+        let height = res.height;
+        let value = extract(res, |res| {
+            let mut deliver_tx: response::DeliverTx = fvm_ipld_encoding::from_slice(&res.value)
+                .context("failed to decode call result as DeliverTx")?;
+
+            // Mimic the Base64 encoding of the value that Tendermint does.
+            deliver_tx.data = encode_data(&deliver_tx.data);
+
+            Ok(deliver_tx)
+        })?;
+        Ok(QueryResponse { height, value })
     }
 
     /// Run an ABCI query.
@@ -45,19 +78,29 @@ pub trait QueryClient: Send + Sync {
 }
 
 /// Extract some value from the query result, unless it's not found or other error.
-fn extract<T, F>(res: AbciQuery, f: F) -> anyhow::Result<Option<T>>
+fn extract_opt<T, F>(res: AbciQuery, f: F) -> anyhow::Result<Option<T>>
 where
     F: FnOnce(AbciQuery) -> anyhow::Result<T>,
 {
     if is_not_found(&res) {
         Ok(None)
-    } else if res.code.is_err() {
+    } else {
+        extract(res, f).map(Some)
+    }
+}
+
+/// Extract some value from the query result, unless there was an error.
+fn extract<T, F>(res: AbciQuery, f: F) -> anyhow::Result<T>
+where
+    F: FnOnce(AbciQuery) -> anyhow::Result<T>,
+{
+    if res.code.is_err() {
         Err(anyhow!(
             "query returned non-zero exit code: {}",
             res.code.value()
         ))
     } else {
-        f(res).map(Some)
+        f(res)
     }
 }
 

--- a/fendermint/rpc/src/response.rs
+++ b/fendermint/rpc/src/response.rs
@@ -18,6 +18,13 @@ pub fn decode_data(data: &Bytes) -> anyhow::Result<Vec<u8>> {
     Ok(data)
 }
 
+/// Apply the encoding that Tendermint does to the bytes inside [`DeliverTx`].
+pub fn encode_data(data: &[u8]) -> Bytes {
+    let b64 = base64::engine::general_purpose::STANDARD.encode(data);
+    let bz = b64.as_bytes();
+    Bytes::copy_from_slice(bz)
+}
+
 /// Parse what Tendermint returns in the `data` field of [`DeliverTx`] as raw bytes.
 pub fn decode_bytes(deliver_tx: &DeliverTx) -> anyhow::Result<Vec<u8>> {
     decode_data(&deliver_tx.data)

--- a/fendermint/testing/smoke-test/Makefile.toml
+++ b/fendermint/testing/smoke-test/Makefile.toml
@@ -49,6 +49,7 @@ run_task = { name = [
 
 
 [tasks.simplecoin-example]
+# Using --release in the hope that it can reuse artifacts compiled earlier for the docker build.
 script = """
 cd ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}
 cargo run -p fendermint_rpc --release --example simplecoin -- \


### PR DESCRIPTION
Closes #94 

Adds a `fevm call` CLI command which has the same parameters as `fevm invoke`, plus an additional `height`, and sends a message to be run without invoking a transaction. It uses the new `fevm_call` method added to a new `CallClient` trait in the RPC library.

```console
❯ cargo run -p fendermint_app --release -- rpc fevm call --help
    Finished release [optimized] target(s) in 0.46s
     Running `target/release/fendermint rpc fevm call --help`
Call an EVM contract without a transaction; print the results as JSON with the return data rendered in hexadecimal format

Usage: fendermint rpc fevm --secret-key <SECRET_KEY> --sequence <SEQUENCE> call [OPTIONS] --contract <CONTRACT> --method <METHOD>

Options:
  -c, --contract <CONTRACT>        Either the actor ID based or the EAM delegated address of the contract to call
  -m, --method <METHOD>            ABI encoded method hash, expected to be in hexadecimal format
  -m, --method-args <METHOD_ARGS>  ABI encoded call arguments passed to the EVM, expected to be in hexadecimal format [default: ]
  -b, --height <HEIGHT>            Block height to query; 0 means latest [default: 0]
  -h, --help                       Print help
```

These options are in addition to what `fevm --help` shows for every command:

```console
Options:
  -v, --value <VALUE>
          Amount of tokens to send, in atto
          
          [default: 0]

  -s, --secret-key <SECRET_KEY>
          Path to the secret key of the sender to sign the transaction

  -n, --sequence <SEQUENCE>
          Sender account nonce

      --gas-limit <GAS_LIMIT>
          Maximum amount of gas that can be charged
          
          [default: 10000000000]

      --gas-fee-cap <GAS_FEE_CAP>
          Price of gas.
          
          Any discrepancy between this and the base fee is paid for by the validator who puts the transaction into the block.
          
          [default: 0]

      --gas-premium <GAS_PREMIUM>
          Gas premium
          
          [default: 0]

  -b, --broadcast-mode <BROADCAST_MODE>
          Whether to wait for the results from Tendermint or not
          
          [default: commit]

          Possible values:
          - async:  Do no wait for the results
          - sync:   Wait for the result of `check_tx`
          - commit: Wait for the result of `deliver_tx`

  -h, --help
          Print help (see a summary with '-h')

```