### PR TITLE
FM-125: Ethereum accounts in genesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2364,6 +2364,7 @@ name = "fendermint_vm_genesis"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
+ "cid",
  "fendermint_testing",
  "fendermint_vm_core",
  "fendermint_vm_encoding",

--- a/fendermint/app/src/options/genesis.rs
+++ b/fendermint/app/src/options/genesis.rs
@@ -3,10 +3,16 @@
 
 use std::path::PathBuf;
 
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 
 use super::parse::{parse_network_version, parse_token_amount};
 use fvm_shared::{econ::TokenAmount, version::NetworkVersion};
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum AccountKind {
+    Regular,
+    Ethereum,
+}
 
 #[derive(Subcommand, Debug)]
 pub enum GenesisCommands {
@@ -56,6 +62,9 @@ pub struct GenesisAddAccountArgs {
     /// Initial balance in atto.
     #[arg(long, short, value_parser = parse_token_amount)]
     pub balance: TokenAmount,
+    /// Indicate whether the account is a regular or ethereum account.
+    #[arg(long, short, default_value = "regular")]
+    pub kind: AccountKind,
 }
 
 #[derive(Args, Debug)]

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -413,7 +413,7 @@ pub async fn get_uncle_by_block_number_and_index<C>(
 }
 
 fn h160_to_fvm_addr(addr: et::H160) -> fvm_shared::address::Address {
-    Address::from(&EthAddress(addr.0))
+    Address::from(EthAddress(addr.0))
 }
 
 /// Fetch transaction results to produce the full block.

--- a/fendermint/vm/actor_interface/src/ethaccount.rs
+++ b/fendermint/vm/actor_interface/src/ethaccount.rs
@@ -1,0 +1,4 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+define_code!(ETHACCOUNT { code_id: 16 });

--- a/fendermint/vm/actor_interface/src/lib.rs
+++ b/fendermint/vm/actor_interface/src/lib.rs
@@ -14,6 +14,9 @@
 //! The actor IDs can be found in [singletons](https://github.com/filecoin-project/builtin-actors/blob/master/runtime/src/builtin/singletons.rs),
 //! while the code IDs are in [builtins](https://github.com/filecoin-project/builtin-actors/blob/master/runtime/src/runtime/builtins.rs)
 
+/// Something we can use for empty state, similar to how the FVM uses `EMPTY_ARR_CID`.
+pub const EMPTY_ARR: [(); 0] = [(); 0]; // Based on how it's done in `Tester`.
+
 macro_rules! define_code {
     ($name:ident { code_id: $code_id:literal }) => {
         paste::paste! {
@@ -36,7 +39,9 @@ macro_rules! define_singleton {
 pub mod account;
 pub mod cron;
 pub mod eam;
+pub mod ethaccount;
 pub mod evm;
 pub mod init;
 pub mod multisig;
+pub mod placeholder;
 pub mod system;

--- a/fendermint/vm/actor_interface/src/placeholder.rs
+++ b/fendermint/vm/actor_interface/src/placeholder.rs
@@ -1,0 +1,8 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+//! Placeholders can be used for delegated address types.
+//! The FVM automatically creates one if the recipient of a transaction
+//! doesn't exist. Then, the executor replaces the code later based on
+//! the namespace in the delegated address.
+
+define_code!(PLACEHOLDER { code_id: 13 });

--- a/fendermint/vm/genesis/Cargo.toml
+++ b/fendermint/vm/genesis/Cargo.toml
@@ -17,6 +17,7 @@ arbitrary = { workspace = true, optional = true }
 quickcheck = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 
+cid = { workspace = true, optional = true }
 fvm_shared = { workspace = true }
 fendermint_testing = { path = "../../testing", optional = true }
 fendermint_vm_core = { path = "../core" }
@@ -35,4 +36,4 @@ fvm_ipld_encoding = { workspace = true }
 
 [features]
 default = []
-arb = ["arbitrary", "quickcheck", "fvm_shared/arb", "fendermint_testing/arb", "rand"]
+arb = ["arbitrary", "quickcheck", "fvm_shared/arb", "fendermint_testing/arb", "rand", "cid"]

--- a/fendermint/vm/interpreter/src/fvm/genesis.rs
+++ b/fendermint/vm/interpreter/src/fvm/genesis.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use async_trait::async_trait;
-use fendermint_vm_actor_interface::{cron, eam, init, system};
+use fendermint_vm_actor_interface::{cron, eam, init, system, EMPTY_ARR};
 use fendermint_vm_core::{chainid, Timestamp};
 use fendermint_vm_genesis::{ActorMeta, Genesis, Validator};
 use fvm_ipld_blockstore::Blockstore;
@@ -84,6 +84,7 @@ where
             system::SYSTEM_ACTOR_ID,
             &system_state,
             TokenAmount::zero(),
+            None,
         )?;
 
         // Init actor
@@ -95,6 +96,7 @@ where
             init::INIT_ACTOR_ID,
             &init_state,
             TokenAmount::zero(),
+            None,
         )?;
 
         // Cron actor
@@ -106,15 +108,16 @@ where
             cron::CRON_ACTOR_ID,
             &cron_state,
             TokenAmount::zero(),
+            None,
         )?;
 
         // Ethereum Account Manager (EAM) actor
-        let eam_state = [(); 0]; // Based on how it's done in `Tester`.
         state.create_actor(
             eam::EAM_ACTOR_CODE_ID,
             eam::EAM_ACTOR_ID,
-            &eam_state,
+            &EMPTY_ARR,
             TokenAmount::zero(),
+            None,
         )?;
 
         // Create accounts


### PR DESCRIPTION
Closes #125 

* Added a `--kind` parameter to the `fendermint genesis add-account` CLI command which can be `regular` (default) or `ethereum`. Depending on its value the public key is hashed as an `f1` or an `f410` address.
* The genesis interpreter inspects the `owner` of the account and if it's an `f410` address it creates the state with the `ethaccount` code ID and sets the `delegated_address`.