### PR TITLE
FM-122: Use FNV hasher for chain ID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2328,6 +2328,7 @@ name = "fendermint_vm_core"
 version = "0.1.0"
 dependencies = [
  "cid",
+ "fnv",
  "fvm_shared",
  "lazy_static",
  "quickcheck 1.0.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,6 +2332,7 @@ dependencies = [
  "lazy_static",
  "quickcheck 1.0.3",
  "quickcheck_macros",
+ "regex",
  "serde",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ quickcheck = "1"
 quickcheck_macros = "1"
 rand = "0.8"
 rand_chacha = "0.3"
+regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 serde_tuple = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ config = "0.13"
 dirs = "5.0"
 ethers = { version = "2.0", features = ["abigen"] }
 ethers-core = { version = "2.0" }
+fnv = "1.0"
 futures = "0.3"
 hex = "0.4"
 jsonrpc-v2 = { version = "0.11", default-features = false, features = ["bytes-v10"] }

--- a/fendermint/vm/core/Cargo.toml
+++ b/fendermint/vm/core/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+fnv = { workspace = true }
 lazy_static = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }

--- a/fendermint/vm/core/Cargo.toml
+++ b/fendermint/vm/core/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 
 [dependencies]
 lazy_static = { workspace = true }
+regex = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 

--- a/fendermint/vm/core/src/chainid.rs
+++ b/fendermint/vm/core/src/chainid.rs
@@ -6,6 +6,7 @@ use cid::{multihash, multihash::MultihashDigest};
 use fvm_shared::bigint::{BigInt, Integer, Sign};
 use fvm_shared::chainid::ChainID;
 use lazy_static::lazy_static;
+use regex::Regex;
 use thiserror::Error;
 
 lazy_static! {
@@ -25,6 +26,11 @@ lazy_static! {
 
     /// Reverse index over the chain IDs.
     static ref KNOWN_CHAIN_NAMES: HashMap<&'static str, u64> = KNOWN_CHAIN_IDS.iter().map(|(k, v)| (*v, *k)).collect();
+
+    /// Regex for capturing a single root subnet ID.
+    ///
+    /// See https://github.com/consensus-shipyard/ipc-actors/pull/109
+    static ref ROOT_RE: Regex = Regex::new(r"^/r([1-9]\d*)$").unwrap();
 }
 
 /// Maximum value that MetaMask and other Ethereum JS tools can safely handle.
@@ -42,17 +48,16 @@ pub enum ChainIDError {
 
 /// Hash the name of the chain and reduce it to a number within the acceptable range.
 ///
-/// If the name is one of the well known ones, return that name as is.
+/// If the name is one of the well known ones, return the ID for that name as-is.
 pub fn from_str_hashed(name: &str) -> Result<ChainID, ChainIDError> {
-    // TODO: If we want to use the subnet ID (e.g. "/root/foo/bar")
-    // as the chain name, we should change it so the "/root" part is
-    // not common to all chain, but rather be like "/filecoin/foo/bar".
-    // And if someone is looking for the ID of "/filecoin" without
-    // any further path (ie. the root) then we should strip the "/"
-    // when looking up if it's a well known network ID.
-
+    // See if the name matches one of the well known chains.
     if let Some(chain_id) = KNOWN_CHAIN_NAMES.get(name) {
         return Ok(ChainID::from(*chain_id));
+    }
+
+    // See if the name is actually a rootnet ID like "/r123"
+    if let Some(chain_id) = just_root_id(name) {
+        return Ok(ChainID::from(chain_id));
     }
 
     let bz = name.as_bytes();
@@ -78,13 +83,21 @@ pub trait HasChainID {
     fn chain_id(&self) -> &ChainID;
 }
 
+/// Extract the root chain ID _iff_ the name is in the format of "/r<chain-id>".
+fn just_root_id(name: &str) -> Option<u64> {
+    ROOT_RE.captures_iter(name).next().and_then(|cap| {
+        let chain_id = &cap[1];
+        chain_id.parse::<u64>().ok()
+    })
+}
+
 #[cfg(test)]
 mod tests {
 
     use fvm_shared::chainid::ChainID;
     use quickcheck_macros::quickcheck;
 
-    use crate::chainid::KNOWN_CHAIN_NAMES;
+    use crate::chainid::{just_root_id, KNOWN_CHAIN_NAMES};
 
     use super::{from_str_hashed, MAX_CHAIN_ID};
 
@@ -132,6 +145,28 @@ mod tests {
     fn chain_id_of_known() {
         for (name, id) in KNOWN_CHAIN_NAMES.iter() {
             assert_eq!(from_str_hashed(name).unwrap(), ChainID::from(*id))
+        }
+    }
+
+    #[test]
+    fn just_root_id_some() {
+        assert_eq!(just_root_id("/r123"), Some(123));
+    }
+
+    #[test]
+    fn just_root_id_none() {
+        for name in [
+            "",
+            "/",
+            "/r",
+            "/r0",
+            "/r01",
+            "/r1234567890123456789012345678901234567890",
+            "123",
+            "abc",
+            "/r123/f456",
+        ] {
+            assert!(just_root_id(name).is_none());
         }
     }
 }

--- a/fendermint/vm/core/src/chainid.rs
+++ b/fendermint/vm/core/src/chainid.rs
@@ -144,6 +144,13 @@ mod tests {
     }
 
     #[test]
+    fn chain_id_examples() {
+        for (name, id) in [("/r123/f0456/f0789", 3911219601699869)] {
+            assert_eq!(u64::from(from_str_hashed(name).unwrap()), id);
+        }
+    }
+
+    #[test]
     fn just_root_id_some() {
         assert_eq!(just_root_id("/r0"), Some(0));
         assert_eq!(just_root_id("/r123"), Some(123));


### PR DESCRIPTION
Closes #122 

Switches to using FNV hash for chain ID like the IPC agent library. Also parses the `"/r123"` format for rootnet chain IDs.