### PR TITLE
FM-99: Ethereum API methods (Part 6)

### DIFF
--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -242,6 +242,10 @@ async fn run(provider: Provider<Http>, opts: Options) -> anyhow::Result<()> {
         v.starts_with("fendermint/")
     })?;
 
+    request("net_version", provider.get_net_version().await, |v| {
+        !v.is_empty() && v.chars().all(|c| c.is_numeric())
+    })?;
+
     request("eth_accounts", provider.get_accounts().await, |acnts| {
         acnts.is_empty()
     })?;

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -207,6 +207,7 @@ impl TestAccount {
 // - eth_getStorageAt
 // - eth_getCode
 // - eth_syncing
+// - web3_clientVersion
 //
 // DOING:
 //
@@ -236,6 +237,10 @@ async fn run(provider: Provider<Http>, opts: Options) -> anyhow::Result<()> {
     let to = TestAccount::new(&opts.secret_key_to)?;
 
     tracing::info!(from = ?from.eth_addr, to = ?to.eth_addr, "ethereum address");
+
+    request("web3_clientVersion", provider.client_version().await, |v| {
+        v.starts_with("fendermint/")
+    })?;
 
     request("eth_accounts", provider.get_accounts().await, |acnts| {
         acnts.is_empty()

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -65,6 +65,16 @@ where
     Ok(et::U64::from(res.value.chain_id))
 }
 
+/// The current FVM network version.
+pub async fn protocol_version<C>(data: JsonRpcData<C>) -> JsonRpcResult<String>
+where
+    C: Client + Sync + Send,
+{
+    let res = data.client.state_params(None).await?;
+    let version: u32 = res.value.network_version.into();
+    Ok(version.to_string())
+}
+
 /// Returns transaction base fee per gas and effective priority fee per gas for the requested/supported block range.
 pub async fn fee_history<C>(
     data: JsonRpcData<C>,

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -9,6 +9,7 @@ use paste::paste;
 use tendermint_rpc::HttpClient;
 
 mod eth;
+mod web3;
 
 macro_rules! with_methods {
     ($server:ident, $module:ident, { $($method:ident),* }) => {
@@ -26,7 +27,7 @@ pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRo
     // This is the list of eth methods. Apart from these Lotus implements 1 method from web3,
     // while Ethermint does more across web3, debug, miner, net, txpool, and personal.
     // The unimplemented ones are commented out, to make it easier to see where we're at.
-    with_methods!(server, eth, {
+    let server = with_methods!(server, eth, {
         accounts,
         blockNumber,
         call,
@@ -74,5 +75,10 @@ pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRo
         // eth_submitWork
         syncing
         // eth_uninstallFilter
+    });
+
+    with_methods!(server, web3, {
+        clientVersion
+        // web3_sha
     })
 }

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -78,7 +78,7 @@ pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRo
     });
 
     with_methods!(server, web3, {
-        clientVersion
-        // web3_sha
+        clientVersion,
+        sha3
     })
 }

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -9,6 +9,7 @@ use paste::paste;
 use tendermint_rpc::HttpClient;
 
 mod eth;
+mod net;
 mod web3;
 
 macro_rules! with_methods {
@@ -77,8 +78,14 @@ pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRo
         // eth_uninstallFilter
     });
 
-    with_methods!(server, web3, {
+    let server = with_methods!(server, web3, {
         clientVersion,
         sha3
+    });
+
+    with_methods!(server, net, {
+        version,
+        listening,
+        peerCount
     })
 }

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -65,7 +65,7 @@ pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRo
         // eth_newBlockFilter
         // eth_newFilter
         // eth_newPendingTransactionFilter
-        // eth_protocolVersion
+        protocolVersion,
         sendRawTransaction,
         // eth_sendTransaction
         // eth_sign

--- a/fendermint/eth/api/src/apis/net.rs
+++ b/fendermint/eth/api/src/apis/net.rs
@@ -1,0 +1,50 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use anyhow::Context;
+use ethers_core::types as et;
+use fendermint_rpc::query::QueryClient;
+use tendermint_rpc::endpoint::net_info;
+use tendermint_rpc::Client;
+
+use crate::{JsonRpcData, JsonRpcResult};
+
+/// The current FVM network version.
+///
+/// Same as eth_protocolVersion
+pub async fn version<C>(data: JsonRpcData<C>) -> JsonRpcResult<String>
+where
+    C: Client + Sync + Send,
+{
+    let res = data.client.state_params(None).await?;
+    let version: u32 = res.value.network_version.into();
+    Ok(version.to_string())
+}
+
+/// Returns true if client is actively listening for network connections.
+pub async fn listening<C>(data: JsonRpcData<C>) -> JsonRpcResult<bool>
+where
+    C: Client + Sync + Send,
+{
+    let res: net_info::Response = data
+        .tm()
+        .net_info()
+        .await
+        .context("failed to fetch net_info")?;
+
+    Ok(res.listening)
+}
+
+/// Returns true if client is actively listening for network connections.
+pub async fn peer_count<C>(data: JsonRpcData<C>) -> JsonRpcResult<et::U64>
+where
+    C: Client + Sync + Send,
+{
+    let res: net_info::Response = data
+        .tm()
+        .net_info()
+        .await
+        .context("failed to fetch net_info")?;
+
+    Ok(et::U64::from(res.n_peers))
+}

--- a/fendermint/eth/api/src/apis/web3.rs
+++ b/fendermint/eth/api/src/apis/web3.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use anyhow::Context;
+use cid::multihash::MultihashDigest;
+use jsonrpc_v2::Params;
 use tendermint::abci;
 use tendermint_rpc::Client;
 
@@ -21,4 +23,21 @@ where
     let version = format!("{}/{}/{}", res.data, res.version, res.app_version);
 
     Ok(version)
+}
+
+/// Returns Keccak-256 (not the standardized SHA3-256) of the given data.
+///
+/// Expects the data as hex encoded string and returns it as such.
+pub async fn sha3<C>(
+    _data: JsonRpcData<C>,
+    Params((input,)): Params<(String,)>,
+) -> JsonRpcResult<String>
+where
+    C: Client + Sync + Send,
+{
+    let input = input.strip_prefix("0x").unwrap_or(&input);
+    let input = hex::decode(input).context("failed to decode input as hex")?;
+    let output = cid::multihash::Code::Keccak256.digest(&input);
+    let output = hex::encode(output.digest());
+    Ok(output)
 }

--- a/fendermint/eth/api/src/apis/web3.rs
+++ b/fendermint/eth/api/src/apis/web3.rs
@@ -1,0 +1,24 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use anyhow::Context;
+use tendermint::abci;
+use tendermint_rpc::Client;
+
+use crate::{JsonRpcData, JsonRpcResult};
+
+/// Returns the current client version.
+pub async fn client_version<C>(data: JsonRpcData<C>) -> JsonRpcResult<String>
+where
+    C: Client + Sync + Send,
+{
+    let res: abci::response::Info = data
+        .tm()
+        .abci_info()
+        .await
+        .context("failed to fetch info")?;
+
+    let version = format!("{}/{}/{}", res.data, res.version, res.app_version);
+
+    Ok(version)
+}


### PR DESCRIPTION
Part of #99 

Closes #133 and #134 

* eth_protocolVersion
* web3_clientVersion
* web3_sha3
* net_version
* net_listening
* net_peerCount

All that's left is the event API (filters and subscriptions).