### PR TITLE
FM-107: Switch to cometbft

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,15 +1265,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "3.2.0"
+name = "curve25519-dalek-ng"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
- "rand_core 0.5.1",
- "subtle",
+ "rand_core 0.6.4",
+ "subtle-ng",
  "zeroize",
 ]
 
@@ -1531,21 +1531,23 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.3"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
+checksum = "5fb04eee5d9d907f29e80ee6b0e78f7e2c82342c63e3580d8c4f69d9d5aad963"
 dependencies = [
- "signature 1.6.4",
+ "pkcs8 0.10.2",
+ "signature 2.1.0",
 ]
 
 [[package]]
-name = "ed25519-dalek"
-version = "1.0.1"
+name = "ed25519-consensus"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core 0.6.4",
  "sha2 0.9.9",
  "zeroize",
 ]
@@ -2124,6 +2126,7 @@ dependencies = [
  "k256 0.11.6",
  "libsecp256k1",
  "num-traits",
+ "prost",
  "quickcheck 1.0.3",
  "quickcheck_macros",
  "rand_chacha 0.3.1",
@@ -2131,6 +2134,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tendermint",
+ "tendermint-proto",
  "tendermint-rpc",
  "tokio",
  "tower-abci",
@@ -2173,8 +2177,10 @@ dependencies = [
  "hex",
  "lazy_static",
  "libsecp256k1",
+ "prost",
  "serde",
  "tendermint",
+ "tendermint-proto",
  "tendermint-rpc",
  "tokio",
  "tracing",
@@ -4775,17 +4781,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ripemd160"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5710,6 +5705,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+
+[[package]]
 name = "svm-rs"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5801,26 +5802,28 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.28.0"
-source = "git+https://github.com/aakoshh/tendermint-rs.git?branch=mikhail/multi-tc-version-support#011dc7bb427f43e14b245d15d7939b2bbffe9411"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1b58bdb6c44a2621b8b6bd0585d5912ba32546317604130a42410bcc813ef16"
 dependencies = [
  "bytes",
+ "digest 0.10.6",
  "ed25519",
- "ed25519-dalek",
+ "ed25519-consensus",
  "flex-error",
  "futures",
- "k256 0.11.6",
+ "k256 0.13.1",
  "num-traits",
  "once_cell",
  "prost",
  "prost-types",
- "ripemd160",
+ "ripemd",
  "serde",
  "serde_bytes",
  "serde_json",
  "serde_repr",
- "sha2 0.9.9",
- "signature 1.6.4",
+ "sha2 0.10.6",
+ "signature 2.1.0",
  "subtle",
  "subtle-encoding",
  "tendermint-proto",
@@ -5830,8 +5833,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-config"
-version = "0.28.0"
-source = "git+https://github.com/aakoshh/tendermint-rs.git?branch=mikhail/multi-tc-version-support#011dc7bb427f43e14b245d15d7939b2bbffe9411"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "088bac81db392e66eedb508c400ebb2096d1e21cc40d71e3739a9bbd6838809a"
 dependencies = [
  "flex-error",
  "serde",
@@ -5843,8 +5847,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.28.0"
-source = "git+https://github.com/aakoshh/tendermint-rs.git?branch=mikhail/multi-tc-version-support#011dc7bb427f43e14b245d15d7939b2bbffe9411"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f15666993e193fa4d2b2479aa1e4f1bbe41283c820812df8dd618f41ca3f7a"
 dependencies = [
  "bytes",
  "flex-error",
@@ -5860,8 +5865,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.28.0"
-source = "git+https://github.com/aakoshh/tendermint-rs.git?branch=mikhail/multi-tc-version-support#011dc7bb427f43e14b245d15d7939b2bbffe9411"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120ccb296a0ec4485ddb78eb842e481d7a859d5659e0f1881456f8c127d5e950"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5874,6 +5880,7 @@ dependencies = [
  "hyper-rustls 0.22.1",
  "peg",
  "pin-project",
+ "semver",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -6208,8 +6215,9 @@ dependencies = [
 
 [[package]]
 name = "tower-abci"
-version = "0.4.0"
-source = "git+https://github.com/consensus-shipyard/tower-abci.git?branch=tendermint-v0.37#ac40edd08a15275a68601380b52cf9458ffb9293"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaddfcab2a1c77ba634491e710b04653c4b53ae1a541c56a02c5c3fc9facc80c"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ libsecp256k1 = "0.7"
 multihash = { version = "0.16.1", default-features = false }
 num-traits = "0.2"
 paste = "1"
+prost = { version = "0.11" }
 quickcheck = "1"
 quickcheck_macros = "1"
 rand = "0.8"
@@ -71,12 +72,8 @@ cid = { version = "0.8", features = ["serde-codec", "std"] }
 # We can work around it by hardcoding the method hashes; currently there is only one.
 # frc42_dispatch = "3.2"
 
-# Tendermint dependencies are forked because we are building against 0.37 release candidates.
-tower-abci = { git = "https://github.com/consensus-shipyard/tower-abci.git", branch = "tendermint-v0.37" }
-tendermint = { git = "https://github.com/aakoshh/tendermint-rs.git", branch = "mikhail/multi-tc-version-support", features = [
-  "secp256k1",
-] }
-tendermint-rpc = { git = "https://github.com/aakoshh/tendermint-rs.git", branch = "mikhail/multi-tc-version-support", features = [
-  "secp256k1",
-  "http-client",
-] }
+# Using the same tendermint-rs dependency as tower-abci. From both we are interested in v037 modules.
+tower-abci = { version = "0.7" }
+tendermint = { version = "0.31", features = ["secp256k1"] }
+tendermint-rpc = { version = "0.31", features = ["secp256k1", "http-client"] }
+tendermint-proto = { version = "0.31" }

--- a/docs/demos/milestone-1/README.md
+++ b/docs/demos/milestone-1/README.md
@@ -6,3 +6,5 @@ This demo shows that FVM has been integrated into an ABCI application. It doesn'
 * [Overview video](https://drive.google.com/file/d/1fv1rVp9cbGuQho5jIqUCHSziJpmId57y/view?usp=sharing)
 * [Demo video](https://drive.google.com/file/d/1-UvOk0qb3nQQQd2SczW6uWFRIMpBDUyB/view?usp=sharing)
 * [Demo script](./fendermint-demo.sh)
+
+This demo was preformed with [Tendermint Core v0.37.0-rc2](https://github.com/tendermint/tendermint/blob/v0.37.0-rc2/docs/introduction/install.md) (with `git checkout v0.37.0-rc2`), before we switched to CometBFT, so we ran `tendermint` commands, not `cometbft`.

--- a/docs/running.md
+++ b/docs/running.md
@@ -154,22 +154,22 @@ The public key was spliced in as it was, in base64 format, which is how it would
 own genesis file format. Note that here we don't have the option to use `Address`, because we have to return
 these as actual `PublicKey` types to Tendermint through ABCI, not as a hash of a key.
 
-### Configure Tendermint
+### Configure CometBFT
 
-First, follow the instructions in [getting started with Tendermint](./tendermint.md) to install the binary,
-then initialize a genesis file for Tendermint at `~/.tendermint`.
+First, follow the instructions in [getting started with CometBFT](./tendermint.md) to install the binary,
+then initialize a genesis file for CometBFT at `~/.cometbft`.
 
 ```shell
-rm -rf ~/.tendermint
-tendermint init
+rm -rf ~/.cometbft
+cometbft init
 ```
 
 The logs show that it created keys and a genesis file:
 
 ```console
-I[2023-03-29|09:58:06.324] Found private validator                      module=main keyFile=/home/aakoshh/.tendermint/config/priv_validator_key.json stateFile=/home/aakoshh/.tendermint/data/priv_validator_state.json
-I[2023-03-29|09:58:06.324] Found node key                               module=main path=/home/aakoshh/.tendermint/config/node_key.json
-I[2023-03-29|09:58:06.324] Found genesis file                           module=main path=/home/aakoshh/.tendermint/config/genesis.json
+I[2023-03-29|09:58:06.324] Found private validator                      module=main keyFile=/home/aakoshh/.cometbft/config/priv_validator_key.json stateFile=/home/aakoshh/.cometbft/data/priv_validator_state.json
+I[2023-03-29|09:58:06.324] Found node key                               module=main path=/home/aakoshh/.cometbft/config/node_key.json
+I[2023-03-29|09:58:06.324] Found genesis file                           module=main path=/home/aakoshh/.cometbft/config/genesis.json
 ```
 
 #### Convert the Genesis file
@@ -178,19 +178,19 @@ We don't want to use the random values created by Tendermint; instead we need to
 file we created earlier to the format Tendermint accepts. Start with the genesis file:
 
 ```shell
-mv ~/.tendermint/config/genesis.json ~/.tendermint/config/genesis.json.orig
+mv ~/.cometbft/config/genesis.json ~/.cometbft/config/genesis.json.orig
 cargo run -p fendermint_app -- \
   genesis --genesis-file test-network/genesis.json \
-  into-tendermint --out ~/.tendermint/config/genesis.json
+  into-tendermint --out ~/.cometbft/config/genesis.json
 ```
 
 Check the contents of the created Tendermint Genesis file:
 
 <details>
-  <summary>~/.tendermint/config/genesis.json</summary>
+  <summary>~/.cometbft/config/genesis.json</summary>
 
 ```console
-$ cat ~/.tendermint/config/genesis.json
+$ cat ~/.cometbft/config/genesis.json
 {
   "genesis_time": "2023-03-29T14:50:12Z",
   "chain_id": "test",
@@ -268,18 +268,18 @@ We can run the following command to replace the default `priv_validator_key.json
 one of the validators we created.
 
 ```shell
-mv ~/.tendermint/config/priv_validator_key.json ~/.tendermint/config/priv_validator_key.json.orig
+mv ~/.cometbft/config/priv_validator_key.json ~/.cometbft/config/priv_validator_key.json.orig
 cargo run -p fendermint_app -- \
-  key into-tendermint --secret-key test-network/keys/bob.sk --out ~/.tendermint/config/priv_validator_key.json
+  key into-tendermint --secret-key test-network/keys/bob.sk --out ~/.cometbft/config/priv_validator_key.json
 ```
 
 See if it looks reasonable:
 
 <details>
-<summary>~/.tendermint/config/priv_validator_key.json</summary>
+<summary>~/.cometbft/config/priv_validator_key.json</summary>
 
 ```console
-$ cat ~/.tendermint/config/priv_validator_key.json
+$ cat ~/.cometbft/config/priv_validator_key.json
 {
   "address": "66FA0CFB373BD737DBFC7CE70BEF994DD42A3812",
   "priv_key": {
@@ -344,20 +344,20 @@ If we need to restart the application from scratch, we can do so by erasing all 
 rm -rf ~/.fendermint/data/rocksdb
 ```
 
-### Run Tendermint
+### Run CometBFT
 
-Tendermint can be configured via `~/.tendermint/config/config.toml`; see the default settings [here](https://docs.tendermint.com/v0.34/tendermint-core/configuration.html).
+CometBFT can be configured via `~/.cometbft/config/config.toml`; see the default settings [here](https://docs.cometbft.com/v0.37/core/configuration).
 
-Now we are ready to start Tendermint and let it connect to the Fendermint Application.
+Now we are ready to start CometBFT and let it connect to the Fendermint Application.
 
 ```shell
-tendermint start
+cometbft start
 ```
 
-If we need to restart the application from scratch, we can erase all Tendermint state like so:
+If we need to restart the application from scratch, we can erase all CometBFT state like so:
 
 ```shell
-tendermint unsafe-reset-all
+cometbft unsafe-reset-all
 ```
 
 If all goes well, we will see block created in the Fendermint Application log as well the Tendermint log:
@@ -368,55 +368,40 @@ If all goes well, we will see block created in the Fendermint Application log as
 ```console
 $ rm -rf ~/.fendermint/data/rocksdb && cargo run -p fendermint_app --release -- --log-level debug run
 ...
-2023-03-30T11:51:34.239909Z DEBUG tower_abci::server: new request request=Info(Info { version: "v0.37.0-rc2", block_version: 11, p2p_version: 8, abci_version: "1.0.0" })
+2023-05-19T09:13:45.400896Z DEBUG tower_abci::v037::server: new request request=Info(Info { version: "0.37.1", block_version: 11, p2p_version: 8, abci_version: "1.0.0" })
 ...
-2023-03-30T11:51:34.240250Z DEBUG tower_abci::server: flushing response response=Ok(Info(Info { data: "fendermint", version: "0.1.0", app_version: 0, last_block_height: block::Height(0), last_block_app_hash: AppHash(0171A0E402203AAAC8F10B0E837FDF2546C98BF164972B07B49196E25322711E3C4807CF8AD8) }))
-2023-03-30T11:51:34.240914Z DEBUG tower_abci::server: new request request=InitChain(...)
+2023-05-19T09:13:45.401018Z DEBUG tower_abci::v037::server: flushing response response=Ok(Info(Info { data: "fendermint", version: "0.1.0", app_version: 0, last_block_height: block::Height(0), last_block_app_hash: AppHash(0171A0E402203AAAC8F10B0E837FDF2546C98BF164972B07B49196E25322711E3C4807CF8AD8) }))
+2023-05-19T09:13:45.401262Z DEBUG tower_abci::v037::server: new request request=InitChain(...)
 ...
-2023-03-30T11:51:34.295133Z  INFO fendermint_app::app: init chain state_root="bafy2bzaceaurow7dd2zs2zek7jb44x4jumraubzy5fyjya5edgxnc32nhap76" app_hash="0171A0E4022029175BE31EB32D648AFA43CE5F89A3220A0738E9709C03A419AED16F4D381FFF"
-2023-03-30T11:51:34.295665Z DEBUG tower_abci::server: flushing response response=Ok(InitChain(...))
+2023-05-19T09:13:54.062109Z DEBUG tower_abci::v037::server: new request request=PrepareProposal(...)
 ...
-2023-03-30T11:51:35.365180Z DEBUG tower_abci::server: new request request=BeginBlock(...)
+2023-05-19T09:13:54.083246Z DEBUG tower_abci::v037::server: new request request=ProcessProposal(ProcessProposal { ..., height: block::Height(3), ... })
 ...
-2023-03-30T11:51:35.365662Z DEBUG fendermint_app::app: begin block height=1
-2023-03-30T11:51:42.552711Z DEBUG fendermint_app::app: initialized exec state
-2023-03-30T11:51:42.553013Z DEBUG tower_abci::server: flushing response response=Ok(BeginBlock(...))
+2023-05-19T09:13:54.105797Z DEBUG fendermint_app::app: begin block height=3
+2023-05-19T09:13:54.105922Z DEBUG fendermint_app::app: initialized exec state
 ...
-2023-03-30T11:51:42.560459Z DEBUG tower_abci::server: flushing response response=Ok(Commit(...))
-...
-2023-03-30T11:51:42.606102Z DEBUG tower_abci::server: new request request=BeginBlock(...)
-...
-2023-03-30T11:51:42.606359Z DEBUG fendermint_app::app: begin block height=2
-2023-03-30T11:51:42.606623Z DEBUG fendermint_app::app: initialized exec state
-...
+2023-05-19T09:13:54.110007Z DEBUG fendermint_app::app: commit state state_root="bafy2bzacebh4fbl6rv7tlxxf2zsxqifjr424tkykwmgffqaho6mvr6hy7dq42" timestamp=1684487633
 ```
 </details>
 
 
 <details>
-  <summary>Tendermint log</summary>
+  <summary>CometBFT log</summary>
 
 ```console
-$ tendermint unsafe-reset-all && tendermint start
+$ cometbft unsafe-reset-all && cometbft start
 ...
-I[2023-03-30|12:51:34.240] ABCI Handshake App Info                      module=consensus height=0 hash=0171A0E402203AAAC8F10B0E837FDF2546C98BF164972B07B49196E25322711E3C4807CF8AD8 software-version=0.1.0 protocol-version=0
-I[2023-03-30|12:51:34.240] ABCI Replay Blocks                           module=consensus appHeight=0 storeHeight=0 stateHeight=0
-I[2023-03-30|12:51:34.299] Completed ABCI Handshake - Tendermint and App are synced module=consensus appHeight=0 appHash=0171A0E402203AAAC8F10B0E837FDF2546C98BF164972B07B49196E25322711E3C4807CF8AD8
+I[2023-05-19|10:13:45.449] Completed ABCI Handshake - CometBFT and App are synced module=consensus appHeight=0 appHash=0171A0E402203AAAC8F10B0E837FDF2546C98BF164972B07B49196E25322711E3C4807CF8AD8
+I[2023-05-19|10:13:45.449] Version info                                 module=main tendermint_version=0.37.1 abci=1.0.0 block=11 p2p=8 commit_hash=2af25aea6
+I[2023-05-19|10:13:45.449] This node is a validator                     module=consensus addr=1202F4D1C5ACCC8219E2973394CBD06FD1F33B5A pubKey=PubKeySecp256k1{02DBBA09ABF7888AA63D75534A8A0CD79209B0E549DFB3FDE015FC61069D1C7232}
 ...
-I[2023-03-30|12:51:35.335] received proposal                            module=consensus proposal="Proposal{1/0 (9FD634BC038D3CA4FC885E8530CD56B1693739AEBACBF404AAB5DDA5ADC8D180:1:756F1391A4CF, -1) 2BC2F835CBC1 @ 2023-03-30T11:51:35.327328663Z}"
-I[2023-03-30|12:51:35.339] received complete proposal block             module=consensus height=1 hash=9FD634BC038D3CA4FC885E8530CD56B1693739AEBACBF404AAB5DDA5ADC8D180
-I[2023-03-30|12:51:35.357] finalizing commit of block                   module=consensus height=1 hash=9FD634BC038D3CA4FC885E8530CD56B1693739AEBACBF404AAB5DDA5ADC8D180 root=0171A0E4022029175BE31EB32D648AFA43CE5F89A3220A0738E9709C03A419AED16F4D381FFF num_txs=0
-I[2023-03-30|12:51:38.316] Timed out                                    module=consensus dur=3s height=1 round=0 step=RoundStepPropose
-I[2023-03-30|12:51:42.553] executed block                               module=state height=1 num_valid_txs=0 num_invalid_txs=0
-I[2023-03-30|12:51:42.560] committed state                              module=state height=1 num_txs=0 app_hash=0171A0E4022029175BE31EB32D648AFA43CE5F89A3220A0738E9709C03A419AED16F4D381FFF
-I[2023-03-30|12:51:42.564] Timed out                                    module=consensus dur=-6.207267593s height=2 round=0 step=RoundStepNewHeight
-I[2023-03-30|12:51:42.567] indexed block                                module=txindex height=1
-I[2023-03-30|12:51:42.577] received proposal                            module=consensus proposal="Proposal{2/0 (5D2D09F6829D7F0481E597CEAE87DCFA5665987B0B7D57C05B302BEB8DB95406:1:4D3E5565CA22, -1) 693D8DF9C36E @ 2023-03-30T11:51:42.570865715Z}"
-I[2023-03-30|12:51:42.581] received complete proposal block             module=consensus height=2 hash=5D2D09F6829D7F0481E597CEAE87DCFA5665987B0B7D57C05B302BEB8DB95406
-I[2023-03-30|12:51:42.598] finalizing commit of block                   module=consensus height=2 hash=5D2D09F6829D7F0481E597CEAE87DCFA5665987B0B7D57C05B302BEB8DB95406 root=0171A0E4022029175BE31EB32D648AFA43CE5F89A3220A0738E9709C03A419AED16F4D381FFF num_txs=0
-I[2023-03-30|12:51:42.607] executed block                               module=state height=2 num_valid_txs=0 num_invalid_txs=0
-I[2023-03-30|12:51:42.612] committed state                              module=state height=2 num_txs=0 app_hash=0171A0E4022029175BE31EB32D648AFA43CE5F89A3220A0738E9709C03A419AED16F4D381FFF
-I[2023-03-30|12:51:42.618] indexed block                                module=txindex height=2
+I[2023-05-19|10:13:54.061] Timed out                                    module=consensus dur=984.901925ms height=3 round=0 step=RoundStepNewHeight
+I[2023-05-19|10:13:54.079] received proposal                            module=consensus proposal="Proposal{3/0 (08CCBA6EDC7B6E77022D98A1BA528F34D2BDFFB94FE02DD36A3ECB873C321E07:1:ADBA4ABBE9A6, -1) 28842808EA1D @ 2023-05-19T09:13:54.072518233Z}"
+I[2023-05-19|10:13:54.082] received complete proposal block             module=consensus height=3 hash=08CCBA6EDC7B6E77022D98A1BA528F34D2BDFFB94FE02DD36A3ECB873C321E07
+I[2023-05-19|10:13:54.098] finalizing commit of block                   module=consensus height=3 hash=08CCBA6EDC7B6E77022D98A1BA528F34D2BDFFB94FE02DD36A3ECB873C321E07 root=0171A0E402204FC2857E8D7F35DEE5D6657820A98F35C9AB0AB30C52C007779958F8F8F8E1CD num_txs=0
+I[2023-05-19|10:13:54.106] executed block                               module=state height=3 num_valid_txs=0 num_invalid_txs=0
+I[2023-05-19|10:13:54.110] committed state                              module=state height=3 num_txs=0 app_hash=0171A0E402204FC2857E8D7F35DEE5D6657820A98F35C9AB0AB30C52C007779958F8F8F8E1CD
+I[2023-05-19|10:13:54.116] indexed block exents                         module=txindex height=3
 ...
 ```
 </details>
@@ -428,27 +413,37 @@ but after that the blocks come in fast, one per second.
 ## Query the state
 
 The Fendermint binary has some commands to support querying state. Behind the scenes it uses the `tendermint_rpc` crate to talk
-to the Tendermint JSON-RPC endpoints, which forward the requests to the Application through ABCI.
+to the CometBFT JSON-RPC endpoints, which forward the requests to the Application through ABCI.
 
 Assuming both processes have been started, see if we can query the state of one of our actors. For this we need the actor address,
 which we saw in the `genesis.json` file earlier.
 
+To make it easier to reuse these addresses, let's store them in variables:
+
+```shell
+ALICE_ADDR=$(cargo run -p fendermint_app --release -- key address --public-key test-network/keys/alice.pk)
+BOB_ADDR=$(cargo run -p fendermint_app --release -- key address --public-key test-network/keys/bob.pk)
+```
+
 ```shell
 cargo run -p fendermint_app --release -- \
-  rpc query actor-state --address f1jqqlnr5b56rnmc34ywp7p7i2lg37ty23s2bmg4y
+  rpc query actor-state --address $ALICE_ADDR
 ```
 
 The state is printed to STDOUT as JSON:
 
 ```console
+$ echo $ALICE_ADDR
+f1i2izmkzef5q6udtdooeujzfsuieybxzl2yer5ey
+$ cargo run -p fendermint_app --release --   rpc query actor-state --address $ALICE_ADDR
 {
   "id": 100,
   "state": {
     "balance": "1000000000000000000",
-    "code": "bafk2bzaceaqi73ey2grdtwgmnl22yj37l6pttsmrqnoc44o6wdqtt5rmpam6y",
+    "code": "bafk2bzacealdyp7dmpc6eir65qhuh2hgv7onmv53rzzyp5futafmjjlxrt6fg",
     "delegated_address": null,
     "sequence": 0,
-    "state": "bafy2bzaceaayg22rmfjw5di7obchf2cdz3yydo32njavenej5uluf7hfatosi"
+    "state": "bafy2bzaceas2zajrutdp7ugb6w2lpmow3z3klr3gzqimxtuz22tkkqallfch4"
   }
 }
 ```
@@ -460,14 +455,14 @@ We can retrieve the raw state of the account with the `ipld` command by using th
 
 ```shell
 cargo run -p fendermint_app --release -- \
-        rpc query ipld --cid bafy2bzaceaayg22rmfjw5di7obchf2cdz3yydo32njavenej5uluf7hfatosi
+        rpc query ipld --cid bafy2bzaceas2zajrutdp7ugb6w2lpmow3z3klr3gzqimxtuz22tkkqallfch4
 ```
 
 The binary contents are printed with Base64 encoding, which we could pipe to a file. It would be more useful to run this query
 programmatically and parse it to the appropriate data structure from [builtin-actors](https://github.com/filecoin-project/builtin-actors).
 
 ```console
-gVUBTCC2x6HvotYLfMWf9/0aWbf541s=
+gVUBRpGWKyQvYeoOY3OJROSyogmA3ys=
 ```
 
 ## Transfer tokens
@@ -477,7 +472,6 @@ The simplest transaction we can do is to transfer tokens from one account to ano
 For example we can send 1000 tokens from Alice to Bob:
 
 ```shell
-BOB_ADDR=$(cargo run -p fendermint_app --release -- key address --public-key test-network/keys/bob.pk)
 cargo run -p fendermint_app --release -- \
   rpc transfer --secret-key test-network/keys/alice.sk --to $BOB_ADDR --sequence 0 --value 1000
 ```
@@ -528,8 +522,6 @@ The `code: 0` parts indicate that both check and delivery were successful. Let's
 $ cargo run -p fendermint_app --release -- rpc query actor-state --address $BOB_ADDR | jq .state.balance
 "1000"
 
-$ ALICE_ADDR=$(cargo run -p fendermint_app --release -- key address --public-key test-network/keys/alice.pk)
-
 $ cargo run -p fendermint_app --release -- rpc query actor-state --address $ALICE_ADDR | jq "{balance: .state.balance, sequence: .state.sequence}"
 {
   "balance": "999999999999999000",
@@ -558,20 +550,24 @@ cargo run -p fendermint_app --release -- \
 Note that now we are using `--sequence 1` because this is the second transaction sent by Alice.
 
 The output shows what addresses have been assigned to the created contract,
-which we can use to call the contract.
+which we can use to call the contract, namely by copying the `delegated_address`.
 
 ```console
-$ cargo run -p fendermint_app --release -- \
+$ CREATE=$(cargo run -p fendermint_app --release -- \
         rpc fevm --secret-key test-network/keys/alice.sk --sequence 1 \
-          create --contract $CONTRACT | jq .return_data
+          create --contract $CONTRACT)
+
+$ echo $CREATE | jq .return_data
 {
-  "actor_address": "f0105",
-  "actor_id": 105,
-  "actor_id_as_eth_address": "ff00000000000000000000000000000000000069",
-  "delegated_address": "f410fsho763qmlcfi6ufnim7sujmbaqyc64b3pzpa7bq",
-  "eth_address": "91ddff6e0c588a8f50ad433f2a258104302f703b",
-  "robust_address": "f2rd3cu2jokusukudmbwotuu4rvoebm45qnze7e6q"
+    "actor_address": "f0105",
+    "actor_id": 105,
+    "actor_id_as_eth_address": "ff00000000000000000000000000000000000069",
+    "delegated_address": "f410f7do6trb2wkh6vwj6wpg5oxpgbipmj6btcc3kipq",
+    "eth_address": "f8dde9c43ab28fead93eb3cdd75de60a1ec4f833",
+    "robust_address": "f2yapgav7dqzifnry3ccqfg3xdzek73zd7rjvwsci"
 }
+
+$ DELEGATED_ADDR=$(echo $CREATE | jq -r .return_data.delegated_address)
 ```
 
 ## Invoke FEVM Contract
@@ -581,11 +577,13 @@ Now that we have a contract deployed, we can call it. The arguments in the follo
 ```console
 $ cargo run -p fendermint_app --release -- \
               rpc fevm --secret-key test-network/keys/alice.sk --sequence 2 \
-                invoke --contract f410fsho763qmlcfi6ufnim7sujmbaqyc64b3pzpa7bq  \
+                invoke --contract $DELEGATED_ADDR  \
                        --method f8b2cb4f --method-args 000000000000000000000000ff00000000000000000000000000000000000064 \
           | jq .return_data
 "0000000000000000000000000000000000000000000000000000000000002710"
 ```
+
+If we look at the [method signatures](https://github.com/filecoin-project/builtin-actors/blob/v10.0.0/actors/evm/tests/contracts/SimpleCoin.signatures#L2) we can see that this is calling [getBalance](https://github.com/filecoin-project/builtin-actors/blob/v10.0.0/actors/evm/tests/contracts/simplecoin.sol#L28), and indeed if we decode `2710` from hexadecimal to decimal, we get the `10000` balance the owner should have.
 
 To avoid having to come up with ABI encoded arguments in hexadecimal format, we can use the RPC client in combination with [ethers](https://docs.rs/crate/ethers/latest) excellent `abigen` functionality.
 
@@ -593,11 +591,11 @@ Here's an [example](../fendermint/rpc/examples/simplecoin.rs) of doing that with
 
 ```console
 $ cargo run -p fendermint_rpc --release --example simplecoin -- --secret-key test-network/keys/alice.sk --verbose
-2023-04-06T11:00:18.287411Z DEBUG fendermint_rpc::client: Using HTTP client to submit request to: http://127.0.0.1:26657/
+2023-05-19T10:18:47.234878Z DEBUG fendermint_rpc::client: Using HTTP client to submit request to: http://127.0.0.1:26657/
 ...
-2023-04-06T11:00:18.586419Z  INFO simplecoin: contract deployed contract_address="f410fiv7rempf2cfdykbfl5xzrjnilgwb3jcgrelnvki" actor_id=107
+2023-05-19T10:18:47.727563Z  INFO simplecoin: contract deployed contract_address="f410fvbmxiqdn6svyo5oubfbzxsorkvydcb5ecmlbwma" actor_id=107
 ...
-2023-04-06T11:00:19.581317Z  INFO simplecoin: owner balance balance="10000" owner_eth_addr="ff00000000000000000000000000000000000064"
+2023-05-19T10:18:48.805085Z  INFO simplecoin: owner balance balance="10000" owner_eth_addr="ff00000000000000000000000000000000000064"
 ```
 
 Note that the script figures out the Alice's nonce on its own, so we don't have to pass it in. It also has an example of running an EVM view method (which is read-only) either as as a distributed read-transaction (which is included on the chain and costs gas) or a query anwered by our node without involving the blockchain. Both have their uses, depending on our level of trust.

--- a/docs/tendermint.md
+++ b/docs/tendermint.md
@@ -2,47 +2,46 @@
 
 To implement the [architecture](./architecture.md) we intend to make use of the following open source components to integrate with Tendermint:
 
-* [Tendermint Core](https://github.com/tendermint/tendermint): The generic blockchain SMR system. In particular we shall use the upcoming [v0.37](https://github.com/tendermint/tendermint/tree/v0.37.0-rc2) version which has the required [extensions](./architecture.md#abci) to [ABCI++](https://github.com/tendermint/tendermint/tree/v0.37.0-rc2/spec/abci). Note that the `tendermint/tendermint` repo is going to be archived; in the future it's possibly going to be developed further at https://github.com/informalsystems/tendermint, and further derivations will be registered at https://github.com/tendermint/ecosystem
-* [tendermint-rs](https://github.com/informalsystems/tendermint-rs/) is a Rust library that contains Tendermint Core [datatypes](https://github.com/informalsystems/tendermint-rs/tree/main/tendermint); the [proto](https://github.com/informalsystems/tendermint-rs/tree/main/proto) code [generated](https://github.com/informalsystems/tendermint-rs/tree/main/tools/proto-compiler) from the Tendermint protobuf definitions; a synchronous [ABCI server](https://github.com/informalsystems/tendermint-rs/tree/main/abci) with a trait the application can implement, with a [KV-store example](https://github.com/informalsystems/tendermint-rs/blob/main/abci/src/application/kvstore/main.rs) familiar from the tutorial; and various other goodies for building docker images, integration testing the application with Tendermint, and so on. Lucky for us there is a [draft PR](https://github.com/informalsystems/tendermint-rs/pull/1193) to compile the protobuf definitions for both the current `v0.34` and the upcoming `v0.37` version, so we can even use that branch as a dependency to get the right data types and not have to do any proto compilation on our end!
-
-Another project worth looking at is Penumbra's [tower-abci](https://github.com/penumbra-zone/tower-abci) which adapts the ABCI interfaces from `tendermint-rs` to be used with [tower](https://crates.io/crates/tower) and has a [server](https://github.com/penumbra-zone/tower-abci/blob/main/src/server.rs) implementation that works with [tokio](https://crates.io/crates/tokio). So, unlike the ABCI server in `tendermint-rs`, this is asynchronous; even if we don't use it, it's easy to follow as an example.
+* [CometBFT](https://github.com/cometbft/cometbft): One of the successors of the generic blockchain SMR system [Tendermint Core](https://github.com/tendermint/tendermint) (others might be listed [here](https://github.com/tendermint/ecosystem)). Originally we used the upcoming [v0.37](https://github.com/tendermint/tendermint/tree/v0.37.0-rc2), but it was eventually released as part of CometBFT. This version has the required [extensions](./architecture.md#abci) to [ABCI++](https://github.com/cometbft/cometbft/tree/v0.37.1/spec/abci).
+* [tendermint-rs](https://github.com/informalsystems/tendermint-rs/) is a Rust library that contains Tendermint [datatypes](https://github.com/informalsystems/tendermint-rs/tree/main/tendermint); the [proto](https://github.com/informalsystems/tendermint-rs/tree/main/proto) code [generated](https://github.com/informalsystems/tendermint-rs/tree/main/tools/proto-compiler) from the Tendermint protobuf definitions; a synchronous [ABCI server](https://github.com/informalsystems/tendermint-rs/tree/main/abci) with a trait the application can implement, with a [KV-store example](https://github.com/informalsystems/tendermint-rs/blob/main/abci/src/application/kvstore/main.rs) familiar from the tutorial; and various other goodies for building docker images, integration testing the application with Tendermint, and so on. Since [this PR](https://github.com/informalsystems/tendermint-rs/pull/1193) the library supports both `v0.34` (the last stable release of Tendermint Core) and the newer `v0.37` version (the two are not wire compatible).
+* [tower-abci](https://github.com/penumbra-zone/tower-abci) from Penumbra adapts the ABCI interfaces from `tendermint-rs` to be used with [tower](https://crates.io/crates/tower) and has a [server](https://github.com/penumbra-zone/tower-abci/blob/v0.7.0/src/v037/server.rs) implementation that works with the the `v0.37` wire format and uses [tokio](https://crates.io/crates/tokio). So, unlike the ABCI server in `tendermint-rs`, this is asynchronous, which we can make use of if we want to inject our own networking.
 
 That should be enough to get us started with Tendermint.
 
 
-## Install Tendermint Core
+## Install CometBFT
 
-We will need Tendermint Core running and building the blockchain, and since we don't want to fork it, we can install the pre-packaged `tendermint` binary from the [releases](https://github.com/tendermint/tendermint/releases). At the time of this writing, our target is the [v0.37.0-rc2](https://github.com/tendermint/tendermint/releases/tag/v0.37.0-rc2) pre-release.
+We will need ~~Tendermint Core~~ CometBFT running and building the blockchain, and since we don't want to fork it, we can install the pre-packaged `cometbft` binary from the [releases](https://github.com/cometbft/cometbft/releases). At the time of this writing, our target is the [v0.37.1](https://github.com/cometbft/cometbft/releases/tag/v0.37.1) release, and things should work with the `v0.37.0-rc2` version of Tendermint Core as well.
 
-Alternatively, we can [install](https://github.com/tendermint/tendermint/blob/main/docs/introduction/install.md) the project from source. I expect to have to dig around in the source code to understand the finer nuances, so this is what I'll do. It needs `go` 1.18 or higher [installed](https://go.dev/doc/install) (check with `go version`).
+Alternatively, we can [install](https://github.com/cometbft/cometbft/blob/main/docs/guides/install.md) the project from source. I expect to have to dig around in the source code to understand the finer nuances, so this is what I'll do. It needs `go` 1.18 or higher [installed](https://go.dev/doc/install) (check with `go version`).
 
 The following code downloads the source, checks out the branch with the necessary ABCI++ features, and installs it.
 ```shell
-git clone https://github.com/tendermint/tendermint.git
-cd tendermint
-git checkout v0.37.0-rc2
+git clone https://github.com/cometbft/cometbft.git
+cd cometbft
+git checkout v0.37.1
 make install
 ```
 
 Check that the installation worked:
 
 ```console
-$ tendermint version
-v0.37.0-rc2
+$ cometbft version
+0.37.1+2af25aea6
 ```
 
-After this we can follow the [quick start guide](https://github.com/tendermint/tendermint/blob/main/docs/introduction/quick-start.md#initialization) to initialize a local node and try out the venerable `kvstore` application.
+After this we can follow the [quick start guide](https://github.com/cometbft/cometbft/blob/main/docs/guides/quick-start.md#initialization) to initialize a local node and try out the venerable `kvstore` application.
 
-Create the genesis files under `$HOME/.tendermint`:
+Create the genesis files under `$HOME/.cometbft`:
 
 ```shell
-tendermint init
+cometbft init
 ```
 
 Start a node; we'll see blocks being created every second:
 
 ```shell
-tendermint node --proxy_app=kvstore
+cometbft node --proxy_app=kvstore
 ```
 
 Then, from another terminal, send a transaction:
@@ -53,10 +52,11 @@ curl -s 'localhost:26657/broadcast_tx_commit?tx="foo=bar"'
 
 Finally, query the value of the key we just added:
 
-```console
-$ curl -s 'localhost:26657/abci_query?data="foo"' | jq -r ".result.response.value | @base64d"
-bar
+```shell
+curl -s 'localhost:26657/abci_query?data="foo"' | jq -r ".result.response.value | @base64d"
 ```
+
+We should see `bar` printed on the console.
 
 Nice! The status of the node can be checked like so:
 
@@ -67,17 +67,23 @@ curl -s localhost:26657/status
 To start from a clean slate, we can just clear out the data directory and run `tendermint init` again:
 
 ```shell
-rm -rf ~/.tendermint
+rm -rf ~/.cometbft
+```
+
+Alternatively, once we have our own genesis set up, we can discard just the blockchain data with the following command:
+
+```shell
+cometbft unsafe-reset-all
 ```
 
 ## Sanity check the Rust libraries
 
-This is an optional step to check that the branch that we'll need to be using from `tendermint-rs` works with our chosen version of `tendermint`. In practice we'll just add a library reference to the github project until it's released, we don't have to clone the project. But it's useful to do so, to get familiar with the code.
+This is an optional step to check that the branch that we'll need to be using from `tendermint-rs` works with our chosen version of `cometbft`. In practice we'll just add a library reference to the github project until it's released, we don't have to clone the project. But it's useful to do so, to get familiar with the code.
 
 ```shell
 git clone git@github.com:informalsystems/tendermint-rs.git
 cd tendermint-rs
-git checkout origin/mikhail/multi-tc-version-support
+git checkout v0.31.0
 ```
 
 Then, go into the `abci` crate to try the [example](https://github.com/informalsystems/tendermint-rs/tree/main/abci#examples) with the `kvstore` that, unlike previously, will run external to `tendermint`:
@@ -92,102 +98,75 @@ Build and run the store:
 cargo run --bin kvstore-rs --features binary,kvstore-app
 ```
 
-Go back to the terminal we used to run `tendermint` and do what they suggest.
+Go back to the terminal we used to run `cometbft` and do what they suggest.
 
 First ensure we have the genesis files:
 
 ```shell
-tendermint init
+cometbft init
 ```
 
 Then try to run Tendermint; it's supposed to connect to `127.0.0.1:26658` where the store is running, and bind itself to `127.0.0.1:26657`:
 
 ```shell
-tendermint unsafe_reset_all && tendermint start
+cometbft unsafe-reset-all && cometbft start
 ```
 
-Unfortunately this doesn't seem to work. In the Tendermint logs we see the process stopping with an error message:
+This seems to work; in the CometBFT logs we see the process producing blocks:
 
 ```console
-$ tendermint start
-I[2023-01-11|10:30:13.757] service start                                module=proxy msg="Starting multiAppConn service" impl=multiAppConn
-I[2023-01-11|10:30:13.757] service start                                module=abci-client connection=query msg="Starting socketClient service" impl=socketClient
+❯ cometbft unsafe-reset-all && cometbft start
 ...
-E[2023-01-11|10:30:13.777] Stopping abci.socketClient for error: read message: read tcp 127.0.0.1:35778->127.0.0.1:26658: read: connection reset by peer module=abci-client connection=query
-I[2023-01-11|10:30:13.777] service stop                                 module=abci-client connection=query msg="Stopping socketClient service" impl=socketClient
-E[2023-01-11|10:30:13.777] query connection terminated. Did the application crash? Please restart tendermint module=proxy err="read message: read tcp 127.0.0.1:35778->127.0.0.1:26658: read: connection reset by peer"
-fish: Job 1, 'tendermint start' terminated by signal SIGTERM (Polite quit request)
+I[2023-05-19|09:22:50.094] ABCI Handshake App Info                      module=consensus height=0 hash=00000000000000000000000000000000 software-version=0.1.0 protocol-version=1
+I[2023-05-19|09:22:50.094] ABCI Replay Blocks                           module=consensus appHeight=0 storeHeight=0 stateHeight=0
+I[2023-05-19|09:22:50.097] Completed ABCI Handshake - CometBFT and App are synced module=consensus appHeight=0 appHash=00000000000000000000000000000000
+...
+I[2023-05-19|09:22:53.193] received complete proposal block             module=consensus height=3 hash=CBAEA6A06C09F6E5D5D4C09315EBFA770FE75E165CDABABD95F91DBFF6E6AFF2
+I[2023-05-19|09:22:53.208] finalizing commit of block                   module=consensus height=3 hash=CBAEA6A06C09F6E5D5D4C09315EBFA770FE75E165CDABABD95F91DBFF6E6AFF2 root=00 num_txs=0
+I[2023-05-19|09:22:53.215] executed block                               module=state height=3 num_valid_txs=0 num_invalid_txs=0
+I[2023-05-19|09:22:53.222] committed state                              module=state height=3 num_txs=0 app_hash=00
+I[2023-05-19|09:22:53.229] indexed block exents                         module=txindex height=3
+...
 ```
 
 We can see the opposite side of the error in the console of the store:
 
 ```console
-$ cargo run --bin kvstore-rs --features binary,kvstore-app
-   ...
-2023-01-11T10:30:13.757461Z  INFO tendermint_abci::server: Incoming connection from: 127.0.0.1:35778
-2023-01-11T10:30:13.757808Z  INFO tendermint_abci::server: Incoming connection from: 127.0.0.1:35792
-2023-01-11T10:30:13.758160Z  INFO tendermint_abci::server: Incoming connection from: 127.0.0.1:35808
-2023-01-11T10:30:13.758581Z  INFO tendermint_abci::server: Incoming connection from: 127.0.0.1:35816
-2023-01-11T10:30:13.759077Z  INFO tendermint_abci::server: Listening for incoming requests from 127.0.0.1:35816
-2023-01-11T10:30:13.759632Z  INFO tendermint_abci::server: Listening for incoming requests from 127.0.0.1:35778
-2023-01-11T10:30:13.760138Z  INFO tendermint_abci::server: Listening for incoming requests from 127.0.0.1:35792
-2023-01-11T10:30:13.760395Z  INFO tendermint_abci::server: Listening for incoming requests from 127.0.0.1:35808
-2023-01-11T10:30:13.777266Z ERROR tendermint_abci::server: Failed to read incoming request from client 127.0.0.1:35778: error encoding protocol buffer
-
-Caused by:
-    failed to decode Protobuf message: Request.value: buffer underflow
-
-Location:
-    /home/aakoshh/.cargo/registry/src/github.com-1ecc6299db9ec823/flex-error-0.4.4/src/tracer_impl/eyre.rs:10:9
-2023-01-11T10:30:13.781317Z  INFO tendermint_abci::server: Client 127.0.0.1:35816 terminated stream
-2023-01-11T10:30:13.781337Z  INFO tendermint_abci::server: Client 127.0.0.1:35808 terminated stream
-2023-01-11T10:30:13.781351Z  INFO tendermint_abci::server: Client 127.0.0.1:35792 terminated stream
+❯ cargo run --bin kvstore-rs --features binary,kvstore-app
+    ...
+2023-05-19T08:22:14.247867Z  INFO tendermint_abci::server: ABCI server running at 127.0.0.1:26658
+2023-05-19T08:22:50.079635Z  INFO tendermint_abci::server: Incoming connection from: 127.0.0.1:44564
+2023-05-19T08:22:50.079749Z  INFO tendermint_abci::server: Incoming connection from: 127.0.0.1:44572
+2023-05-19T08:22:50.079843Z  INFO tendermint_abci::server: Listening for incoming requests from 127.0.0.1:44564
+2023-05-19T08:22:50.079879Z  INFO tendermint_abci::server: Incoming connection from: 127.0.0.1:44576
+2023-05-19T08:22:50.079887Z  INFO tendermint_abci::server: Listening for incoming requests from 127.0.0.1:44572
+2023-05-19T08:22:50.079996Z  INFO tendermint_abci::server: Incoming connection from: 127.0.0.1:44590
+2023-05-19T08:22:50.080002Z  INFO tendermint_abci::server: Listening for incoming requests from 127.0.0.1:44576
+2023-05-19T08:22:50.080110Z  INFO tendermint_abci::server: Listening for incoming requests from 127.0.0.1:44590
+2023-05-19T08:22:51.154772Z  INFO tendermint_abci::application::kvstore: Committed height 1
+2023-05-19T08:22:52.183919Z  INFO tendermint_abci::application::kvstore: Committed height 2
+2023-05-19T08:22:53.222453Z  INFO tendermint_abci::application::kvstore: Committed height 3
+...
 ```
 
-We can try it with the latest stable version of Tendermint:
+Try to send a transaction:
+
+```console
+❯ curl 'http://127.0.0.1:26657/broadcast_tx_async?tx="somekey=somevalue"'
+{"jsonrpc":"2.0","id":-1,"result":{"code":0,"data":"","log":"","codespace":"","hash":"17ED61261A5357FEE7ACDE4FAB154882A346E479AC236CFB2F22A2E8870A9C3D"}}
+```
+
+and a query:
+
+```console
+❯ curl 'http://127.0.0.1:26657/abci_query?data=0x736f6d656b6579'
+{"jsonrpc":"2.0","id":-1,"result":{"response":{"code":0,"log":"exists","info":"","index":"0","key":"c29tZWtleQ==","value":"c29tZXZhbHVl","proofOps":null,"height":"300","codespace":""}}}
+```
+
+All balls!
+
+Now just make sure we clean up the compilation artifacts:
 
 ```shell
-cd tendermint
-git checkout v0.34.24
-make install
-rm ~/.tendermint
-tendermint init
+cargo clean
 ```
-
-With this version, Tendermint is able to start:
-
-```console
-❯ tendermint unsafe_reset_all && tendermint start
-Deprecated: snake_case commands will be replaced by hyphen-case commands in the next major release
-I[2023-01-11|10:51:31.856] Removed all blockchain history               module=main dir=/home/aakoshh/.tendermint/data
-I[2023-01-11|10:51:31.870] Reset private validator file to genesis state module=main keyFile=/home/aakoshh/.tendermint/config/priv_validator_key.json stateFile=/home/aakoshh/.tendermint/data/priv_validator_state.json
-I[2023-01-11|10:51:31.978] service start                                module=proxy msg="Starting multiAppConn service" impl=multiAppConn
-I[2023-01-11|10:51:31.978] service start                                module=abci-client connection=query msg="Starting socketClient service" impl=socketClient
-I[2023-01-11|10:51:31.978] service start                                module=abci-client connection=snapshot msg="Starting socketClient service" impl=socketClient
-I[2023-01-11|10:51:31.978] service start                                module=abci-client connection=mempool msg="Starting socketClient service" impl=socketClient
-I[2023-01-11|10:51:31.978] service start                                module=abci-client connection=consensus msg="Starting socketClient service" impl=socketClient
-I[2023-01-11|10:51:31.978] service start                                module=events msg="Starting EventBus service" impl=EventBus
-I[2023-01-11|10:51:31.978] service start                                module=pubsub msg="Starting PubSub service" impl=PubSub
-I[2023-01-11|10:51:31.993] service start                                module=txindex msg="Starting IndexerService service" impl=IndexerService
-I[2023-01-11|10:51:31.994] ABCI Handshake App Info                      module=consensus height=0 hash=00000000000000000000000000000000 software-version=0.1.0 protocol-version=1
-I[2023-01-11|10:51:31.994] ABCI Replay Blocks                           module=consensus appHeight=0 storeHeight=0 stateHeight=0
-I[2023-01-11|10:51:31.998] Completed ABCI Handshake - Tendermint and App are synced module=consensus appHeight=0 appHash=00000000000000000000000000000000
-I[2023-01-11|10:51:31.998] Version info                                 module=main tendermint_version=v0.34.24 block=11 p2p=8
-...
-```
-
-And we can see commits in the ABCI server:
-
-```console
-...
-2023-01-11T10:51:31.979523Z  INFO tendermint_abci::server: Listening for incoming requests from 127.0.0.1:57168
-2023-01-11T10:51:33.064188Z  INFO tendermint_abci::application::kvstore: Committed height 1
-2023-01-11T10:51:34.091852Z  INFO tendermint_abci::application::kvstore: Committed height 2
-...
-```
-
-So it looks like something changed during the `0.34` to `0.37` transition in the Protobuf encoding that the decoder doesn't expect. We'll have to find out what and fix it.
-
-As it turned out the reason was the change in the length encoding between the two versions of Tendermint: going from `varint` to `varuint`. This is something that has been updated before in `tendermint-rs` when `0.35` was being adopted, before it was subsequently abandoned; but the fix was easy to find on Github.
-
-On further delibration `tower-abci` seems to have plenty of benefits; updating it to work with the draft version of `tendermint-rs` and the `0.37` pre-release only required a [few changes](https://github.com/consensus-shipyard/tower-abci/pull/1), so that's what we're aiming to go with.

--- a/fendermint/abci/examples/kvstore.rs
+++ b/fendermint/abci/examples/kvstore.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use fendermint_abci::{AbciResult as Result, Application, ApplicationService};
 use structopt::StructOpt;
 use tendermint::abci::{request, response, Event, EventAttributeIndexExt};
-use tower_abci::{split, Server};
+use tower_abci::{split, v037::Server};
 use tracing::{info, Level};
 
 /// In-memory, hashmap-backed key-value store ABCI application.

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -18,11 +18,13 @@ hex = { workspace = true }
 k256 = { workspace = true }
 libsecp256k1 = { workspace = true }
 num-traits = { workspace = true }
+prost = { workspace = true }
 rand_chacha = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tendermint = { workspace = true }
 tendermint-rpc = { workspace = true }
+tendermint-proto = { workspace = true }
 tokio = { workspace = true }
 tower-abci = { workspace = true }
 tracing = { workspace = true }

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -423,7 +423,7 @@ where
 
         let response = match result {
             Err(e) => invalid_query(AppError::InvalidEncoding, e.description),
-            Ok(result) => to_query(result, block_height),
+            Ok(result) => to_query(result, block_height)?,
         };
         Ok(response)
     }

--- a/fendermint/app/src/cmd/key.rs
+++ b/fendermint/app/src/cmd/key.rs
@@ -41,7 +41,7 @@ cmd! {
   KeyIntoTendermintArgs(self) {
     let sk = read_secret_key(&self.secret_key)?;
     let pk = PublicKey::from_secret_key(&sk);
-    let vk = k256::ecdsa::VerifyingKey::from_sec1_bytes(&pk.serialize())?;
+    let vk = tendermint::crypto::default::ecdsa_secp256k1::VerifyingKey::from_sec1_bytes(&pk.serialize())?;
     let pub_key = tendermint::PublicKey::Secp256k1(vk);
     let address = tendermint::account::Id::from(pub_key);
 

--- a/fendermint/app/src/cmd/key.rs
+++ b/fendermint/app/src/cmd/key.rs
@@ -1,7 +1,7 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use fvm_shared::address::Address;
 use libsecp256k1::{PublicKey, SecretKey};
 use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
@@ -41,7 +41,8 @@ cmd! {
   KeyIntoTendermintArgs(self) {
     let sk = read_secret_key(&self.secret_key)?;
     let pk = PublicKey::from_secret_key(&sk);
-    let vk = tendermint::crypto::default::ecdsa_secp256k1::VerifyingKey::from_sec1_bytes(&pk.serialize())?;
+    let vk = tendermint::crypto::default::ecdsa_secp256k1::VerifyingKey::from_sec1_bytes(&pk.serialize())
+      .map_err(|e| anyhow!("failed to convert public key: {e}"))?;
     let pub_key = tendermint::PublicKey::Secp256k1(vk);
     let address = tendermint::account::Id::from(pub_key);
 

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -44,7 +44,7 @@ async fn run(settings: Settings) -> anyhow::Result<()> {
         tower_abci::split::service(service, settings.abci.bound);
 
     // Hand those components to the ABCI server. This is where tower layers could be added.
-    let server = tower_abci::Server::builder()
+    let server = tower_abci::v037::Server::builder()
         .consensus(consensus)
         .snapshot(snapshot)
         .mempool(mempool)

--- a/fendermint/app/src/tmconv.rs
+++ b/fendermint/app/src/tmconv.rs
@@ -198,7 +198,10 @@ pub fn to_validator_updates(
     let mut updates = vec![];
     for v in validators {
         let bz = v.public_key.0.serialize();
-        let key = tendermint::crypto::default::ecdsa_secp256k1::VerifyingKey::from_sec1_bytes(&bz)?;
+
+        let key = tendermint::crypto::default::ecdsa_secp256k1::VerifyingKey::from_sec1_bytes(&bz)
+            .map_err(|e| anyhow!("failed to convert public key: {e}"))?;
+
         updates.push(tendermint::validator::Update {
             pub_key: tendermint::public_key::PublicKey::Secp256k1(key),
             power: tendermint::vote::Power::try_from(v.power.0)?,

--- a/fendermint/app/src/tmconv.rs
+++ b/fendermint/app/src/tmconv.rs
@@ -1,22 +1,24 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 //! Conversions to Tendermint data types.
+use anyhow::{anyhow, Context};
 use fendermint_vm_genesis::Validator;
 use fendermint_vm_interpreter::{
     fvm::{FvmApplyRet, FvmCheckRet, FvmQueryRet},
     Timestamp,
 };
 use fvm_shared::{error::ExitCode, event::StampedEvent};
+use prost::Message;
 use std::num::NonZeroU32;
 use tendermint::abci::{response, Code, Event, EventAttribute};
 
 use crate::{app::AppError, BlockHeight};
 
 /// IPLD encoding of data types we know we must be able to encode.
-macro_rules! must_encode {
+macro_rules! ipld_encode {
     ($var:ident) => {
         fvm_ipld_encoding::to_vec(&$var)
-            .unwrap_or_else(|e| panic!("error encoding {}: {}", stringify!($var), e))
+            .map_err(|e| anyhow!("error IPLD encoding {}: {}", stringify!($var), e))?
     };
 }
 
@@ -133,7 +135,7 @@ pub fn to_events(kind: &str, stamped_events: Vec<StampedEvent>) -> Vec<Event> {
 }
 
 /// Map to query results.
-pub fn to_query(ret: FvmQueryRet, block_height: BlockHeight) -> response::Query {
+pub fn to_query(ret: FvmQueryRet, block_height: BlockHeight) -> anyhow::Result<response::Query> {
     let exit_code = match ret {
         FvmQueryRet::Ipld(None) | FvmQueryRet::ActorState(None) => ExitCode::USR_NOT_FOUND,
         FvmQueryRet::Ipld(_) | FvmQueryRet::ActorState(_) => ExitCode::OK,
@@ -151,35 +153,42 @@ pub fn to_query(ret: FvmQueryRet, block_height: BlockHeight) -> response::Query 
         FvmQueryRet::Ipld(Some(bz)) => (Vec::new(), bz),
         FvmQueryRet::ActorState(Some(x)) => {
             let (id, st) = *x;
-            let k = must_encode!(id);
-            let v = must_encode!(st);
+            let k = ipld_encode!(id);
+            let v = ipld_encode!(st);
             (k, v)
         }
         FvmQueryRet::Call(ret) => {
             // Send back an entire Tendermint deliver_tx response, encoded as IPLD.
             // This is so there is a single representation of a call result, instead
             // of a normal delivery being one way and a query exposing `FvmApplyRet`.
-            let r = to_deliver_tx(ret);
-            let v = must_encode!(r);
+            let dtx = to_deliver_tx(ret);
+            let dtx = tendermint_proto::abci::ResponseDeliverTx::from(dtx);
+            let mut buf = bytes::BytesMut::new();
+            dtx.encode(&mut buf)?;
+            let bz = buf.to_vec();
+            // So the value is an IPLD encoded Protobuf byte vector.
+            let v = ipld_encode!(bz);
             (Vec::new(), v)
         }
         FvmQueryRet::EstimateGas(est) => {
-            let v = must_encode!(est);
+            let v = ipld_encode!(est);
             (Vec::new(), v)
         }
     };
 
     // The height here is the height of the block that was committed, not in which the app hash appeared.
-    let height = tendermint::block::Height::try_from(block_height).expect("height too big");
+    let height = tendermint::block::Height::try_from(block_height).context("height too big")?;
 
-    response::Query {
+    let res = response::Query {
         code: to_code(exit_code),
         info: to_error_msg(exit_code).to_owned(),
         key: key.into(),
         value: value.into(),
         height,
         ..Default::default()
-    }
+    };
+
+    Ok(res)
 }
 
 /// Project Genesis validators to Tendermint.
@@ -189,7 +198,7 @@ pub fn to_validator_updates(
     let mut updates = vec![];
     for v in validators {
         let bz = v.public_key.0.serialize();
-        let key = k256::ecdsa::VerifyingKey::from_sec1_bytes(&bz)?;
+        let key = tendermint::crypto::default::ecdsa_secp256k1::VerifyingKey::from_sec1_bytes(&bz)?;
         updates.push(tendermint::validator::Update {
             pub_key: tendermint::public_key::PublicKey::Secp256k1(key),
             power: tendermint::vote::Power::try_from(v.power.0)?,

--- a/fendermint/rpc/Cargo.toml
+++ b/fendermint/rpc/Cargo.toml
@@ -12,9 +12,11 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
 libsecp256k1 = { workspace = true }
+prost = { workspace = true }
 serde = { workspace = true }
 tendermint = { workspace = true }
 tendermint-rpc = { workspace = true }
+tendermint-proto = { workspace = true }
 tracing = { workspace = true }
 
 cid = { workspace = true }

--- a/fendermint/rpc/src/client.rs
+++ b/fendermint/rpc/src/client.rs
@@ -8,8 +8,7 @@ use async_trait::async_trait;
 use fendermint_vm_message::chain::ChainMessage;
 use tendermint::abci::response::DeliverTx;
 use tendermint::block::Height;
-use tendermint_rpc::v0_37::Client;
-use tendermint_rpc::{endpoint::abci_query::AbciQuery, HttpClient, Scheme, Url};
+use tendermint_rpc::{endpoint::abci_query::AbciQuery, Client, HttpClient, Scheme, Url};
 
 use fendermint_vm_message::query::FvmQuery;
 

--- a/fendermint/testing/smoke-test/Makefile.toml
+++ b/fendermint/testing/smoke-test/Makefile.toml
@@ -1,8 +1,8 @@
 [env]
 NETWORK_NAME = "smoke"
-TM_CONTAINER_NAME = "smoke-tendermint"
+CMT_CONTAINER_NAME = "smoke-cometbft"
 FM_CONTAINER_NAME = "smoke-fendermint"
-TM_DOCKER_IMAGE = "tendermint/tendermint:v0.37.0-rc2"
+CMT_DOCKER_IMAGE = "cometbft/cometbft:v0.37.x"
 FM_DOCKER_IMAGE = "fendermint:latest"
 TEST_DATA_DIR = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/fendermint/testing/smoke-test/test-data"
 TEST_SCRIPTS_DIR = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/fendermint/testing/smoke-test/scripts"
@@ -26,10 +26,10 @@ run_task = { name = [
 dependencies = [
   "test-data-dir",
   "network-create",
-  "tendermint-init",
+  "cometbft-init",
   "fendermint-init",
   "fendermint-start",
-  "tendermint-start",
+  "cometbft-start",
   "wait",
 ]
 
@@ -39,8 +39,8 @@ dependencies = ["simplecoin-example"]
 [tasks.teardown]
 # `dependencies` doesn't seem to work with `cleanup_task`.
 run_task = { name = [
-  "tendermint-stop",
-  "tendermint-rm",
+  "cometbft-stop",
+  "cometbft-rm",
   "fendermint-stop",
   "fendermint-rm",
   "network-rm",
@@ -60,7 +60,7 @@ cargo run -p fendermint_rpc --release --example simplecoin -- \
 [tasks.test-data-dir]
 script = """
 mkdir -p ${TEST_DATA_DIR}/fendermint;
-mkdir -p ${TEST_DATA_DIR}/tendermint;
+mkdir -p ${TEST_DATA_DIR}/cometbft;
 """
 
 [tasks.test-data-dir-rm]
@@ -69,34 +69,34 @@ rm -rf ${TEST_DATA_DIR}
 """
 
 
-[tasks.tendermint-pull]
+[tasks.cometbft-pull]
 command = "docker"
-args = ["pull", "${TM_DOCKER_IMAGE}"]
+args = ["pull", "${CMT_DOCKER_IMAGE}"]
 
-[tasks.tendermint-init]
-extend = "tendermint-run"
+[tasks.cometbft-init]
+extend = "cometbft-run"
 env = { "CMD" = "init", "FLAGS" = "-a STDOUT -a STDERR" }
 
-[tasks.tendermint-start]
-extend = "tendermint-run"
+[tasks.cometbft-start]
+extend = "cometbft-run"
 env = { "CMD" = "start", "FLAGS" = "-d" }
 
-[tasks.tendermint-run]
+[tasks.cometbft-run]
 script = """
 docker run \
   ${FLAGS} \
   --rm \
-  --name ${TM_CONTAINER_NAME} \
+  --name ${CMT_CONTAINER_NAME} \
   --user $(id -u) \
   --network ${NETWORK_NAME} \
   --publish 26657:${HOST_RPC_PORT} \
-  --volume ${TEST_DATA_DIR}/tendermint:/tendermint \
-  --env TM_PROXY_APP=tcp://${FM_CONTAINER_NAME}:26658 \
-  --env TM_PEX=false \
-  ${TM_DOCKER_IMAGE} \
+  --volume ${TEST_DATA_DIR}/cometbft:/cometbft \
+  --env CMT_PROXY_APP=tcp://${FM_CONTAINER_NAME}:26658 \
+  --env CMT_PEX=false \
+  ${CMT_DOCKER_IMAGE} \
   ${CMD}
 """
-dependencies = ["tendermint-pull", "test-data-dir", "network-create"]
+dependencies = ["cometbft-pull", "test-data-dir", "network-create"]
 
 
 [tasks.fendermint-init]
@@ -135,13 +135,13 @@ command = "docker"
 args = ["network", "rm", "${NETWORK_NAME}"]
 ignore_errors = true
 
-[tasks.tendermint-rm]
+[tasks.cometbft-rm]
 extend = "docker-rm"
-env = { "CONTAINER_NAME" = "${TM_CONTAINER_NAME}" }
+env = { "CONTAINER_NAME" = "${CMT_CONTAINER_NAME}" }
 
-[tasks.tendermint-stop]
+[tasks.cometbft-stop]
 extend = "docker-stop"
-env = { "CONTAINER_NAME" = "${TM_CONTAINER_NAME}" }
+env = { "CONTAINER_NAME" = "${CMT_CONTAINER_NAME}" }
 
 [tasks.fendermint-rm]
 extend = "docker-rm"

--- a/fendermint/testing/smoke-test/scripts/init.sh
+++ b/fendermint/testing/smoke-test/scripts/init.sh
@@ -2,8 +2,11 @@
 
 # Create test artifacts, which is basically the Tendermint genesis file.
 
-KEYS_DIR=/data/fendermint/keys
-GENESIS_FILE=/data/fendermint/genesis.json
+CMT_DIR=/data/cometbft
+FM_DIR=/data/fendermint
+
+KEYS_DIR=$FM_DIR/keys
+GENESIS_FILE=$FM_DIR/genesis.json
 
 # Create a genesis file
 fendermint genesis --genesis-file $GENESIS_FILE new --network-name smoke --base-fee 1000  --timestamp 1680101412
@@ -34,12 +37,12 @@ fendermint \
   genesis --genesis-file $GENESIS_FILE \
   add-validator --public-key $KEYS_DIR/bob.pk --power 1
 
-# Convert FM genesis to TM
+# Convert FM genesis to CMT
 fendermint \
   genesis --genesis-file $GENESIS_FILE \
-  into-tendermint --out /data/tendermint/config/genesis.json
+  into-tendermint --out $CMT_DIR/config/genesis.json
 
-# Convert FM validator key to TM
+# Convert FM validator key to CMT
 fendermint \
   key into-tendermint --secret-key $KEYS_DIR/bob.sk \
-    --out /data/tendermint/config/priv_validator_key.json
+    --out $CMT_DIR/config/priv_validator_key.json

--- a/fendermint/vm/message/src/chain.rs
+++ b/fendermint/vm/message/src/chain.rs
@@ -12,7 +12,7 @@ use crate::signed::SignedMessage;
 /// signed by BLS signatures are aggregated to the block level, and their original
 /// signatures are stripped from the messages, to save space. Tendermint Core will
 /// not do this for us (perhaps with ABCI++ Vote Extensions we could do it), though.
-#[derive(Clone, Debug, Serialize, Deserialize, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ChainMessage {
     /// A message that can be passed on to the FVM as-is.
     Signed(Box<SignedMessage>),


### PR DESCRIPTION
Closes #107 

- [x]  Switch to official `tendermint-rs` release
- [x] Update docs to use new [install](https://github.com/cometbft/cometbft/blob/main/docs/guides/install.md) instructions and change the commands to `cometbft` instead of `tendermint`
- [x] Use `cometbft` docker image (there is a `0.37.x` tag) in e2e tests

As a side effect of catching up with `tendermint-rs`, I had to change what the `FvmQuery::Call` ABCI query gets back in response. This is the one that is running a transaction in a local read-only fashion. Previously I returned an IPLD encoded `DeliverTx` construct from `tendermint-rs` itself, so that the client library has the same fields and data types to work with when it comes to seeing transaction results. However, the `Deserialize` trait was removed from this type, so while I could turn it into bytes with `fvm_ipld_encoding`, there wasn't a way to get it back. Apparently they introduced a `dialect` module which will have complete `serde` support, it's generic in its even payloads, which is where I guess there were some differences across consumers. 

To get around this problem, I am now turning the `DeliverTx` into protobuf bytes, and encode that as IPLD (not needed but everything else is IPLD). I thought this is actually better because at least the ABCI protobuf is available to all consumers, although it might be a bad idea to push that dependency to consumers. If push comes to shove we can come up with a DTO, but it needs to duplicate events too. Or we can look at this `dialect`, but that's specific to this Rust library. Our RPC client hides this craziness from the consumer.