### PR TITLE
FM-112: Use a namespace for state store

### DIFF
--- a/fendermint/rocksdb/src/blockstore.rs
+++ b/fendermint/rocksdb/src/blockstore.rs
@@ -1,8 +1,11 @@
+use std::sync::Arc;
+
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
+use anyhow::anyhow;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use rocksdb::WriteBatchWithTransaction;
+use rocksdb::{BoundColumnFamily, OptimisticTransactionDB, WriteBatchWithTransaction};
 
 use crate::RocksDb;
 
@@ -15,6 +18,7 @@ impl Blockstore for RocksDb {
         Ok(self.write(k.to_bytes(), block)?)
     }
 
+    // Called by the BufferedBlockstore during flush.
     fn put_many_keyed<D, I>(&self, blocks: I) -> anyhow::Result<()>
     where
         Self: Sized,
@@ -34,6 +38,59 @@ impl Blockstore for RocksDb {
 
         // For some reason with the `write_without_wal` version if I restart the application
         // it doesn't find the manifest root.
+        Ok(self.db.write(batch)?)
+    }
+}
+
+/// A [`Blockstore`] implementation that writes to a specific namespace, not the default like above.
+#[derive(Clone)]
+pub struct NamespaceBlockstore {
+    db: Arc<OptimisticTransactionDB>,
+    ns: String,
+}
+
+impl NamespaceBlockstore {
+    pub fn new(db: RocksDb, ns: String) -> anyhow::Result<Self> {
+        // All namespaces are pre-created during open.
+        if !db.has_cf_handle(&ns) {
+            Err(anyhow!("namespace {ns} does not exist!"))
+        } else {
+            Ok(Self { db: db.db, ns })
+        }
+    }
+
+    // Unfortunately there doesn't seem to be a way to avoid having to
+    // clone another instance for each operation :(
+    fn cf(&self) -> anyhow::Result<Arc<BoundColumnFamily>> {
+        self.db
+            .cf_handle(&self.ns)
+            .ok_or_else(|| anyhow!("namespace {} does not exist!", self.ns))
+    }
+}
+
+impl Blockstore for NamespaceBlockstore {
+    fn get(&self, k: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
+        Ok(self.db.get_cf(&self.cf()?, k.to_bytes())?)
+    }
+
+    fn put_keyed(&self, k: &Cid, block: &[u8]) -> anyhow::Result<()> {
+        Ok(self.db.put_cf(&self.cf()?, k.to_bytes(), block)?)
+    }
+
+    // Called by the BufferedBlockstore during flush.
+    fn put_many_keyed<D, I>(&self, blocks: I) -> anyhow::Result<()>
+    where
+        Self: Sized,
+        D: AsRef<[u8]>,
+        I: IntoIterator<Item = (Cid, D)>,
+    {
+        let cf = self.cf()?;
+        let mut batch = WriteBatchWithTransaction::<true>::default();
+        for (cid, v) in blocks.into_iter() {
+            let k = cid.to_bytes();
+            let v = v.as_ref();
+            batch.put_cf(&cf, k, v);
+        }
         Ok(self.db.write(batch)?)
     }
 }

--- a/fendermint/rocksdb/src/lib.rs
+++ b/fendermint/rocksdb/src/lib.rs
@@ -3,7 +3,7 @@
 mod rocks;
 
 #[cfg(feature = "blockstore")]
-mod blockstore;
+pub mod blockstore;
 #[cfg(feature = "kvstore")]
 mod kvstore;
 


### PR DESCRIPTION
Closes #112 

Added a `NamespaceBlockstore` to separate the data that is only supposed to be writeable for actors. In the future the IPLD Resolver should use its own namespace to write data, but it can also use this one to read data.