### PR TITLE
FM-99: Ethereum API facade entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1660,6 +1709,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "erased-serde"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2b0c2380453a92ea8b6c8e5f64ecaafccddde8ceab55ff7a8ac1029f894569"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,6 +2099,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba569491c70ec8471e34aa7e9c0b9e82bb5d2464c0398442d17d3c4af814e5a"
 
 [[package]]
+name = "extensions"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258f70bd2b060d448403a66d420e81dcac3e5247a4928a887404a5e03715e2e0"
+dependencies = [
+ "fxhash",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2110,6 +2177,7 @@ dependencies = [
  "config 0.13.3",
  "dirs",
  "fendermint_abci",
+ "fendermint_eth_api",
  "fendermint_rocksdb",
  "fendermint_rpc",
  "fendermint_storage",
@@ -2141,6 +2209,16 @@ dependencies = [
  "tower-abci",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "fendermint_eth_api"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "jsonrpc-v2",
+ "tracing",
 ]
 
 [[package]]
@@ -3403,6 +3481,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-v2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b2a38e4b2dc33f5bfe487781a5e82d0c60ab2b7f2fa1f132cbac177e9c708"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "erased-serde",
+ "extensions",
+ "futures",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "k256"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3636,6 +3729,12 @@ checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "md-5"
@@ -5208,6 +5307,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5779,6 +5887,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "fendermint/testing",
   "fendermint/testing/*-test",
   "fendermint/vm/*",
+  "fendermint/eth/*",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -25,6 +26,7 @@ arbitrary = { version = "1", features = ["derive"] }
 arbtest = "0.2"
 async-stm = "0.2"
 async-trait = "0.1"
+axum = "0.6"
 base64 = "0.21"
 blake2b_simd = "1.0"
 bytes = "1.4"
@@ -33,7 +35,8 @@ config = "0.13"
 dirs = "5.0"
 futures = "0.3"
 hex = "0.4"
-k256 = "0.11"                                                       # Same as tendermint-rs
+jsonrpc-v2 = { version = "0.11", default-features = false, features = ["bytes-v10"] }
+k256 = "0.11"                                                                         # Same as tendermint-rs
 lazy_static = "1.4"
 libsecp256k1 = "0.7"
 multihash = { version = "0.16.1", default-features = false }

--- a/fendermint/abci/src/application.rs
+++ b/fendermint/abci/src/application.rs
@@ -161,6 +161,11 @@ where
         // but if we use the `tower_abci::buffer4::Worker` that means nothing else
         // get processed during that time.
         let app = self.0.clone();
+
+        // Another trick to avoid any subtle bugs is the mem::replace.
+        // See https://github.com/tower-rs/tower/issues/547
+        let app: A = std::mem::replace(&mut self.0, app);
+
         let res = async move {
             let res = match req {
                 Request::Echo(r) => Response::Echo(app.echo(r).await?),

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -34,6 +34,7 @@ fendermint_abci = { path = "../abci" }
 fendermint_storage = { path = "../storage" }
 fendermint_rocksdb = { path = "../rocksdb" }
 fendermint_rpc = { path = "../rpc" }
+fendermint_eth_api = { path = "../eth/api" }
 fendermint_vm_actor_interface = { path = "../vm/actor_interface" }
 fendermint_vm_core = { path = "../vm/core" }
 fendermint_vm_interpreter = { path = "../vm/interpreter", features = ["bundle"] }

--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -13,3 +13,20 @@ bound = 1
 [db]
 # Keep unlimited history by default.
 state_hist_size = 0
+
+# Ethereum API facade.
+[eth]
+
+# Ethereum API facade for JSON-RPC.
+[eth.http]
+# Only accept local connections by default.
+host = "127.0.0.1"
+# The default port where the Ethereum JSON-RPC API will listen to connections.
+port = 8545
+
+# Ethereum API facade for WebSockets.
+[eth.ws]
+# Only accept local connections by default.
+host = "127.0.0.1"
+# The default port where the Ethereum WebSocket API will listen to connections.
+port = 8546

--- a/fendermint/app/src/cmd/eth.rs
+++ b/fendermint/app/src/cmd/eth.rs
@@ -1,0 +1,27 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use fendermint_rpc::client::http_client;
+use tendermint_rpc::HttpClient;
+
+use crate::{
+    cmd,
+    options::eth::{EthArgs, EthCommands},
+    settings::EthSettings,
+};
+
+cmd! {
+  EthArgs(self, settings: EthSettings) {
+    match self.command.clone() {
+      EthCommands::Run { url, proxy_url } => {
+        let client = http_client(url, proxy_url)?;
+        run(client, settings).await
+      }
+    }
+  }
+}
+
+/// Run the Ethereum
+async fn run(_client: HttpClient, settings: EthSettings) -> anyhow::Result<()> {
+    fendermint_eth_api::listen(settings.http.addr()).await
+}

--- a/fendermint/app/src/cmd/mod.rs
+++ b/fendermint/app/src/cmd/mod.rs
@@ -13,6 +13,7 @@ use base64::engine::GeneralPurpose;
 use base64::engine::{DecodePaddingMode, GeneralPurposeConfig};
 use base64::{alphabet, Engine};
 
+pub mod eth;
 pub mod genesis;
 pub mod key;
 pub mod rpc;
@@ -83,6 +84,7 @@ pub async fn exec(opts: &Options) -> anyhow::Result<()> {
         Commands::Key(args) => args.exec(()).await,
         Commands::Genesis(args) => args.exec(()).await,
         Commands::Rpc(args) => args.exec(()).await,
+        Commands::Eth(args) => args.exec(settings(opts)?.eth).await,
     }
 }
 

--- a/fendermint/app/src/options/eth.rs
+++ b/fendermint/app/src/options/eth.rs
@@ -1,0 +1,31 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use clap::{Args, Subcommand};
+use tendermint_rpc::Url;
+
+#[derive(Args, Debug)]
+pub struct EthArgs {
+    #[command(subcommand)]
+    pub command: EthCommands,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum EthCommands {
+    /// Run the Ethereum JSON-RPC facade.
+    Run {
+        /// The URL of the Tendermint node's RPC endpoint.
+        #[arg(
+            long,
+            short,
+            default_value = "http://127.0.0.1:26657",
+            env = "TENDERMINT_RPC_URL"
+        )]
+        url: Url,
+
+        /// An optional HTTP/S proxy through which to submit requests to the
+        /// Tendermint node's RPC endpoint.
+        #[arg(long)]
+        proxy_url: Option<Url>,
+    },
+}

--- a/fendermint/app/src/options/mod.rs
+++ b/fendermint/app/src/options/mod.rs
@@ -7,8 +7,9 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::settings::expand_tilde;
 
-use self::{genesis::GenesisArgs, key::KeyArgs, rpc::RpcArgs, run::RunArgs};
+use self::{eth::EthArgs, genesis::GenesisArgs, key::KeyArgs, rpc::RpcArgs, run::RunArgs};
 
+pub mod eth;
 pub mod genesis;
 pub mod key;
 pub mod rpc;
@@ -79,4 +80,6 @@ pub enum Commands {
     Genesis(GenesisArgs),
     /// Subcommands related to sending JSON-RPC commands/queries to Tendermint.
     Rpc(RpcArgs),
+    /// Subcommands related to the Ethereum API facade.
+    Eth(EthArgs),
 }

--- a/fendermint/app/src/settings.rs
+++ b/fendermint/app/src/settings.rs
@@ -28,6 +28,27 @@ pub struct DbSettings {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct Address {
+    pub host: String,
+    pub port: u32,
+}
+
+impl Address {
+    pub fn addr(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+}
+
+/// Ethereum API facade settings.
+#[derive(Debug, Deserialize)]
+pub struct EthSettings {
+    /// Listen address for JSON-RPC
+    pub http: Address,
+    /// Listen address for WebSockets
+    pub ws: Address,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct Settings {
     /// Home directory configured on the CLI, to which all paths in settings can be set relative.
     home_dir: PathBuf,
@@ -35,6 +56,7 @@ pub struct Settings {
     builtin_actors_bundle: PathBuf,
     pub abci: AbciSettings,
     pub db: DbSettings,
+    pub eth: EthSettings,
 }
 
 impl Settings {

--- a/fendermint/eth/api/Cargo.toml
+++ b/fendermint/eth/api/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "fendermint_eth_api"
+description = "Ethereum JSON-RPC facade"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+axum = { workspace = true }
+jsonrpc-v2 = { workspace = true }
+tracing = { workspace = true }

--- a/fendermint/eth/api/src/lib.rs
+++ b/fendermint/eth/api/src/lib.rs
@@ -1,0 +1,20 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use anyhow::anyhow;
+use std::net::ToSocketAddrs;
+
+/// Start listening to JSON-RPC requests.
+pub async fn listen<A: ToSocketAddrs>(listen_addr: A) -> anyhow::Result<()> {
+    if let Some(listen_addr) = listen_addr.to_socket_addrs()?.next() {
+        let router = axum::Router::new();
+
+        let server = axum::Server::try_bind(&listen_addr)?.serve(router.into_make_service());
+
+        tracing::info!(?listen_addr, "bound Ethereum API");
+        server.await?;
+        Ok(())
+    } else {
+        Err(anyhow!("failed to convert to any socket address"))
+    }
+}


### PR DESCRIPTION
Part of #99 

Establishes a `fendermint_eth_api` library crate which can listen to the JSON-RPC and eventually WebSocket requests from Ethereum tools. This is started as another command under `fendermint_app`:

```console
❯ cargo run -p fendermint_app --release -q -- eth run --help
Run the Ethereum JSON-RPC facade

Usage: fendermint eth run [OPTIONS]

Options:
  -u, --url <URL>              The URL of the Tendermint node's RPC endpoint [env: TENDERMINT_RPC_URL=] [default: http://127.0.0.1:26657]
      --proxy-url <PROXY_URL>  An optional HTTP/S proxy through which to submit requests to the Tendermint node's RPC endpoint
  -h, --help                   Print help
```

Further to these options, we have some extra settings in `default.toml`:

```toml
# Ethereum API facade.
[eth]

# Ethereum API facade for JSON-RPC.
[eth.http]
# Only accept local connections by default.
host = "127.0.0.1"
# The default port where the Ethereum JSON-RPC API will listen to connections.
port = 8545

# Ethereum API facade for WebSockets.
[eth.ws]
# Only accept local connections by default.
host = "127.0.0.1"
# The default port where the Ethereum WebSocket API will listen to connections.
port = 8546
```

The default values for the ports have been chosen to match `geth`. 

### Why not a separate binary?

Initially I created the `fendermint_eth_api` as a binary crate with a `main.rs`, which is where I thought it will have only one job to do, which is to run the server. It would have still required its own settings file, though, so I thought we can move some config utilities to a common crate, like log levels, home directory and tilde handling.

But then I thought it might get confusing how to handle the `~/.fendermint/config` directory, which currently has a `default.toml`. Do we really want operators to have to worry about two different config files? 

By putting the entry under the same `fendermint` application as a subcommand, we don't have to create another `Dockerfile`, it all gets compiled into one, and just started with a different command and the relevant environment variable overrides. Notably it would not touch the DB section of the settings, and not share a volume with the ABCI container. 

### Why these JSON-RPC libraries?

I saw the `ipc-agent` implemented one [from scratch](https://github.com/consensus-shipyard/ipc-agent/blob/v0.3.0/src/server/jsonrpc.rs), but it can't be separately imported. The [jsonrpsee](https://crates.io/crates/jsonrpsee) library seems to be most used, but it contains many more features to learn, while the [jsonrpc-v2](https://crates.io/crates/jsonrpc-v2) used by Forest seems simple, and they already [worked out the details](https://github.com/ChainSafe/forest/blob/v0.8.2/node/rpc/src/lib.rs) of making it work with [axum](https://crates.io/crates/axum), which looked all right in [this comparison](https://kerkour.com/rust-web-framework-2022). I didn't ask if they would make the same choice again, but it looks like an easy start.