### PR TITLE
FM-99: Ethereum API methods (Part 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,6 +2422,7 @@ dependencies = [
  "arbitrary",
  "blake2b_simd",
  "cid",
+ "ethers",
  "ethers-core",
  "fendermint_testing",
  "fendermint_vm_actor_interface",

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -197,9 +197,9 @@ impl TestAccount {
 // - eth_feeHistory
 // - eth_sendRawTransaction
 // - eth_call
+// - eth_estimateGas
 //
 // DOING:
-// - eth_estimateGas
 //
 // TODO:
 // - eth_newBlockFilter

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -7,11 +7,12 @@
 // * https://github.com/filecoin-project/lotus/blob/v1.23.1-rc2/node/impl/full/eth.go
 
 use anyhow::Context;
+use ethers_core::types as et;
 use ethers_core::types::transaction::eip2718::TypedTransaction;
-use ethers_core::types::{self as et, BlockId};
 use ethers_core::utils::rlp;
 use fendermint_rpc::message::MessageFactory;
 use fendermint_rpc::query::QueryClient;
+use fendermint_rpc::response::decode_fevm_invoke;
 use fendermint_vm_message::chain::ChainMessage;
 use fendermint_vm_message::signed::SignedMessage;
 use fvm_shared::crypto::signature::Signature;
@@ -190,10 +191,7 @@ pub async fn get_balance<C>(
 where
     C: Client + Sync + Send + Send,
 {
-    let header = match block_id {
-        BlockId::Number(n) => data.header_by_height(n).await?,
-        BlockId::Hash(h) => data.header_by_hash(h).await?,
-    };
+    let header = data.header_by_id(block_id).await?;
     let height = header.height;
     let addr = to_fvm_address(addr);
     let res = data.client.actor_state(&addr, Some(height)).await?;
@@ -331,10 +329,7 @@ pub async fn get_transaction_count<C>(
 where
     C: Client + Sync + Send + Send,
 {
-    let header = match block_id {
-        BlockId::Number(n) => data.header_by_height(n).await?,
-        BlockId::Hash(h) => data.header_by_hash(h).await?,
-    };
+    let header = data.header_by_id(block_id).await?;
     let height = header.height;
     let addr = to_fvm_address(addr);
     let res = data.client.actor_state(&addr, Some(height)).await?;
@@ -432,7 +427,7 @@ where
     C: Client + Sync + Send + Send,
 {
     let rlp = rlp::Rlp::new(tx.as_ref());
-    let (tx, sig) = et::transaction::eip2718::TypedTransaction::decode_signed(&rlp)
+    let (tx, sig) = TypedTransaction::decode_signed(&rlp)
         .context("failed to decode RLP as signed TypedTransaction")?;
 
     let msg = match tx {
@@ -458,5 +453,38 @@ where
             ExitCode::new(res.code.value()),
             hex::encode(res.data.as_ref()), // TODO: What is the content?
         )
+    }
+}
+
+/// Creates new message call transaction or a contract creation for signed transactions.
+pub async fn call<C>(
+    data: JsonRpcData<C>,
+    Params((tx, block_id)): Params<(TypedTransaction, et::BlockId)>,
+) -> JsonRpcResult<et::Bytes>
+where
+    C: Client + Sync + Send + Send,
+{
+    let msg = match tx {
+        TypedTransaction::Eip1559(tx) => to_fvm_message(&tx)?,
+        TypedTransaction::Legacy(_) | TypedTransaction::Eip2930(_) => {
+            return error(
+                ExitCode::USR_ILLEGAL_ARGUMENT,
+                "unexpected transaction type",
+            )
+        }
+    };
+
+    let header = data.header_by_id(block_id).await?;
+    let response = data.client.call(msg, Some(header.height)).await?;
+    let deliver_tx = response.value;
+
+    // Based on Lotus, we should return the data from the receipt.
+    if deliver_tx.code.is_err() {
+        error(ExitCode::new(deliver_tx.code.value()), deliver_tx.info)
+    } else {
+        let return_data = decode_fevm_invoke(&deliver_tx)
+            .context("error decoding data from deliver_tx in query")?;
+
+        Ok(et::Bytes::from(return_data))
     }
 }

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -490,7 +490,10 @@ where
 
     // Based on Lotus, we should return the data from the receipt.
     if !estimate.exit_code.is_success() {
-        error(estimate.exit_code, "failed to estimate gas")
+        error(
+            estimate.exit_code,
+            format!("failed to estimate gas: {}", estimate.info),
+        )
     } else {
         Ok(estimate.gas_limit.into())
     }

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -29,7 +29,7 @@ pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRo
     with_methods!(server, eth, {
         accounts,
         blockNumber,
-        // eth_call
+        call,
         chainId,
         // eth_coinbase
         // eth_compileLLL

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -35,7 +35,7 @@ pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRo
         // eth_compileLLL
         // eth_compileSerpent
         // eth_compileSolidity
-        // eth_estimateGas
+        estimateGas,
         feeHistory,
         gasPrice,
         getBalance,

--- a/fendermint/eth/api/src/conv/from_eth.rs
+++ b/fendermint/eth/api/src/conv/from_eth.rs
@@ -4,11 +4,26 @@
 //! Helper methods to convert between Ethereum and FVM data formats.
 
 use anyhow::Context;
-use ethers_core::types::H256;
+use ethers_core::types::{transaction::eip2718::TypedTransaction, H256};
 
 pub use fendermint_vm_message::conv::from_eth::*;
+use fvm_shared::{error::ExitCode, message::Message};
+
+use crate::{error, JsonRpcResult};
 
 pub fn to_tm_hash(value: &H256) -> anyhow::Result<tendermint::Hash> {
     tendermint::Hash::try_from(value.as_bytes().to_vec())
         .context("failed to convert to Tendermint Hash")
+}
+
+pub fn to_fvm_message(tx: TypedTransaction) -> JsonRpcResult<Message> {
+    match tx {
+        TypedTransaction::Eip1559(tx) => {
+            Ok(fendermint_vm_message::conv::from_eth::to_fvm_message(&tx)?)
+        }
+        TypedTransaction::Legacy(_) | TypedTransaction::Eip2930(_) => error(
+            ExitCode::USR_ILLEGAL_ARGUMENT,
+            "unexpected transaction type",
+        ),
+    }
 }

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -85,6 +85,17 @@ where
         Ok(header)
     }
 
+    /// Get the Tendermint header at a specificed height or hash.
+    pub async fn header_by_id(
+        &self,
+        block_id: et::BlockId,
+    ) -> JsonRpcResult<tendermint::block::Header> {
+        match block_id {
+            et::BlockId::Number(n) => self.header_by_height(n).await,
+            et::BlockId::Hash(h) => self.header_by_hash(h).await,
+        }
+    }
+
     /// Get a Tendermint block by hash, if it exists.
     pub async fn block_by_hash_opt(
         &self,

--- a/fendermint/rpc/src/response.rs
+++ b/fendermint/rpc/src/response.rs
@@ -42,6 +42,14 @@ pub fn decode_fevm_create(deliver_tx: &DeliverTx) -> anyhow::Result<CreateReturn
 /// Parse what Tendermint returns in the `data` field of [`DeliverTx`] as raw ABI return value.
 pub fn decode_fevm_invoke(deliver_tx: &DeliverTx) -> anyhow::Result<Vec<u8>> {
     let data = decode_data(&deliver_tx.data)?;
+
+    // Some calls like transfers between Ethereum accounts don't return any data.
+    if data.is_empty() {
+        return Ok(data);
+    }
+
+    // This is the data return by the FEVM itself, not something wrapping another piece,
+    // that is, it's as if it was returning `CreateReturn`, it's returning `RawBytes` encoded as IPLD.
     fvm_ipld_encoding::from_slice::<BytesDe>(&data)
         .map(|bz| bz.0)
         .map_err(|e| anyhow!("failed to deserialize bytes returned by FEVM: {e}"))

--- a/fendermint/testing/smoke-test/scripts/init.sh
+++ b/fendermint/testing/smoke-test/scripts/init.sh
@@ -40,7 +40,7 @@ for NAME in emily eric; do
   fendermint \
     genesis --genesis-file $GENESIS_FILE \
     add-account --public-key $KEYS_DIR/$NAME.pk \
-                --balance 1000000000000000000 \
+                --balance 1000000000000000000000 \
                 --kind ethereum
 done
 

--- a/fendermint/vm/actor_interface/src/burntfunds.rs
+++ b/fendermint/vm/actor_interface/src/burntfunds.rs
@@ -1,0 +1,6 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+// The burnt funds actor is just an Account actor.
+
+define_id!(BURNT_FUNDS { id: 99 });

--- a/fendermint/vm/actor_interface/src/lib.rs
+++ b/fendermint/vm/actor_interface/src/lib.rs
@@ -51,4 +51,5 @@ pub mod evm;
 pub mod init;
 pub mod multisig;
 pub mod placeholder;
+pub mod reward;
 pub mod system;

--- a/fendermint/vm/actor_interface/src/lib.rs
+++ b/fendermint/vm/actor_interface/src/lib.rs
@@ -26,17 +26,24 @@ macro_rules! define_code {
     };
 }
 
-macro_rules! define_singleton {
-    ($name:ident { id: $id:literal, code_id: $code_id:literal }) => {
+macro_rules! define_id {
+    ($name:ident { id: $id:literal }) => {
         paste::paste! {
             pub const [<$name _ACTOR_ID>]: fvm_shared::ActorID = $id;
             pub const [<$name _ACTOR_ADDR>]: fvm_shared::address::Address = fvm_shared::address::Address::new_id([<$name _ACTOR_ID>]);
         }
+    };
+}
+
+macro_rules! define_singleton {
+    ($name:ident { id: $id:literal, code_id: $code_id:literal }) => {
+        define_id!($name { id: $id });
         define_code!($name { code_id: $code_id });
     };
 }
 
 pub mod account;
+pub mod burntfunds;
 pub mod cron;
 pub mod eam;
 pub mod ethaccount;

--- a/fendermint/vm/actor_interface/src/reward.rs
+++ b/fendermint/vm/actor_interface/src/reward.rs
@@ -1,0 +1,8 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+// The reward actor is a singleton, but for now let's just use a
+// simple account, instead of the one in the built-in actors library,
+// because that has too many Filecoin mainnet specific things.
+
+define_id!(REWARD { id: 2 });

--- a/fendermint/vm/interpreter/src/fvm/genesis.rs
+++ b/fendermint/vm/interpreter/src/fvm/genesis.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use async_trait::async_trait;
-use fendermint_vm_actor_interface::{cron, eam, init, system, EMPTY_ARR};
+use fendermint_vm_actor_interface::{account, burntfunds, cron, eam, init, system, EMPTY_ARR};
 use fendermint_vm_core::{chainid, Timestamp};
 use fendermint_vm_genesis::{ActorMeta, Genesis, Validator};
 use fvm_ipld_blockstore::Blockstore;
@@ -48,10 +48,13 @@ where
     /// TODO:
     /// * burnt funds?
     /// * faucet?
+    /// * rewards?
     /// * IPC
     ///
-    /// See [Lotus](https://github.com/filecoin-project/lotus/blob/v1.20.4/chain/gen/genesis/genesis.go) for reference
-    /// and the [ref-fvm tester](https://github.com/filecoin-project/ref-fvm/blob/fvm%40v3.1.0/testing/integration/src/tester.rs#L99-L103).
+    /// See genesis initialization in:
+    /// * [Lotus](https://github.com/filecoin-project/lotus/blob/v1.20.4/chain/gen/genesis/genesis.go)
+    /// * [ref-fvm tester](https://github.com/filecoin-project/ref-fvm/blob/fvm%40v3.1.0/testing/integration/src/tester.rs#L99-L103)
+    /// * [fvm-workbench](https://github.com/anorth/fvm-workbench/blob/67219b3fd0b5654d54f722ab5acea6ec0abb2edc/builtin/src/genesis.rs)
     async fn init(
         &self,
         mut state: Self::State,
@@ -116,6 +119,17 @@ where
             eam::EAM_ACTOR_CODE_ID,
             eam::EAM_ACTOR_ID,
             &EMPTY_ARR,
+            TokenAmount::zero(),
+            None,
+        )?;
+
+        // Burnt funds actor (it's just an account).
+        state.create_actor(
+            account::ACCOUNT_ACTOR_CODE_ID,
+            burntfunds::BURNT_FUNDS_ACTOR_ID,
+            &account::State {
+                address: burntfunds::BURNT_FUNDS_ACTOR_ADDR,
+            },
             TokenAmount::zero(),
             None,
         )?;

--- a/fendermint/vm/interpreter/src/fvm/genesis.rs
+++ b/fendermint/vm/interpreter/src/fvm/genesis.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use async_trait::async_trait;
-use fendermint_vm_actor_interface::{account, burntfunds, cron, eam, init, system, EMPTY_ARR};
+use fendermint_vm_actor_interface::{
+    account, burntfunds, cron, eam, init, reward, system, EMPTY_ARR,
+};
 use fendermint_vm_core::{chainid, Timestamp};
 use fendermint_vm_genesis::{ActorMeta, Genesis, Validator};
 use fvm_ipld_blockstore::Blockstore;
@@ -79,13 +81,12 @@ where
         };
 
         // System actor
-        let system_state = system::State {
-            builtin_actors: state.manifest_data_cid,
-        };
         state.create_actor(
             system::SYSTEM_ACTOR_CODE_ID,
             system::SYSTEM_ACTOR_ID,
-            &system_state,
+            &system::State {
+                builtin_actors: state.manifest_data_cid,
+            },
             TokenAmount::zero(),
             None,
         )?;
@@ -103,13 +104,12 @@ where
         )?;
 
         // Cron actor
-        let cron_state = cron::State {
-            entries: vec![], // TODO: Maybe with the IPC.
-        };
         state.create_actor(
             cron::CRON_ACTOR_CODE_ID,
             cron::CRON_ACTOR_ID,
-            &cron_state,
+            &cron::State {
+                entries: vec![], // TODO: Maybe with the IPC.
+            },
             TokenAmount::zero(),
             None,
         )?;
@@ -129,6 +129,19 @@ where
             burntfunds::BURNT_FUNDS_ACTOR_ID,
             &account::State {
                 address: burntfunds::BURNT_FUNDS_ACTOR_ADDR,
+            },
+            TokenAmount::zero(),
+            None,
+        )?;
+
+        // A placeholder for the reward actor, beause I don't think
+        // using the one in the builtin actors library would be appropriate.
+        // This effectively burns the miner rewards. Better than panicking.
+        state.create_actor(
+            account::ACCOUNT_ACTOR_CODE_ID,
+            reward::REWARD_ACTOR_ID,
+            &account::State {
+                address: reward::REWARD_ACTOR_ADDR,
             },
             TokenAmount::zero(),
             None,

--- a/fendermint/vm/interpreter/src/fvm/query.rs
+++ b/fendermint/vm/interpreter/src/fvm/query.rs
@@ -70,10 +70,16 @@ where
                 // XXX: This value is for Filecoin, and it's not even used by the FVM, but at least it should not have a problem with it.
                 msg.gas_limit = BLOCK_GAS_LIMIT;
 
+                // TODO: This actually fails if the caller doesn't have enough gas.
+                //       Should we modify the state tree up front to give it more?
                 let apply_ret = state.call(*msg)?;
 
                 let est = GasEstimate {
                     exit_code: apply_ret.msg_receipt.exit_code,
+                    info: apply_ret
+                        .failure_info
+                        .map(|x| x.to_string())
+                        .unwrap_or_default(),
                     gas_limit: apply_ret.msg_receipt.gas_used,
                 };
 

--- a/fendermint/vm/interpreter/src/signed.rs
+++ b/fendermint/vm/interpreter/src/signed.rs
@@ -53,7 +53,9 @@ where
 
         match msg.verify(chain_id) {
             Err(SignedMessageError::Ipld(e)) => Err(anyhow!(e)),
-            Err(SignedMessageError::Ethereum(e)) => Err(e),
+            Err(SignedMessageError::Ethereum(e)) => {
+                Ok((state, Err(InvalidSignature(e.to_string()))))
+            }
             Err(SignedMessageError::InvalidSignature(s)) => {
                 // TODO: We can penalize the validator for including an invalid signature.
                 Ok((state, Err(InvalidSignature(s))))
@@ -98,7 +100,9 @@ where
 
         match verify_result {
             Err(SignedMessageError::Ipld(e)) => Err(anyhow!(e)),
-            Err(SignedMessageError::Ethereum(e)) => Err(e),
+            Err(SignedMessageError::Ethereum(e)) => {
+                Ok((state, Err(InvalidSignature(e.to_string()))))
+            }
             Err(SignedMessageError::InvalidSignature(s)) => {
                 // There is nobody we can punish for this, we can just tell Tendermint to discard this message,
                 // and potentially block the source IP address.

--- a/fendermint/vm/message/Cargo.toml
+++ b/fendermint/vm/message/Cargo.toml
@@ -32,9 +32,11 @@ fendermint_vm_actor_interface = { path = "../actor_interface" }
 fendermint_testing = { path = "../../testing", optional = true }
 
 [dev-dependencies]
+ethers = { workspace = true }
+hex = { workspace = true }
 quickcheck = { workspace = true }
 quickcheck_macros = { workspace = true }
-hex = { workspace = true }
+
 
 # Enable arb on self for tests.
 # Ideally we could do this with `#[cfg(any(test, feature = "arb"))]`,

--- a/fendermint/vm/message/src/conv/mod.rs
+++ b/fendermint/vm/message/src/conv/mod.rs
@@ -3,3 +3,79 @@
 
 pub mod from_eth;
 pub mod from_fvm;
+
+#[cfg(test)]
+pub mod tests {
+    use fendermint_testing::arb::{ArbMessage, ArbTokenAmount};
+    use fendermint_vm_actor_interface::{
+        eam::{self, EthAddress},
+        evm,
+    };
+    use fvm_ipld_encoding::{BytesSer, RawBytes};
+    use fvm_shared::{address::Address, bigint::Integer, econ::TokenAmount, message::Message};
+    use rand::{rngs::StdRng, SeedableRng};
+
+    use super::from_fvm::MAX_U256;
+
+    #[derive(Clone, Debug)]
+    struct EthDelegatedAddress(Address);
+
+    impl quickcheck::Arbitrary for EthDelegatedAddress {
+        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+            let mut subaddr: [u8; 20] = std::array::from_fn(|_| u8::arbitrary(g));
+            while EthAddress(subaddr).is_masked_id() {
+                subaddr[0] = u8::arbitrary(g);
+            }
+            Self(Address::new_delegated(eam::EAM_ACTOR_ID, &subaddr).unwrap())
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct EthTokenAmount(TokenAmount);
+
+    impl quickcheck::Arbitrary for EthTokenAmount {
+        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+            let t = ArbTokenAmount::arbitrary(g).0;
+            let (_, t) = t.atto().div_mod_floor(&MAX_U256);
+            Self(TokenAmount::from_atto(t))
+        }
+    }
+
+    /// Message that only contains data which can survive a roundtrip.
+    #[derive(Clone, Debug)]
+    pub struct EthMessage(pub Message);
+
+    impl quickcheck::Arbitrary for EthMessage {
+        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+            let mut m = ArbMessage::arbitrary(g).0;
+            m.version = 0;
+            m.method_num = evm::Method::InvokeContract as u64;
+            m.from = EthDelegatedAddress::arbitrary(g).0;
+            m.to = EthDelegatedAddress::arbitrary(g).0;
+            m.value = EthTokenAmount::arbitrary(g).0;
+            m.gas_fee_cap = EthTokenAmount::arbitrary(g).0;
+            m.gas_premium = EthTokenAmount::arbitrary(g).0;
+            // The random bytes will fail to deserialize.
+            // With the EVM we expect them to be IPLD serialized bytes.
+            m.params =
+                RawBytes::serialize(BytesSer(m.params.bytes())).expect("failedto serialize params");
+            Self(m)
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct KeyPair {
+        pub sk: libsecp256k1::SecretKey,
+        pub pk: libsecp256k1::PublicKey,
+    }
+
+    impl quickcheck::Arbitrary for KeyPair {
+        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+            let seed = u64::arbitrary(g);
+            let mut rng = StdRng::seed_from_u64(seed);
+            let sk = libsecp256k1::SecretKey::random(&mut rng);
+            let pk = libsecp256k1::PublicKey::from_secret_key(&sk);
+            Self { sk, pk }
+        }
+    }
+}

--- a/fendermint/vm/message/src/query.rs
+++ b/fendermint/vm/message/src/query.rs
@@ -71,6 +71,8 @@ pub struct ActorState {
 pub struct GasEstimate {
     /// Exit code, potentially signalling out-of-gas errors, or that the actor was not found.
     pub exit_code: ExitCode,
+    /// Any information about failed estimations.
+    pub info: String,
     /// Gas used during the probing.
     ///
     /// Potentially contains an over-estimate, but it should be within the account balance limit.

--- a/fendermint/vm/message/src/signed.rs
+++ b/fendermint/vm/message/src/signed.rs
@@ -260,27 +260,10 @@ mod tests {
     use fendermint_vm_actor_interface::eam::EthAddress;
     use fvm_shared::{address::Address, chainid::ChainID};
     use quickcheck_macros::quickcheck;
-    use rand::{rngs::StdRng, SeedableRng};
 
-    use crate::conv::from_fvm::tests::EthMessage;
+    use crate::conv::tests::{EthMessage, KeyPair};
 
     use super::SignedMessage;
-
-    #[derive(Debug, Clone)]
-    struct KeyPair {
-        sk: libsecp256k1::SecretKey,
-        pk: libsecp256k1::PublicKey,
-    }
-
-    impl quickcheck::Arbitrary for KeyPair {
-        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-            let seed = u64::arbitrary(g);
-            let mut rng = StdRng::seed_from_u64(seed);
-            let sk = libsecp256k1::SecretKey::random(&mut rng);
-            let pk = libsecp256k1::PublicKey::from_secret_key(&sk);
-            Self { sk, pk }
-        }
-    }
 
     #[quickcheck]
     fn chain_id_in_signature(
@@ -319,8 +302,6 @@ mod tests {
         let ea = EthAddress::new_secp256k1(&pk.serialize()).map_err(|e| e.to_string())?;
         let mut msg = msg.0;
         msg.from = Address::from(ea);
-
-        eprintln!("from = {:?}", msg.from);
 
         let signed =
             SignedMessage::new_secp256k1(msg, &sk, &chain_id).map_err(|e| e.to_string())?;


### PR DESCRIPTION
Part of #99 

Implements the following Ethereum API methods:
* `eth_call`
* `eth_estimateGas`

Using those, it tests transaction deployment of `SimpleCoin` and calling `get_balance` (a pure function exercising `eth_call`).