### PR TITLE
FM-120: ABCI query for state params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,6 @@ dependencies = [
  "clap 4.2.7",
  "ethers",
  "fendermint_vm_actor_interface",
- "fendermint_vm_core",
  "fendermint_vm_genesis",
  "fendermint_vm_message",
  "fvm_ipld_encoding",

--- a/fendermint/app/src/cmd/rpc.rs
+++ b/fendermint/app/src/cmd/rpc.rs
@@ -97,6 +97,11 @@ async fn query(
                 }
             }
         }
+        RpcQueryCommands::StateParams => {
+            let res = client.state_params(Some(height)).await?;
+            let json = json!({ "response": res });
+            print_json(&json)?;
+        }
     };
     Ok(())
 }

--- a/fendermint/app/src/options/rpc.rs
+++ b/fendermint/app/src/options/rpc.rs
@@ -87,6 +87,8 @@ pub enum RpcQueryCommands {
         #[arg(long, short, value_parser = parse_address)]
         address: Address,
     },
+    /// Get the slowly changing state parameters.
+    StateParams,
 }
 
 #[derive(Subcommand, Debug, Clone)]

--- a/fendermint/app/src/tmconv.rs
+++ b/fendermint/app/src/tmconv.rs
@@ -140,6 +140,7 @@ pub fn to_query(ret: FvmQueryRet, block_height: BlockHeight) -> anyhow::Result<r
         // For calls and estimates, the caller needs to look into the `value` field to see the real exit code;
         // the query itself is successful, even if the value represents a failure.
         FvmQueryRet::Call(_) | FvmQueryRet::EstimateGas(_) => ExitCode::OK,
+        FvmQueryRet::StateParams(_) => ExitCode::OK,
     };
 
     // The return value has a `key` field which is supposed to be set to the data matched.
@@ -170,6 +171,10 @@ pub fn to_query(ret: FvmQueryRet, block_height: BlockHeight) -> anyhow::Result<r
         }
         FvmQueryRet::EstimateGas(est) => {
             let v = ipld_encode!(est);
+            (Vec::new(), v)
+        }
+        FvmQueryRet::StateParams(sp) => {
+            let v = ipld_encode!(sp);
             (Vec::new(), v)
         }
     };

--- a/fendermint/rpc/Cargo.toml
+++ b/fendermint/rpc/Cargo.toml
@@ -24,7 +24,6 @@ fvm_ipld_encoding = { workspace = true }
 fvm_shared = { workspace = true }
 
 fendermint_vm_actor_interface = { path = "../vm/actor_interface" }
-fendermint_vm_core = { path = "../vm/core" }
 fendermint_vm_message = { path = "../vm/message", features = ["secp256k1"] }
 
 [dev-dependencies]

--- a/fendermint/rpc/src/query.rs
+++ b/fendermint/rpc/src/query.rs
@@ -14,7 +14,7 @@ use cid::Cid;
 use fvm_shared::ActorID;
 use fvm_shared::{address::Address, error::ExitCode};
 
-use fendermint_vm_message::query::{ActorState, FvmQuery, GasEstimate};
+use fendermint_vm_message::query::{ActorState, FvmQuery, GasEstimate, StateParams};
 
 use crate::response::encode_data;
 
@@ -95,6 +95,20 @@ pub trait QueryClient: Send + Sync {
         let value = extract(res, |res| {
             fvm_ipld_encoding::from_slice(&res.value)
                 .context("failed to decode GasEstimate from query")
+        })?;
+        Ok(QueryResponse { height, value })
+    }
+
+    /// Slowly changing state parameters.
+    async fn state_params(
+        &self,
+        height: Option<Height>,
+    ) -> anyhow::Result<QueryResponse<StateParams>> {
+        let res = self.perform(FvmQuery::StateParams, height).await?;
+        let height = res.height;
+        let value = extract(res, |res| {
+            fvm_ipld_encoding::from_slice(&res.value)
+                .context("failed to decode StateParams from query")
         })?;
         Ok(QueryResponse { height, value })
     }

--- a/fendermint/vm/interpreter/src/fvm/query.rs
+++ b/fendermint/vm/interpreter/src/fvm/query.rs
@@ -1,7 +1,7 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use async_trait::async_trait;
-use fendermint_vm_message::query::{ActorState, FvmQuery, GasEstimate};
+use fendermint_vm_message::query::{ActorState, FvmQuery, GasEstimate, StateParams};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::{ActorID, BLOCK_GAS_LIMIT};
 
@@ -22,6 +22,8 @@ pub enum FvmQueryRet {
     Call(FvmApplyRet),
     /// The estimated gas limit.
     EstimateGas(GasEstimate),
+    /// Current state parameters.
+    StateParams(StateParams),
 }
 
 #[async_trait]
@@ -76,6 +78,16 @@ where
                 };
 
                 FvmQueryRet::EstimateGas(est)
+            }
+            FvmQuery::StateParams => {
+                let state_params = state.state_params();
+                let state_params = StateParams {
+                    base_fee: state_params.base_fee.clone(),
+                    circ_supply: state_params.circ_supply.clone(),
+                    chain_id: state_params.chain_id,
+                    network_version: state_params.network_version,
+                };
+                FvmQueryRet::StateParams(state_params)
             }
         };
         Ok((state, res))

--- a/fendermint/vm/interpreter/src/fvm/state/query.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/query.rs
@@ -151,4 +151,8 @@ where
         }
         self.with_exec_state(|s| s.execute_explicit(msg))
     }
+
+    pub fn state_params(&self) -> &FvmStateParams {
+        &self.state_params
+    }
 }


### PR DESCRIPTION
Closes #120

Adds a new ABCI query, RPC and CLI method to retrieve the state parameters comprising of `circ_supply`, `base_fee`, `network_version` and `chain_id`.

```console
$ cargo run -q -p fendermint_app --release -- rpc query --help
Send an ABCI query

Usage: fendermint rpc query [OPTIONS] <COMMAND>

Commands:
  ipld          Get raw IPLD content; print it as base64 string
  actor-state   Get the state of an actor; print it as JSON
  state-params  Get the slowly changing state parameters
  help          Print this message or the help of the given subcommand(s)

Options:
  -b, --height <HEIGHT>  Block height to query; 0 means latest [default: 0]
  -h, --help             Print help

❯ cargo run -q -p fendermint_app --release -- rpc query state-params --help
Get the slowly changing state parameters

Usage: fendermint rpc query state-params

Options:
  -h, --help  Print help
```