### PR TITLE
FM-99: Register methods and call in smoke test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2218,6 +2218,9 @@ dependencies = [
  "anyhow",
  "axum",
  "jsonrpc-v2",
+ "paste",
+ "serde_json",
+ "tendermint-rpc",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2217,13 +2217,19 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "clap 4.2.7",
+ "ethers",
  "ethers-core",
+ "hex",
  "jsonrpc-v2",
+ "lazy_static",
  "paste",
  "serde_json",
  "tendermint",
  "tendermint-rpc",
+ "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2217,6 +2217,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "ethers-core",
  "jsonrpc-v2",
  "paste",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2221,6 +2221,7 @@ dependencies = [
  "jsonrpc-v2",
  "paste",
  "serde_json",
+ "tendermint",
  "tendermint-rpc",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,13 @@
 members = [
   "fendermint/abci",
   "fendermint/app",
+  "fendermint/eth/api",
   "fendermint/rocksdb",
   "fendermint/rpc",
   "fendermint/storage",
   "fendermint/testing",
   "fendermint/testing/*-test",
   "fendermint/vm/*",
-  "fendermint/eth/*",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ bytes = "1.4"
 clap = { version = "4.1", features = ["derive", "env"] }
 config = "0.13"
 dirs = "5.0"
+ethers = { version = "2.0", features = ["abigen"] }
+ethers-core = { version = "2.0" }
 futures = "0.3"
 hex = "0.4"
 jsonrpc-v2 = { version = "0.11", default-features = false, features = ["bytes-v10"] }

--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -22,6 +22,8 @@ CMD ["run"]
 STOPSIGNAL SIGTERM
 
 ENV FM_ABCI__HOST=0.0.0.0
+ENV FM_ETH__HTTP__HOST=0.0.0.0
+ENV FM_ETH__WS__HOST=0.0.0.0
 
 COPY fendermint/app/config $FM_HOME_DIR/config
 COPY docker/.artifacts/bundle.car $FM_HOME_DIR/bundle.car

--- a/docker/local.Dockerfile
+++ b/docker/local.Dockerfile
@@ -32,6 +32,8 @@ CMD ["run"]
 STOPSIGNAL SIGTERM
 
 ENV FM_ABCI__HOST=0.0.0.0
+ENV FM_ETH__HTTP__HOST=0.0.0.0
+ENV FM_ETH__WS__HOST=0.0.0.0
 
 # We could build the actor bundles in the `builder` as well,
 # but we should be able to copy it from somewhere.

--- a/fendermint/app/src/cmd/eth.rs
+++ b/fendermint/app/src/cmd/eth.rs
@@ -15,13 +15,13 @@ cmd! {
     match self.command.clone() {
       EthCommands::Run { url, proxy_url } => {
         let client = http_client(url, proxy_url)?;
-        run(client, settings).await
+        run(settings, client).await
       }
     }
   }
 }
 
 /// Run the Ethereum
-async fn run(_client: HttpClient, settings: EthSettings) -> anyhow::Result<()> {
-    fendermint_eth_api::listen(settings.http.addr()).await
+async fn run(settings: EthSettings, client: HttpClient) -> anyhow::Result<()> {
+    fendermint_eth_api::listen(settings.http.addr(), client).await
 }

--- a/fendermint/eth/api/Cargo.toml
+++ b/fendermint/eth/api/Cargo.toml
@@ -10,4 +10,7 @@ license.workspace = true
 anyhow = { workspace = true }
 axum = { workspace = true }
 jsonrpc-v2 = { workspace = true }
+paste = { workspace = true }
+serde_json = { workspace = true }
 tracing = { workspace = true }
+tendermint-rpc = { workspace = true }

--- a/fendermint/eth/api/Cargo.toml
+++ b/fendermint/eth/api/Cargo.toml
@@ -16,3 +16,13 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 tendermint = { workspace = true }
 tendermint-rpc = { workspace = true }
+
+
+[dev-dependencies]
+clap = { workspace = true }
+ethers = { workspace = true, features = ["abigen"] }
+hex = { workspace = true }
+lazy_static = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/fendermint/eth/api/Cargo.toml
+++ b/fendermint/eth/api/Cargo.toml
@@ -14,4 +14,5 @@ jsonrpc-v2 = { workspace = true, features = ["easy-errors"] }
 paste = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
+tendermint = { workspace = true }
 tendermint-rpc = { workspace = true }

--- a/fendermint/eth/api/Cargo.toml
+++ b/fendermint/eth/api/Cargo.toml
@@ -8,8 +8,9 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+ethers-core = { workspace = true }
 axum = { workspace = true }
-jsonrpc-v2 = { workspace = true }
+jsonrpc-v2 = { workspace = true, features = ["easy-errors"] }
 paste = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -12,6 +12,15 @@
 //! ```text
 //! cargo run -p fendermint_eth_api --release --example ethers --
 //! ```
+//!
+//! A method can also be called directly with `curl`:
+//!
+//! ```text
+//! curl -X POST -i \
+//!      -H 'Content-Type: application/json' \
+//!      -d '{"jsonrpc":"2.0","id":"id","method":"eth_blockNumber","params":[]}' \
+//!      http://localhost:8545
+//! ```
 
 use std::fmt::Debug;
 
@@ -132,7 +141,7 @@ impl CheckResult for bool {
         if *self {
             Ok(())
         } else {
-            Err(anyhow!("condition failed"))
+            Err(anyhow!("expected true; got false"))
         }
     }
 }
@@ -146,7 +155,7 @@ where
     match res {
         Ok(value) => match check(&value).check_result() {
             Ok(()) => Ok(value),
-            Err(e) => Err(anyhow!("failed to check {method} ({value:?}): {e}")),
+            Err(e) => Err(anyhow!("failed to check {method}: {e}:\n{value:?}")),
         },
         Err(e) => Err(anyhow!("failed to call {method}: {e}")),
     }
@@ -158,7 +167,7 @@ async fn run(provider: Provider<Http>) -> anyhow::Result<()> {
     })?;
 
     request("eth_accounts", provider.get_accounts().await, |acnts| {
-        acnts.len() > 0
+        acnts.is_empty()
     })?;
 
     Ok(())

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -13,7 +13,11 @@
 //! cargo run -p fendermint_eth_api --release --example ethers --
 //! ```
 
+use std::fmt::Debug;
+
+use anyhow::anyhow;
 use clap::Parser;
+use ethers::providers::{Http, Middleware, Provider, ProviderError};
 use tracing::Level;
 
 #[derive(Parser, Debug)]
@@ -39,9 +43,123 @@ impl Options {
             Level::INFO
         }
     }
+
+    pub fn http_endpoint(&self) -> String {
+        format!("http://{}:{}", self.http_host, self.http_port)
+    }
 }
+
 /// See the module docs for how to run.
 #[tokio::main]
-async fn main() {
-    println!("Hello Ethers")
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let opts: Options = Options::parse();
+
+    tracing_subscriber::fmt()
+        .with_max_level(opts.log_level())
+        .init();
+
+    let provider = Provider::<Http>::try_from(opts.http_endpoint())?;
+
+    run(provider).await?;
+
+    Ok(())
+}
+
+// The following methods are called by the Provider.
+//
+// OK:
+// - eth_accounts
+// - eth_blockNumber
+//
+// TODO:
+// - eth_newBlockFilter
+// - eth_newBlockFilter
+// - eth_newPendingTransactionFilter
+// - eth_getBlockByHash
+// - eth_getBlockByNumber
+// - eth_call
+// - eth_getUncleCountByBlockHash
+// - eth_getUncleCountByBlockNumber
+// - eth_getUncleByBlockHashAndIndex
+// - eth_getUncleByBlockNumberAndIndex
+// - eth_getTransactionByHash
+// - eth_getTransactionReceipt
+// - eth_getBlockReceipts
+// - eth_gasPrice
+// - eth_getTransactionCount
+// - eth_getBalance
+// - eth_chainId
+// - eth_syncing
+// - eth_call
+// - eth_estimateGas
+// - eth_createAccessList
+// - eth_sendTransaction
+// - eth_sendRawTransaction
+// - eth_sign
+// - eth_sign
+// - eth_getLogs
+// - eth_newBlockFilter
+// - eth_newPendingTransactionFilter
+// - eth_newFilter
+// - eth_uninstallFilter
+// - eth_getFilterChanges
+// - eth_getstorageat
+// - eth_getStorageAt
+// - eth_getCode
+// - eth_getProof
+// - eth_mining
+// - eth_subscribe
+// - eth_unsubscribe
+// - eth_feeHistory
+// - eth_feeHistory
+// - eth_blockNumber
+// - eth_getChainId
+// - eth_estimateGas
+// - geth_admin_nodeinfo
+// - spawn_geth_and_create_provider
+// - spawn_geth_and_create_provider
+// - spawn_geth_instances
+// - spawn_geth_and_create_provider
+// - add_second_geth_peer
+// - spawn_geth_instances
+
+trait CheckResult {
+    fn check_result(&self) -> anyhow::Result<()>;
+}
+
+impl CheckResult for bool {
+    fn check_result(&self) -> anyhow::Result<()> {
+        if *self {
+            Ok(())
+        } else {
+            Err(anyhow!("condition failed"))
+        }
+    }
+}
+
+fn request<T, F, C>(method: &str, res: Result<T, ProviderError>, check: F) -> anyhow::Result<T>
+where
+    T: Debug,
+    F: FnOnce(&T) -> C,
+    C: CheckResult,
+{
+    match res {
+        Ok(value) => match check(&value).check_result() {
+            Ok(()) => Ok(value),
+            Err(e) => Err(anyhow!("failed to check {method} ({value:?}): {e}")),
+        },
+        Err(e) => Err(anyhow!("failed to call {method}: {e}")),
+    }
+}
+
+async fn run(provider: Provider<Http>) -> anyhow::Result<()> {
+    request("eth_blockNumber", provider.get_block_number().await, |bn| {
+        bn.as_u64() > 0
+    })?;
+
+    request("eth_accounts", provider.get_accounts().await, |acnts| {
+        acnts.len() > 0
+    })?;
+
+    Ok(())
 }

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -1,0 +1,47 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+//! Example of using the Ethereum JSON-RPC facade with the Ethers provider.
+//!
+//! The example assumes that the following has been started and running in the background:
+//! 1. Fendermint ABCI application
+//! 2. Tendermint Core / Comet BFT
+//! 3. Fendermint Ethereum API facade
+//!
+//! # Usage
+//! ```text
+//! cargo run -p fendermint_eth_api --release --example ethers --
+//! ```
+
+use clap::Parser;
+use tracing::Level;
+
+#[derive(Parser, Debug)]
+pub struct Options {
+    /// The host of the Fendermint Ethereum API endpoint.
+    #[arg(long, default_value = "127.0.0.1", env = "FM_ETH__HTTP__HOST")]
+    pub http_host: String,
+
+    /// The port of the Fendermint Ethereum API endpoint.
+    #[arg(long, default_value = "8545", env = "FM_ETH__HTTP__PORT")]
+    pub http_port: u32,
+
+    /// Enable DEBUG logs.
+    #[arg(long, short)]
+    pub verbose: bool,
+}
+
+impl Options {
+    pub fn log_level(&self) -> Level {
+        if self.verbose {
+            Level::DEBUG
+        } else {
+            Level::INFO
+        }
+    }
+}
+/// See the module docs for how to run.
+#[tokio::main]
+async fn main() {
+    println!("Hello Ethers")
+}

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -5,28 +5,35 @@
 // * https://github.com/evmos/ethermint/blob/ebbe0ffd0d474abd745254dc01e60273ea758dae/rpc/namespaces/ethereum/eth/api.go#L44
 // * https://github.com/filecoin-project/lotus/blob/v1.23.1-rc2/api/api_full.go#L783
 
-use jsonrpc_v2::{Data, Error as JsonRpcError, Params};
+use ethers_core::types as ethtypes;
+use jsonrpc_v2::{Data, Params};
+use tendermint_rpc::{endpoint, Client};
 
 use crate::JsonRpcState;
+
+use super::JsonRpcResult;
 
 /// Returns a list of addresses owned by client.
 ///
 /// It will always return [] since we don't expect Fendermint to manage private keys.
-pub async fn accounts(data: Data<JsonRpcState>) -> Result<Vec<String>, JsonRpcError> {
-    todo!()
+pub async fn accounts(_data: Data<JsonRpcState>) -> JsonRpcResult<Vec<ethtypes::Address>> {
+    Ok(vec![])
 }
 
 /// Returns the number of most recent block.
-pub async fn block_number(data: Data<JsonRpcState>) -> Result<u64, JsonRpcError> {
-    todo!()
+pub async fn block_number(data: Data<JsonRpcState>) -> JsonRpcResult<ethtypes::U64> {
+    let res: endpoint::block::Response = data.client.latest_block().await?;
+    let height = res.block.header.height;
+    let height = ethtypes::U64::from(height.value());
+    Ok(height)
 }
 
 /// Returns the number of transactions in a block matching the given block number.
 ///
 /// QUANTITY|TAG - integer of a block number, or the string "earliest", "latest" or "pending", as in the default block parameter.
 pub async fn get_block_transaction_count_by_number(
-    data: Data<JsonRpcState>,
-    Params(params): Params<u64>,
-) -> Result<u64, JsonRpcError> {
+    _data: Data<JsonRpcState>,
+    Params(_params): Params<ethtypes::BlockNumber>,
+) -> JsonRpcResult<ethtypes::U64> {
     todo!()
 }

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -6,22 +6,23 @@
 // * https://github.com/filecoin-project/lotus/blob/v1.23.1-rc2/api/api_full.go#L783
 
 use ethers_core::types as ethtypes;
-use jsonrpc_v2::{Data, Params};
+use jsonrpc_v2::Params;
 use tendermint_rpc::{endpoint, Client};
 
-use crate::JsonRpcState;
-
-use super::JsonRpcResult;
+use crate::{JsonRpcData, JsonRpcResult};
 
 /// Returns a list of addresses owned by client.
 ///
 /// It will always return [] since we don't expect Fendermint to manage private keys.
-pub async fn accounts(_data: Data<JsonRpcState>) -> JsonRpcResult<Vec<ethtypes::Address>> {
+pub async fn accounts<C>(_data: JsonRpcData<C>) -> JsonRpcResult<Vec<ethtypes::Address>> {
     Ok(vec![])
 }
 
 /// Returns the number of most recent block.
-pub async fn block_number(data: Data<JsonRpcState>) -> JsonRpcResult<ethtypes::U64> {
+pub async fn block_number<C>(data: JsonRpcData<C>) -> JsonRpcResult<ethtypes::U64>
+where
+    C: Client + Sync,
+{
     let res: endpoint::block::Response = data.client.latest_block().await?;
     let height = res.block.header.height;
     let height = ethtypes::U64::from(height.value());
@@ -31,8 +32,8 @@ pub async fn block_number(data: Data<JsonRpcState>) -> JsonRpcResult<ethtypes::U
 /// Returns the number of transactions in a block matching the given block number.
 ///
 /// QUANTITY|TAG - integer of a block number, or the string "earliest", "latest" or "pending", as in the default block parameter.
-pub async fn get_block_transaction_count_by_number(
-    _data: Data<JsonRpcState>,
+pub async fn get_block_transaction_count_by_number<C: Client>(
+    _data: JsonRpcData<C>,
     Params(_params): Params<ethtypes::BlockNumber>,
 ) -> JsonRpcResult<ethtypes::U64> {
     todo!()

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -1,0 +1,32 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+// See the following for inspiration:
+// * https://github.com/evmos/ethermint/blob/ebbe0ffd0d474abd745254dc01e60273ea758dae/rpc/namespaces/ethereum/eth/api.go#L44
+// * https://github.com/filecoin-project/lotus/blob/v1.23.1-rc2/api/api_full.go#L783
+
+use jsonrpc_v2::{Data, Error as JsonRpcError, Params};
+
+use crate::JsonRpcState;
+
+/// Returns a list of addresses owned by client.
+///
+/// It will always return [] since we don't expect Fendermint to manage private keys.
+pub async fn accounts(data: Data<JsonRpcState>) -> Result<Vec<String>, JsonRpcError> {
+    todo!()
+}
+
+/// Returns the number of most recent block.
+pub async fn block_number(data: Data<JsonRpcState>) -> Result<u64, JsonRpcError> {
+    todo!()
+}
+
+/// Returns the number of transactions in a block matching the given block number.
+///
+/// QUANTITY|TAG - integer of a block number, or the string "earliest", "latest" or "pending", as in the default block parameter.
+pub async fn get_block_transaction_count_by_number(
+    data: Data<JsonRpcState>,
+    Params(params): Params<u64>,
+) -> Result<u64, JsonRpcError> {
+    todo!()
+}

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -22,61 +22,54 @@ macro_rules! with_methods {
 }
 
 pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRouter> {
+    // This is the list of eth methods. Apart from these Lotus implements 1 method from web3,
+    // while Ethermint does more across web3, debug, miner, net, txpool, and personal.
+    // The unimplemented ones are commented out, to make it easier to see where we're at.
     with_methods!(server, eth, {
         accounts,
         blockNumber,
+        // eth_call
+        // eth_chainId
+        // eth_coinbase
+        // eth_compileLLL
+        // eth_compileSerpent
+        // eth_compileSolidity
+        // eth_estimateGas
+        // eth_gasPrice
+        // eth_getBalance
+        // eth_getBlockByHash
+        // eth_getBlockByNumber
+        // eth_getBlockTransactionCountByHash
         getBlockTransactionCountByNumber
+        // eth_getCode
+        // eth_getCompilers
+        // eth_getFilterChanges
+        // eth_getFilterLogs
+        // eth_getLogs
+        // eth_getStorageAt
+        // eth_getTransactionByBlockHashAndIndex
+        // eth_getTransactionByBlockNumberAndIndex
+        // eth_getTransactionByHash
+        // eth_getTransactionCount
+        // eth_getTransactionReceipt
+        // eth_getUncleByBlockHashAndIndex
+        // eth_getUncleByBlockNumberAndIndex
+        // eth_getUncleCountByBlockHash
+        // eth_getUncleCountByBlockNumber
+        // eth_getWork
+        // eth_hashrate
+        // eth_mining
+        // eth_newBlockFilter
+        // eth_newFilter
+        // eth_newPendingTransactionFilter
+        // eth_protocolVersion
+        // eth_sendRawTransaction
+        // eth_sendTransaction
+        // eth_sign
+        // eth_signTransaction
+        // eth_submitHashrate
+        // eth_submitWork
+        // eth_syncing
+        // eth_uninstallFilter
     })
 }
-
-/*
-This is the list of eth methods.
-Apart from this Lotus implement 1 method from web3,
-while Ethermint does more across web3, debug, miner, net, txpool, and personal.
-
-eth_accounts
-eth_blockNumber
-eth_call
-eth_chainId
-eth_coinbase
-eth_compileLLL
-eth_compileSerpent
-eth_compileSolidity
-eth_estimateGas
-eth_gasPrice
-eth_getBalance
-eth_getBlockByHash
-eth_getBlockByNumber
-eth_getBlockTransactionCountByHash
-eth_getBlockTransactionCountByNumber
-eth_getCode
-eth_getCompilers
-eth_getFilterChanges
-eth_getFilterLogs
-eth_getLogs
-eth_getStorageAt
-eth_getTransactionByBlockHashAndIndex
-eth_getTransactionByBlockNumberAndIndex
-eth_getTransactionByHash
-eth_getTransactionCount
-eth_getTransactionReceipt
-eth_getUncleByBlockHashAndIndex
-eth_getUncleByBlockNumberAndIndex
-eth_getUncleCountByBlockHash
-eth_getUncleCountByBlockNumber
-eth_getWork
-eth_hashrate
-eth_mining
-eth_newBlockFilter
-eth_newFilter
-eth_newPendingTransactionFilter
-eth_protocolVersion
-eth_sendRawTransaction
-eth_sendTransaction
-eth_sign
-eth_signTransaction
-eth_submitHashrate
-eth_submitWork
-eth_syncing
-eth_uninstallFilter
-*/

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -5,10 +5,9 @@
 
 use jsonrpc_v2::{MapRouter, ServerBuilder};
 use paste::paste;
+use tendermint_rpc::HttpClient;
 
 mod eth;
-
-type JsonRpcResult<T> = Result<T, jsonrpc_v2::Error>;
 
 macro_rules! with_methods {
     ($server:ident, $module:ident, { $($method:ident),* }) => {
@@ -16,7 +15,7 @@ macro_rules! with_methods {
             $server
                 $(.with_method(
                     stringify!([< $module _ $method >]),
-                    $module :: [< $method:snake >]
+                    $module :: [< $method:snake >] ::<HttpClient>
                 ))*
         }
     };

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -1,0 +1,83 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+// See https://ethereum.org/en/developers/docs/apis/json-rpc/#json-rpc-methods
+
+use jsonrpc_v2::{MapRouter, ServerBuilder};
+use paste::paste;
+
+mod eth;
+
+macro_rules! with_methods {
+    ($server:ident, $module:ident, { $($method:ident),* }) => {
+        paste!{
+            $server
+                $(.with_method(
+                    stringify!([< $module _ $method >]),
+                    $module :: [< $method:snake >]
+                ))*
+        }
+    };
+}
+
+pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRouter> {
+    let server = with_methods!(server, eth, {
+        accounts,
+        blockNumber,
+        getBlockTransactionCountByNumber
+    });
+
+    server
+}
+
+/*
+This is the list of eth methods.
+Apart from this Lotus implement 1 method from web3,
+while Ethermint does more across web3, debug, miner, net, txpool, and personal.
+
+eth_accounts
+eth_blockNumber
+eth_call
+eth_chainId
+eth_coinbase
+eth_compileLLL
+eth_compileSerpent
+eth_compileSolidity
+eth_estimateGas
+eth_gasPrice
+eth_getBalance
+eth_getBlockByHash
+eth_getBlockByNumber
+eth_getBlockTransactionCountByHash
+eth_getBlockTransactionCountByNumber
+eth_getCode
+eth_getCompilers
+eth_getFilterChanges
+eth_getFilterLogs
+eth_getLogs
+eth_getStorageAt
+eth_getTransactionByBlockHashAndIndex
+eth_getTransactionByBlockNumberAndIndex
+eth_getTransactionByHash
+eth_getTransactionCount
+eth_getTransactionReceipt
+eth_getUncleByBlockHashAndIndex
+eth_getUncleByBlockNumberAndIndex
+eth_getUncleCountByBlockHash
+eth_getUncleCountByBlockNumber
+eth_getWork
+eth_hashrate
+eth_mining
+eth_newBlockFilter
+eth_newFilter
+eth_newPendingTransactionFilter
+eth_protocolVersion
+eth_sendRawTransaction
+eth_sendTransaction
+eth_sign
+eth_signTransaction
+eth_submitHashrate
+eth_submitWork
+eth_syncing
+eth_uninstallFilter
+*/

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -8,6 +8,8 @@ use paste::paste;
 
 mod eth;
 
+type JsonRpcResult<T> = Result<T, jsonrpc_v2::Error>;
+
 macro_rules! with_methods {
     ($server:ident, $module:ident, { $($method:ident),* }) => {
         paste!{
@@ -21,13 +23,11 @@ macro_rules! with_methods {
 }
 
 pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRouter> {
-    let server = with_methods!(server, eth, {
+    with_methods!(server, eth, {
         accounts,
         blockNumber,
         getBlockTransactionCountByNumber
-    });
-
-    server
+    })
 }
 
 /*

--- a/fendermint/eth/api/src/lib.rs
+++ b/fendermint/eth/api/src/lib.rs
@@ -48,7 +48,7 @@ fn make_server(state: JsonRpcState<HttpClient>) -> JsonRpcServer {
 /// Register routes in the `axum` router to handle JSON-RPC and WebSocket calls.
 fn make_router(server: JsonRpcServer) -> axum::Router {
     axum::Router::new()
-        //.route("/rpc/v0", get(rpc_ws_handler::handle))
-        .route("/rpc/v0", post(rpc_http_handler::handle))
+        //.route("/", get(rpc_ws_handler::handle))
+        .route("/", post(rpc_http_handler::handle))
         .with_state(server)
 }

--- a/fendermint/eth/api/src/lib.rs
+++ b/fendermint/eth/api/src/lib.rs
@@ -2,13 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use anyhow::anyhow;
-use std::net::ToSocketAddrs;
+use axum::routing::post;
+use jsonrpc_v2::Data;
+use std::{net::ToSocketAddrs, sync::Arc};
+use tendermint_rpc::HttpClient;
+
+mod apis;
+mod rpc_http_handler;
+
+type JsonRpcServer = Arc<jsonrpc_v2::Server<jsonrpc_v2::MapRouter>>;
+type JsonRpcState = Arc<HttpClient>;
 
 /// Start listening to JSON-RPC requests.
-pub async fn listen<A: ToSocketAddrs>(listen_addr: A) -> anyhow::Result<()> {
+pub async fn listen<A: ToSocketAddrs>(listen_addr: A, client: HttpClient) -> anyhow::Result<()> {
     if let Some(listen_addr) = listen_addr.to_socket_addrs()?.next() {
-        let router = axum::Router::new();
-
+        let server = make_server(Arc::new(client));
+        let router = make_router(server);
         let server = axum::Server::try_bind(&listen_addr)?.serve(router.into_make_service());
 
         tracing::info!(?listen_addr, "bound Ethereum API");
@@ -17,4 +26,19 @@ pub async fn listen<A: ToSocketAddrs>(listen_addr: A) -> anyhow::Result<()> {
     } else {
         Err(anyhow!("failed to convert to any socket address"))
     }
+}
+
+/// Register method handlers with the JSON-RPC server construct.
+fn make_server(state: JsonRpcState) -> JsonRpcServer {
+    let server = jsonrpc_v2::Server::new().with_data(Data(state));
+    let server = apis::register_methods(server);
+    server.finish()
+}
+
+/// Register routes in the `axum` router to handle JSON-RPC and WebSocket calls.
+fn make_router(server: JsonRpcServer) -> axum::Router {
+    axum::Router::new()
+        //.route("/rpc/v0", get(rpc_ws_handler::handle))
+        .route("/rpc/v0", post(rpc_http_handler::handle))
+        .with_state(server)
 }

--- a/fendermint/eth/api/src/rpc_http_handler.rs
+++ b/fendermint/eth/api/src/rpc_http_handler.rs
@@ -20,13 +20,18 @@ pub async fn handle(
 
     // NOTE: Any authorization can come here.
 
+    let method = request.method_ref().to_owned();
+
     match call_rpc_str(server.clone(), request).await {
-        Ok(result) => (StatusCode::OK, response_headers, result),
-        Err(err) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            response_headers,
-            err.to_string(),
-        ),
+        Ok(result) => {
+            tracing::debug!(method, "RPC call success");
+            (StatusCode::OK, response_headers, result)
+        }
+        Err(err) => {
+            let msg = err.to_string();
+            tracing::error!(method, msg, "RPC call failure");
+            (StatusCode::INTERNAL_SERVER_ERROR, response_headers, msg)
+        }
     }
 }
 

--- a/fendermint/eth/api/src/rpc_http_handler.rs
+++ b/fendermint/eth/api/src/rpc_http_handler.rs
@@ -1,0 +1,40 @@
+// Copyright 2022-2023 Protocol Labs
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+// Based on https://github.com/ChainSafe/forest/blob/v0.8.2/node/rpc/src/rpc_http_handler.rs
+
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use jsonrpc_v2::RequestObject as JsonRpcRequestObject;
+
+use crate::JsonRpcServer;
+
+/// Handle JSON-RPC calls.
+pub async fn handle(
+    _headers: HeaderMap,
+    axum::extract::State(server): axum::extract::State<JsonRpcServer>,
+    axum::Json(request): axum::Json<JsonRpcRequestObject>,
+) -> impl IntoResponse {
+    let response_headers = [("content-type", "application/json-rpc;charset=utf-8")];
+
+    // NOTE: Any authorization can come here.
+
+    match call_rpc_str(server.clone(), request).await {
+        Ok(result) => (StatusCode::OK, response_headers, result),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            response_headers,
+            err.to_string(),
+        ),
+    }
+}
+
+// Calls an RPC method and returns the full response as a string.
+pub async fn call_rpc_str(
+    server: JsonRpcServer,
+    request: JsonRpcRequestObject,
+) -> anyhow::Result<String> {
+    let response = server.handle(request).await;
+    Ok(serde_json::to_string(&response)?)
+}

--- a/fendermint/rpc/Cargo.toml
+++ b/fendermint/rpc/Cargo.toml
@@ -29,7 +29,7 @@ fendermint_vm_message = { path = "../vm/message", features = ["secp256k1"] }
 
 [dev-dependencies]
 clap = { workspace = true }
-ethers = { version = "2.0", features = ["abigen"] }
+ethers = { workspace = true, features = ["abigen"] }
 hex = { workspace = true }
 lazy_static = { workspace = true }
 tokio = { workspace = true }

--- a/fendermint/rpc/examples/simplecoin.rs
+++ b/fendermint/rpc/examples/simplecoin.rs
@@ -1,5 +1,6 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
+
 //! Example of using the RPC library in combination with ethers abigen
 //! to programmatically deploy and call a contract.
 //!
@@ -63,7 +64,7 @@ abigen!(
 //         .unwrap()
 //         .generate()
 //         .unwrap()
-//         .write_to_file("./tests/storage_footprint_abi.rs")
+//         .write_to_file("./simplecoin.rs")
 //         .unwrap();
 // ```
 // This approach combined with `build.rs` was explored in https://github.com/filecoin-project/ref-fvm/pull/1507

--- a/fendermint/testing/smoke-test/Makefile.toml
+++ b/fendermint/testing/smoke-test/Makefile.toml
@@ -2,17 +2,23 @@
 NETWORK_NAME = "smoke"
 CMT_CONTAINER_NAME = "smoke-cometbft"
 FM_CONTAINER_NAME = "smoke-fendermint"
+ETHAPI_CONTAINER_NAME = "smoke-ethapi"
 CMT_DOCKER_IMAGE = "cometbft/cometbft:v0.37.x"
 FM_DOCKER_IMAGE = "fendermint:latest"
 TEST_DATA_DIR = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/fendermint/testing/smoke-test/test-data"
 TEST_SCRIPTS_DIR = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/fendermint/testing/smoke-test/scripts"
 ACTORS_BUNDLE = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/../builtin-actors/output/bundle.car"
-HOST_RPC_PORT = 26657
+CMT_HOST_PORT = 26657
+ETHAPI_HOST_PORT = 8545
 CARGO_MAKE_WAIT_MILLISECONDS = 5000
 
 # smoke-test infrastructure:
 # cargo install cargo-make
 # cargo make
+# - or -
+# cargo setup
+# cargo test
+# cargo treardown
 
 [tasks.default]
 clear = true
@@ -30,11 +36,12 @@ dependencies = [
   "fendermint-init",
   "fendermint-start",
   "cometbft-start",
+  "ethapi-start",
   "wait",
 ]
 
 [tasks.test]
-dependencies = ["simplecoin-example"]
+dependencies = ["simplecoin-example", "ethapi-example"]
 
 [tasks.teardown]
 # `dependencies` doesn't seem to work with `cleanup_task`.
@@ -43,6 +50,8 @@ run_task = { name = [
   "cometbft-rm",
   "fendermint-stop",
   "fendermint-rm",
+  "ethapi-stop",
+  "ethapi-rm",
   "network-rm",
   "test-data-dir-rm",
 ] }
@@ -54,6 +63,13 @@ script = """
 cd ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}
 cargo run -p fendermint_rpc --release --example simplecoin -- \
   --secret-key fendermint/testing/smoke-test/test-data/fendermint/keys/alice.sk
+"""
+
+
+[tasks.ethapi-example]
+script = """
+cd ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}
+cargo run -p fendermint_eth_api --release --example ethers
 """
 
 
@@ -89,7 +105,7 @@ docker run \
   --name ${CMT_CONTAINER_NAME} \
   --user $(id -u) \
   --network ${NETWORK_NAME} \
-  --publish 26657:${HOST_RPC_PORT} \
+  --publish 26657:${CMT_HOST_PORT} \
   --volume ${TEST_DATA_DIR}/cometbft:/cometbft \
   --env CMT_PROXY_APP=tcp://${FM_CONTAINER_NAME}:26658 \
   --env CMT_PEX=false \
@@ -126,6 +142,27 @@ docker run \
 """
 dependencies = ["test-data-dir", "network-create"]
 
+[tasks.ethapi-start]
+extend = "ethapi-run"
+env = { "CMD" = "eth run", "FLAGS" = "-d" }
+
+
+[tasks.ethapi-run]
+script = """
+docker run \
+  ${FLAGS} \
+  --rm \
+  --name ${ETHAPI_CONTAINER_NAME} \
+  --init \
+  --user $(id -u) \
+  --network ${NETWORK_NAME} \
+  --publish 8545:${ETHAPI_HOST_PORT} \
+  --env TENDERMINT_RPC_URL=http://${CMT_CONTAINER_NAME}:26657 \
+  ${FM_DOCKER_IMAGE} \
+  ${CMD}
+"""
+dependencies = ["network-create"]
+
 [tasks.network-create]
 command = "docker"
 args = ["network", "create", "${NETWORK_NAME}"]
@@ -151,6 +188,14 @@ env = { "CONTAINER_NAME" = "${FM_CONTAINER_NAME}" }
 [tasks.fendermint-stop]
 extend = "docker-stop"
 env = { "CONTAINER_NAME" = "${FM_CONTAINER_NAME}" }
+
+[tasks.ethapi-rm]
+extend = "docker-rm"
+env = { "CONTAINER_NAME" = "${ETHAPI_CONTAINER_NAME}" }
+
+[tasks.ethapi-stop]
+extend = "docker-stop"
+env = { "CONTAINER_NAME" = "${ETHAPI_CONTAINER_NAME}" }
 
 [tasks.docker-stop]
 command = "docker"


### PR DESCRIPTION
Part of #99 

Start registering `eth` method handlers, and call the ones already implemented _and_ available through `ethers-providers` as part of the smoke tests.