### PR TITLE
FM-111: Query the chain ID from genesis in SimpleCoin example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2251,6 +2251,7 @@ dependencies = [
  "ethers",
  "fendermint_vm_actor_interface",
  "fendermint_vm_core",
+ "fendermint_vm_genesis",
  "fendermint_vm_message",
  "fvm_ipld_encoding",
  "fvm_shared",

--- a/docs/running.md
+++ b/docs/running.md
@@ -576,7 +576,7 @@ Now that we have a contract deployed, we can call it. The arguments in the follo
 
 ```console
 $ cargo run -p fendermint_app --release -- \
-              rpc fevm --secret-key test-network/keys/alice.sk --sequence 2 --chain-name test \
+              rpc fevm --secret-key test-network/keys/alice.sk --sequence 2 \
                 invoke --contract $DELEGATED_ADDR  \
                        --method f8b2cb4f --method-args 000000000000000000000000ff00000000000000000000000000000000000064 \
           | jq .return_data
@@ -590,7 +590,7 @@ To avoid having to come up with ABI encoded arguments in hexadecimal format, we 
 Here's an [example](../fendermint/rpc/examples/simplecoin.rs) of doing that with the [SimpleCoin](https://github.com/filecoin-project/builtin-actors/blob/v10.0.0/actors/evm/tests/contracts/simplecoin.sol) contract.
 
 ```console
-$ cargo run -p fendermint_rpc --release --example simplecoin -- --secret-key test-network/keys/alice.sk --chain-name test --verbose
+$ cargo run -p fendermint_rpc --release --example simplecoin -- --secret-key test-network/keys/alice.sk --verbose
 2023-05-19T10:18:47.234878Z DEBUG fendermint_rpc::client: Using HTTP client to submit request to: http://127.0.0.1:26657/
 ...
 2023-05-19T10:18:47.727563Z  INFO simplecoin: contract deployed contract_address="f410fvbmxiqdn6svyo5oubfbzxsorkvydcb5ecmlbwma" actor_id=107

--- a/fendermint/rpc/Cargo.toml
+++ b/fendermint/rpc/Cargo.toml
@@ -35,3 +35,5 @@ lazy_static = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+fendermint_vm_genesis = { path = "../vm/genesis" }

--- a/fendermint/testing/smoke-test/Makefile.toml
+++ b/fendermint/testing/smoke-test/Makefile.toml
@@ -53,8 +53,7 @@ run_task = { name = [
 script = """
 cd ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}
 cargo run -p fendermint_rpc --release --example simplecoin -- \
-  --secret-key fendermint/testing/smoke-test/test-data/fendermint/keys/alice.sk \
-  --chain-name ${NETWORK_NAME}
+  --secret-key fendermint/testing/smoke-test/test-data/fendermint/keys/alice.sk
 """
 
 


### PR DESCRIPTION
Follow up for #111 

Do away with the `--chain-name` parameter in the SimpleCoin example by querying the Tendermint `genesis()` API endpoint and using the `chain_id` field. It makes it easier to call the example (similar to how it figures out the nonce) and demonstrates the use of the underlying Tendermint client.