### PR TITLE
FM-99: Ethereum API methods (Part 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,6 +2337,7 @@ dependencies = [
  "cid",
  "ethers-core",
  "fendermint_vm_genesis",
+ "fil_actors_evm_shared",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
@@ -2462,6 +2472,49 @@ checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "fil_actors_evm_shared"
+version = "11.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#421855a7b968114ac59422c1faeca968482eccf4"
+dependencies = [
+ "fil_actors_runtime",
+ "fvm_ipld_encoding",
+ "fvm_shared",
+ "hex",
+ "serde",
+ "uint",
+]
+
+[[package]]
+name = "fil_actors_runtime"
+version = "11.0.0"
+source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#421855a7b968114ac59422c1faeca968482eccf4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "castaway",
+ "cid",
+ "fvm_ipld_amt",
+ "fvm_ipld_bitfield",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
+ "fvm_shared",
+ "itertools 0.10.5",
+ "log",
+ "multihash",
+ "num",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "regex",
+ "serde",
+ "serde_repr",
+ "sha2 0.10.6",
+ "thiserror",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -2822,6 +2875,18 @@ dependencies = [
  "once_cell",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "fvm_ipld_bitfield"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1950291f40d2d1047eb0a4568f7ef6d5b4973452dcef012dffb1957fe483ff7"
+dependencies = [
+ "fvm_ipld_encoding",
+ "serde",
+ "thiserror",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -3980,6 +4045,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3989,6 +4068,17 @@ dependencies = [
  "num-integer",
  "num-traits",
  "quickcheck 1.0.3",
+ "serde",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+dependencies = [
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -4010,6 +4100,30 @@ checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -43,7 +43,7 @@ use ethers_core::{
     k256::ecdsa::SigningKey,
     types::{
         transaction::eip2718::TypedTransaction, Address, BlockId, BlockNumber, Bytes,
-        Eip1559TransactionRequest, TransactionReceipt, H160, H256, U256, U64,
+        Eip1559TransactionRequest, SyncingStatus, TransactionReceipt, H160, H256, U256, U64,
     },
 };
 use fendermint_rpc::message::MessageFactory;
@@ -206,28 +206,28 @@ impl TestAccount {
 // - eth_getBlockReceipts
 // - eth_getStorageAt
 // - eth_getCode
+// - eth_syncing
 //
 // DOING:
 //
 // TODO:
-// - eth_newBlockFilter
-// - eth_newPendingTransactionFilter
-// - eth_syncing
-// - eth_createAccessList
+//
 // - eth_getLogs
 // - eth_newBlockFilter
+// - eth_newPendingTransactionFilter
 // - eth_newPendingTransactionFilter
 // - eth_newFilter
 // - eth_uninstallFilter
 // - eth_getFilterChanges
-// - eth_getProof
-// - eth_mining
 // - eth_subscribe
 // - eth_unsubscribe
 //
 // WON'T DO:
 // - eth_sign
 // - eth_sendTransaction
+// - eth_mining
+// - eth_createAccessList
+// - eth_getProof
 //
 
 /// Exercise the above methods, so we know at least the parameters are lined up correctly.
@@ -490,6 +490,10 @@ async fn run(provider: Provider<Http>, opts: Options) -> anyhow::Result<()> {
                 && ar.zip(br).take_while(|(a, b)| a == b).count() > 0
         },
     )?;
+
+    request("eth_syncing", mw.syncing().await, |s| {
+        *s == SyncingStatus::IsFalse // There is only one node.
+    })?;
 
     Ok(())
 }

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -204,11 +204,11 @@ impl TestAccount {
 // - eth_estimateGas
 //
 // DOING:
+// - eth_getBlockReceipts
 //
 // TODO:
 // - eth_newBlockFilter
 // - eth_newPendingTransactionFilter
-// - eth_getBlockReceipts
 // - eth_syncing
 // - eth_createAccessList
 // - eth_getLogs
@@ -385,6 +385,12 @@ async fn run(provider: Provider<Http>, opts: Options) -> anyhow::Result<()> {
         |tx| tx.is_some(),
     )?;
 
+    request(
+        "eth_getBlockReceipts",
+        provider.get_block_receipts(BlockNumber::Number(bn)).await,
+        |rs| !rs.is_empty(),
+    )?;
+
     // Calling with 0 nonce so the node figures out the latest value.
     let mut probe_tx = transfer.clone();
     probe_tx.set_nonce(0);
@@ -442,7 +448,8 @@ async fn run(provider: Provider<Http>, opts: Options) -> anyhow::Result<()> {
         &mut coin_call.tx,
         Some(BlockId::Number(BlockNumber::Latest)),
     )
-    .await?;
+    .await
+    .context("failed to fill call transaction")?;
 
     let coin_balance: U256 = coin_call.call().await.context("coin balance call failed")?;
 

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -13,13 +13,11 @@ use ethers_core::utils::rlp;
 use fendermint_rpc::message::MessageFactory;
 use fendermint_rpc::query::QueryClient;
 use fendermint_rpc::response::decode_fevm_invoke;
-use fendermint_vm_actor_interface::{evm, system};
+use fendermint_vm_actor_interface::evm;
 use fendermint_vm_message::chain::ChainMessage;
 use fendermint_vm_message::signed::SignedMessage;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::crypto::signature::Signature;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::message::Message;
 use fvm_shared::{chainid::ChainID, error::ExitCode};
 use jsonrpc_v2::Params;
 use tendermint_rpc::endpoint;
@@ -40,10 +38,6 @@ use crate::{
 };
 
 const MAX_FEE_HIST_SIZE: usize = 1024;
-
-/// Gas limit to set for read-only transactions
-/// where it's otherwise not specified.
-const READ_ONLY_GAS: u64 = fvm_shared::BLOCK_GAS_LIMIT;
 
 /// Returns a list of addresses owned by client.
 ///
@@ -558,16 +552,14 @@ where
 
 /// Returns the value from a storage position at a given address.
 ///
-/// The return value is a hex encoded H256.
+/// The return value is a hex encoded U256.
 pub async fn get_storage_at<C>(
     data: JsonRpcData<C>,
-    Params((address, position, block_number)): Params<(et::H160, et::U256, et::BlockNumber)>,
+    Params((address, position, block_id)): Params<(et::H160, et::U256, et::BlockId)>,
 ) -> JsonRpcResult<String>
 where
     C: Client + Sync + Send + Send,
 {
-    let header = data.header_by_height(block_number).await?;
-
     let params = evm::GetStorageAtParams {
         storage_key: {
             let mut bz = [0u8; 32];
@@ -577,38 +569,41 @@ where
     };
     let params = RawBytes::serialize(params).context("failed to serialize position to IPLD")?;
 
-    // We send off a read-only query to an EVM actor at the given address.
-    let message = Message {
-        version: Default::default(),
-        from: system::SYSTEM_ACTOR_ADDR,
-        to: to_fvm_address(address),
-        sequence: 0, // Let the node figure out the value.
-        value: TokenAmount::from_atto(0),
-        method_num: evm::Method::GetStorageAt as u64,
-        params,
-        gas_limit: READ_ONLY_GAS,
-        gas_fee_cap: TokenAmount::from_atto(0),
-        gas_premium: TokenAmount::from_atto(0),
-    };
-
-    let result = data
-        .client
-        .call(message, Some(header.height))
-        .await
-        .context("failed to call contract")?;
-
-    if result.value.code.is_err() {
-        return error(ExitCode::new(result.value.code.value()), result.value.info);
-    }
-
-    let data = fendermint_rpc::response::decode_bytes(&result.value)
-        .context("failed to decode data as bytes")?;
-
-    let data: evm::GetStorageAtReturn =
-        fvm_ipld_encoding::from_slice(&data).context("failed to decode as GetStorageAtReturn")?;
+    let ret: evm::GetStorageAtReturn = data
+        .read_evm_actor(address, evm::Method::GetStorageAt, params, block_id)
+        .await?;
 
     // The client library expects hex encoded string.
     let mut bz = [0u8; 32];
-    data.storage.to_big_endian(&mut bz);
+    ret.storage.to_big_endian(&mut bz);
     Ok(hex::encode(bz))
+}
+
+/// Returns code at a given address.
+pub async fn get_code<C>(
+    data: JsonRpcData<C>,
+    Params((address, block_id)): Params<(et::H160, et::BlockId)>,
+) -> JsonRpcResult<et::Bytes>
+where
+    C: Client + Sync + Send + Send,
+{
+    // This method has no input parameters.
+    let params = RawBytes::default();
+
+    let ret: evm::BytecodeReturn = data
+        .read_evm_actor(address, evm::Method::GetBytecode, params, block_id)
+        .await?;
+
+    match ret.code {
+        None => Ok(et::Bytes::default()),
+        Some(cid) => {
+            let code = data
+                .client
+                .ipld(&cid)
+                .await
+                .context("failed to fetch bytecode")?;
+
+            Ok(code.map(et::Bytes::from).unwrap_or_default())
+        }
+    }
 }

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -20,7 +20,7 @@ use fvm_ipld_encoding::RawBytes;
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::{chainid::ChainID, error::ExitCode};
 use jsonrpc_v2::Params;
-use tendermint_rpc::endpoint;
+use tendermint_rpc::endpoint::{self, status};
 use tendermint_rpc::{
     endpoint::{block, block_results, broadcast::tx_sync, consensus_params, header},
     Client,
@@ -59,7 +59,7 @@ where
 /// Returns the chain ID used for signing replay-protected transactions.
 pub async fn chain_id<C>(data: JsonRpcData<C>) -> JsonRpcResult<et::U64>
 where
-    C: Client + Sync + Send + Send,
+    C: Client + Sync + Send,
 {
     let res = data.client.state_params(None).await?;
     Ok(et::U64::from(res.value.chain_id))
@@ -75,7 +75,7 @@ pub async fn fee_history<C>(
     )>,
 ) -> JsonRpcResult<et::FeeHistory>
 where
-    C: Client + Sync + Send + Send,
+    C: Client + Sync + Send,
 {
     if block_count > et::U256::from(MAX_FEE_HIST_SIZE) {
         return error(
@@ -179,7 +179,7 @@ where
 /// Returns the current price per gas in wei.
 pub async fn gas_price<C>(data: JsonRpcData<C>) -> JsonRpcResult<et::U256>
 where
-    C: Client + Sync + Send + Send,
+    C: Client + Sync + Send,
 {
     let res = data.client.state_params(None).await?;
     let price = to_eth_tokens(&res.value.base_fee)?;
@@ -192,7 +192,7 @@ pub async fn get_balance<C>(
     Params((addr, block_id)): Params<(et::Address, et::BlockId)>,
 ) -> JsonRpcResult<et::U256>
 where
-    C: Client + Sync + Send + Send,
+    C: Client + Sync + Send,
 {
     let header = data.header_by_id(block_id).await?;
     let height = header.height;
@@ -211,7 +211,7 @@ pub async fn get_block_by_hash<C>(
     Params((block_hash, full_tx)): Params<(et::H256, bool)>,
 ) -> JsonRpcResult<Option<et::Block<serde_json::Value>>>
 where
-    C: Client + Sync + Send + Send,
+    C: Client + Sync + Send,
 {
     match data.block_by_hash_opt(block_hash).await? {
         Some(block) => data.enrich_block(block, full_tx).await.map(Some),
@@ -269,7 +269,7 @@ pub async fn get_transaction_by_block_hash_and_index<C>(
     Params((block_hash, index)): Params<(et::H256, et::U64)>,
 ) -> JsonRpcResult<Option<et::Transaction>>
 where
-    C: Client + Sync + Send + Send,
+    C: Client + Sync + Send,
 {
     if let Some(block) = data.block_by_hash_opt(block_hash).await? {
         data.transaction_by_index(block, index).await
@@ -284,7 +284,7 @@ pub async fn get_transaction_by_block_number_and_index<C>(
     Params((block_number, index)): Params<(et::BlockNumber, et::U64)>,
 ) -> JsonRpcResult<Option<et::Transaction>>
 where
-    C: Client + Sync + Send + Send,
+    C: Client + Sync + Send,
 {
     let block = data.block_by_height(block_number).await?;
     data.transaction_by_index(block, index).await
@@ -296,7 +296,7 @@ pub async fn get_transaction_by_hash<C>(
     Params((tx_hash,)): Params<(et::H256,)>,
 ) -> JsonRpcResult<Option<et::Transaction>>
 where
-    C: Client + Sync + Send + Send,
+    C: Client + Sync + Send,
 {
     let hash = to_tm_hash(&tx_hash)?;
 
@@ -330,7 +330,7 @@ pub async fn get_transaction_count<C>(
     Params((addr, block_id)): Params<(et::Address, et::BlockId)>,
 ) -> JsonRpcResult<et::U64>
 where
-    C: Client + Sync + Send + Send,
+    C: Client + Sync + Send,
 {
     let header = data.header_by_id(block_id).await?;
     let height = header.height;
@@ -352,7 +352,7 @@ pub async fn get_transaction_receipt<C>(
     Params((tx_hash,)): Params<(et::H256,)>,
 ) -> JsonRpcResult<Option<et::TransactionReceipt>>
 where
-    C: Client + Sync + Send + Send,
+    C: Client + Sync + Send,
 {
     let hash = to_tm_hash(&tx_hash)?;
 
@@ -475,7 +475,7 @@ pub async fn send_raw_transaction<C>(
     Params((tx,)): Params<(et::Bytes,)>,
 ) -> JsonRpcResult<et::TxHash>
 where
-    C: Client + Sync + Send + Send,
+    C: Client + Sync + Send,
 {
     let rlp = rlp::Rlp::new(tx.as_ref());
     let (tx, sig) = TypedTransaction::decode_signed(&rlp)
@@ -505,7 +505,7 @@ pub async fn call<C>(
     Params((tx, block_id)): Params<(TypedTransaction, et::BlockId)>,
 ) -> JsonRpcResult<et::Bytes>
 where
-    C: Client + Sync + Send + Send,
+    C: Client + Sync + Send,
 {
     let msg = to_fvm_message(tx)?;
     let header = data.header_by_id(block_id).await?;
@@ -532,7 +532,7 @@ pub async fn estimate_gas<C>(
     Params((tx, block_id)): Params<(TypedTransaction, et::BlockId)>,
 ) -> JsonRpcResult<et::U256>
 where
-    C: Client + Sync + Send + Send,
+    C: Client + Sync + Send,
 {
     let msg = to_fvm_message(tx)?;
     let header = data.header_by_id(block_id).await?;
@@ -558,7 +558,7 @@ pub async fn get_storage_at<C>(
     Params((address, position, block_id)): Params<(et::H160, et::U256, et::BlockId)>,
 ) -> JsonRpcResult<String>
 where
-    C: Client + Sync + Send + Send,
+    C: Client + Sync + Send,
 {
     let params = evm::GetStorageAtParams {
         storage_key: {
@@ -585,7 +585,7 @@ pub async fn get_code<C>(
     Params((address, block_id)): Params<(et::H160, et::BlockId)>,
 ) -> JsonRpcResult<et::Bytes>
 where
-    C: Client + Sync + Send + Send,
+    C: Client + Sync + Send,
 {
     // This method has no input parameters.
     let params = RawBytes::default();
@@ -606,4 +606,42 @@ where
             Ok(code.map(et::Bytes::from).unwrap_or_default())
         }
     }
+}
+
+/// Returns an object with data about the sync status or false.
+pub async fn syncing<C>(data: JsonRpcData<C>) -> JsonRpcResult<et::SyncingStatus>
+where
+    C: Client + Sync + Send,
+{
+    let status: status::Response = data.tm().status().await.context("failed to fetch status")?;
+    let info = status.sync_info;
+    let status = if !info.catching_up {
+        et::SyncingStatus::IsFalse
+    } else {
+        let progress = et::SyncProgress {
+            // This would be the block we executed.
+            current_block: et::U64::from(info.latest_block_height.value()),
+            // This would be the block we know about but haven't got to yet.
+            highest_block: et::U64::from(info.latest_block_height.value()),
+            // This would be the block we started syncing from.
+            starting_block: Default::default(),
+            pulled_states: None,
+            known_states: None,
+            healed_bytecode_bytes: None,
+            healed_bytecodes: None,
+            healed_trienode_bytes: None,
+            healed_trienodes: None,
+            healing_bytecode: None,
+            healing_trienodes: None,
+            synced_account_bytes: None,
+            synced_accounts: None,
+            synced_bytecode_bytes: None,
+            synced_bytecodes: None,
+            synced_storage: None,
+            synced_storage_bytes: None,
+        };
+        et::SyncingStatus::IsSyncing(Box::new(progress))
+    };
+
+    Ok(status)
 }

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -43,6 +43,7 @@ pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRo
         getBlockByNumber,
         getBlockTransactionCountByHash,
         getBlockTransactionCountByNumber,
+        getBlockReceipts,
         // eth_getCode
         // eth_getCompilers
         // eth_getFilterChanges

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -66,13 +66,13 @@ pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRo
         // eth_newFilter
         // eth_newPendingTransactionFilter
         // eth_protocolVersion
-        sendRawTransaction
+        sendRawTransaction,
         // eth_sendTransaction
         // eth_sign
         // eth_signTransaction
         // eth_submitHashrate
         // eth_submitWork
-        // eth_syncing
+        syncing
         // eth_uninstallFilter
     })
 }

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -44,7 +44,7 @@ pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRo
         getBlockTransactionCountByHash,
         getBlockTransactionCountByNumber,
         getBlockReceipts,
-        // eth_getCode
+        getCode,
         // eth_getCompilers
         // eth_getFilterChanges
         // eth_getFilterLogs

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -49,7 +49,7 @@ pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRo
         // eth_getFilterChanges
         // eth_getFilterLogs
         // eth_getLogs
-        // eth_getStorageAt
+        getStorageAt,
         getTransactionByBlockHashAndIndex,
         getTransactionByBlockNumberAndIndex,
         getTransactionByHash,

--- a/fendermint/vm/actor_interface/Cargo.toml
+++ b/fendermint/vm/actor_interface/Cargo.toml
@@ -27,6 +27,11 @@ fvm_ipld_blockstore = { workspace = true }
 
 fendermint_vm_genesis = { path = "../genesis" }
 
+# We are using the bundle for the builtin-actors dependency, and repeating DTO classes on our side,
+# to cut down the time it takes to compile everything. However, some projects have a "shared" part,
+# and this copy-paste is clunky, so at least for those that have it, we should use it.
+fil_actors_evm_shared = { git = "https://github.com/filecoin-project/builtin-actors", branch = "next" }
+
 [dev-dependencies]
 ethers-core = { workspace = true }
 libsecp256k1 = { workspace = true }

--- a/fendermint/vm/actor_interface/src/eam.rs
+++ b/fendermint/vm/actor_interface/src/eam.rs
@@ -25,6 +25,7 @@ pub enum Method {
     CreateExternal = 4,
 }
 
+// TODO: We could re-export `fil_evm_actor_shared::address::EvmAddress`.
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EthAddress(#[serde(with = "strict_bytes")] pub [u8; 20]);
 

--- a/fendermint/vm/actor_interface/src/evm.rs
+++ b/fendermint/vm/actor_interface/src/evm.rs
@@ -5,6 +5,8 @@ use cid::Cid;
 use fvm_shared::METHOD_CONSTRUCTOR;
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
+pub use fil_actors_evm_shared::uints;
+
 define_code!(EVM { code_id: 14 });
 
 #[repr(u64)]
@@ -22,8 +24,21 @@ pub enum Method {
     InvokeContract = 3844450837,
 }
 
+// XXX: I don't know why the following arent' part of `fil_actors_evm_shared` :(
+
 #[derive(Serialize_tuple, Deserialize_tuple)]
 #[serde(transparent)]
 pub struct BytecodeReturn {
     pub code: Option<Cid>,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct GetStorageAtParams {
+    pub storage_key: uints::U256,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+#[serde(transparent)]
+pub struct GetStorageAtReturn {
+    pub storage: uints::U256,
 }


### PR DESCRIPTION
Part of #99 

Added new methods:
* eth_getBlockReceipts
* eth_getStorageAt
* eth_code
* eth_syncing

What's left are methods of the event API (which require web sockets) and non-eth methods.