### PR TITLE
FM-137: Ethereum API filter methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2229,6 +2229,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "serde",
  "serde_json",
+ "serde_with",
  "tempfile",
  "tendermint",
  "tendermint-proto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-tungstenite"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0388bb7a400072bbb41ceb75d65c3baefb2ea99672fa22e85278452cd9b58b"
+dependencies = [
+ "futures-io",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "rustls-native-certs 0.6.3",
+ "tokio",
+ "tokio-rustls 0.23.4",
+ "tungstenite",
+]
+
+[[package]]
 name = "async_io_stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3319,7 +3335,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-rustls 0.22.1",
- "rustls-native-certs",
+ "rustls-native-certs 0.5.0",
  "tokio",
  "tokio-rustls 0.22.0",
  "tower-service",
@@ -3337,7 +3353,7 @@ dependencies = [
  "hyper",
  "log",
  "rustls 0.19.1",
- "rustls-native-certs",
+ "rustls-native-certs 0.5.0",
  "tokio",
  "tokio-rustls 0.22.0",
  "webpki 0.21.4",
@@ -5211,6 +5227,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6158,6 +6186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "120ccb296a0ec4485ddb78eb842e481d7a859d5659e0f1881456f8c127d5e950"
 dependencies = [
  "async-trait",
+ "async-tungstenite",
  "bytes",
  "flex-error",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,5 +82,5 @@ cid = { version = "0.8", features = ["serde-codec", "std"] }
 # Using the same tendermint-rs dependency as tower-abci. From both we are interested in v037 modules.
 tower-abci = { version = "0.7" }
 tendermint = { version = "0.31", features = ["secp256k1"] }
-tendermint-rpc = { version = "0.31", features = ["secp256k1", "http-client"] }
+tendermint-rpc = { version = "0.31", features = ["secp256k1", "http-client", "websocket-client"] }
 tendermint-proto = { version = "0.31" }

--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -21,9 +21,8 @@ CMD ["run"]
 
 STOPSIGNAL SIGTERM
 
-ENV FM_ABCI__HOST=0.0.0.0
-ENV FM_ETH__HTTP__HOST=0.0.0.0
-ENV FM_ETH__WS__HOST=0.0.0.0
+ENV FM_ABCI__LISTEN__HOST=0.0.0.0
+ENV FM_ETH__LISTEN__HOST=0.0.0.0
 
 COPY fendermint/app/config $FM_HOME_DIR/config
 COPY docker/.artifacts/bundle.car $FM_HOME_DIR/bundle.car

--- a/docker/local.Dockerfile
+++ b/docker/local.Dockerfile
@@ -31,9 +31,8 @@ CMD ["run"]
 
 STOPSIGNAL SIGTERM
 
-ENV FM_ABCI__HOST=0.0.0.0
-ENV FM_ETH__HTTP__HOST=0.0.0.0
-ENV FM_ETH__WS__HOST=0.0.0.0
+ENV FM_ABCI__LISTEN__HOST=0.0.0.0
+ENV FM_ETH__LISTEN__HOST=0.0.0.0
 
 # We could build the actor bundles in the `builder` as well,
 # but we should be able to copy it from somewhere.

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -22,6 +22,7 @@ prost = { workspace = true }
 rand_chacha = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_with = { workspace = true }
 tendermint = { workspace = true }
 tendermint-rpc = { workspace = true }
 tendermint-proto = { workspace = true }

--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -4,29 +4,24 @@ data_dir = "data"
 builtin_actors_bundle = "bundle.car"
 
 [abci]
+bound = 1
+
+[abci.listen]
 # Only accept connections from Tendermint, assumed to be running locally.
 host = "127.0.0.1"
 # The default port where Tendermint is going to connect to the application.
 port = 26658
-bound = 1
 
 [db]
 # Keep unlimited history by default.
 state_hist_size = 0
 
-# Ethereum API facade.
+# Ethereum API facade
 [eth]
 
-# Ethereum API facade for JSON-RPC.
-[eth.http]
+[eth.listen]
 # Only accept local connections by default.
 host = "127.0.0.1"
-# The default port where the Ethereum JSON-RPC API will listen to connections.
+# The default port where the Ethereum API will listen to
+# JSON-RPC (POST) and WebSockets (GET) requests.
 port = 8545
-
-# Ethereum API facade for WebSockets.
-[eth.ws]
-# Only accept local connections by default.
-host = "127.0.0.1"
-# The default port where the Ethereum WebSocket API will listen to connections.
-port = 8546

--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -18,6 +18,8 @@ state_hist_size = 0
 
 # Ethereum API facade
 [eth]
+# Maximum time allowed between polls for filter changes, in seconds, before the subscription is canceled.
+filter_timeout = 300
 
 [eth.listen]
 # Only accept local connections by default.

--- a/fendermint/app/src/cmd/eth.rs
+++ b/fendermint/app/src/cmd/eth.rs
@@ -29,5 +29,5 @@ cmd! {
 
 /// Run the Ethereum
 async fn run(settings: EthSettings, client: WebSocketClient) -> anyhow::Result<()> {
-    fendermint_eth_api::listen(settings.listen.addr(), client).await
+    fendermint_eth_api::listen(settings.listen.addr(), client, settings.filter_timeout).await
 }

--- a/fendermint/app/src/cmd/eth.rs
+++ b/fendermint/app/src/cmd/eth.rs
@@ -23,5 +23,5 @@ cmd! {
 
 /// Run the Ethereum
 async fn run(settings: EthSettings, client: HttpClient) -> anyhow::Result<()> {
-    fendermint_eth_api::listen(settings.http.addr(), client).await
+    fendermint_eth_api::listen(settings.listen.addr(), client).await
 }

--- a/fendermint/app/src/cmd/eth.rs
+++ b/fendermint/app/src/cmd/eth.rs
@@ -1,8 +1,8 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use fendermint_rpc::client::http_client;
-use tendermint_rpc::HttpClient;
+use fendermint_rpc::client::ws_client;
+use tendermint_rpc::WebSocketClient;
 
 use crate::{
     cmd,
@@ -13,15 +13,21 @@ use crate::{
 cmd! {
   EthArgs(self, settings: EthSettings) {
     match self.command.clone() {
-      EthCommands::Run { url, proxy_url } => {
-        let client = http_client(url, proxy_url)?;
-        run(settings, client).await
+      EthCommands::Run { url, proxy_url: _ } => {
+        let (client, driver) = ws_client(url).await?;
+        let driver_handle = tokio::spawn(async move { driver.run().await });
+
+        let result = run(settings, client).await;
+
+        // Await the driver's termination to ensure proper connection closure.
+        let _ = driver_handle.await;
+        result
       }
     }
   }
 }
 
 /// Run the Ethereum
-async fn run(settings: EthSettings, client: HttpClient) -> anyhow::Result<()> {
+async fn run(settings: EthSettings, client: WebSocketClient) -> anyhow::Result<()> {
     fendermint_eth_api::listen(settings.listen.addr(), client).await
 }

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -58,7 +58,7 @@ async fn run(settings: Settings) -> anyhow::Result<()> {
 
     // Run the ABCI server.
     server
-        .listen(settings.abci.listen_addr())
+        .listen(settings.abci.listen.addr())
         .await
         .map_err(|e| anyhow!("error listening: {e}"))?;
 

--- a/fendermint/app/src/options/eth.rs
+++ b/fendermint/app/src/options/eth.rs
@@ -18,8 +18,8 @@ pub enum EthCommands {
         #[arg(
             long,
             short,
-            default_value = "http://127.0.0.1:26657",
-            env = "TENDERMINT_RPC_URL"
+            default_value = "ws://127.0.0.1:26657/websocket",
+            env = "TENDERMINT_WS_URL"
         )]
         url: Url,
 

--- a/fendermint/app/src/settings.rs
+++ b/fendermint/app/src/settings.rs
@@ -6,28 +6,6 @@ use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Deserialize)]
-pub struct AbciSettings {
-    pub host: String,
-    pub port: u32,
-    /// Queue size for each ABCI component.
-    pub bound: usize,
-}
-
-impl AbciSettings {
-    pub fn listen_addr(&self) -> String {
-        format!("{}:{}", self.host, self.port)
-    }
-}
-
-#[derive(Debug, Deserialize)]
-pub struct DbSettings {
-    /// Length of the app state history to keep in the database before pruning; 0 means unlimited.
-    ///
-    /// This affects how long we can go back in state queries.
-    pub state_hist_size: u64,
-}
-
-#[derive(Debug, Deserialize)]
 pub struct Address {
     pub host: String,
     pub port: u32,
@@ -39,13 +17,25 @@ impl Address {
     }
 }
 
+#[derive(Debug, Deserialize)]
+pub struct AbciSettings {
+    pub listen: Address,
+    /// Queue size for each ABCI component.
+    pub bound: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DbSettings {
+    /// Length of the app state history to keep in the database before pruning; 0 means unlimited.
+    ///
+    /// This affects how long we can go back in state queries.
+    pub state_hist_size: u64,
+}
+
 /// Ethereum API facade settings.
 #[derive(Debug, Deserialize)]
 pub struct EthSettings {
-    /// Listen address for JSON-RPC
-    pub http: Address,
-    /// Listen address for WebSockets
-    pub ws: Address,
+    pub listen: Address,
 }
 
 #[derive(Debug, Deserialize)]

--- a/fendermint/app/src/settings.rs
+++ b/fendermint/app/src/settings.rs
@@ -3,7 +3,11 @@
 
 use config::{Config, ConfigError, Environment, File};
 use serde::Deserialize;
-use std::path::{Path, PathBuf};
+use serde_with::{serde_as, DurationSeconds};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 #[derive(Debug, Deserialize)]
 pub struct Address {
@@ -33,9 +37,12 @@ pub struct DbSettings {
 }
 
 /// Ethereum API facade settings.
+#[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct EthSettings {
     pub listen: Address,
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub filter_timeout: Duration,
 }
 
 #[derive(Debug, Deserialize)]

--- a/fendermint/app/src/tmconv.rs
+++ b/fendermint/app/src/tmconv.rs
@@ -112,6 +112,24 @@ pub fn to_begin_block(ret: FvmApplyRet) -> response::BeginBlock {
 }
 
 /// Convert events to key-value pairs.
+///
+///
+/// Fot the EVM, they are returned like so:
+///
+/// ```text
+/// StampedEvent { emitter: 103,
+///  event: ActorEvent { entries: [
+///    Entry { flags: FLAG_INDEXED_VALUE, key: "t1", value: RawBytes { 5820ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef } },
+///    Entry { flags: FLAG_INDEXED_VALUE, key: "t2", value: RawBytes { 54ff00000000000000000000000000000000000065 } },
+///    Entry { flags: FLAG_INDEXED_VALUE, key: "t3", value: RawBytes { 54ff00000000000000000000000000000000000066 } },
+///    Entry { flags: FLAG_INDEXED_VALUE, key: "d", value: RawBytes { 582000000000000000000000000000000000000000000000000000000000000007d0 } }] } }
+/// ```
+///
+/// The values are:
+/// * "t1" will be the cbor encoded keccak-256 hash of the event signature Transfer(address,address,uint256)
+/// * "t2" will be the first indexed argument, i.e. _from  (cbor encoded byte array; needs padding to 32 bytes to work with ethers)
+/// * "t3" will be the second indexed argument, i.e. _to (cbor encoded byte array; needs padding to 32 bytes to work with ethers)
+/// * "d" is a cbor encoded byte array of all the remaining arguments
 pub fn to_events(kind: &str, stamped_events: Vec<StampedEvent>) -> Vec<Event> {
     stamped_events
         .into_iter()

--- a/fendermint/eth/api/Cargo.toml
+++ b/fendermint/eth/api/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 tendermint = { workspace = true }
 tendermint-rpc = { workspace = true }
+tokio = { workspace = true }
 
 cid = { workspace = true }
 fvm_shared = { workspace = true }
@@ -42,7 +43,6 @@ tracing-subscriber = { workspace = true }
 quickcheck = { workspace = true }
 quickcheck_macros = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
 
 fendermint_testing = { path = "../../testing", features = ["arb"] }
 fendermint_vm_message = { path = "../../vm/message", features = ["arb"] }

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -552,6 +552,15 @@ async fn run(provider: Provider<Http>, opts: Options) -> anyhow::Result<()> {
         |logs| *logs == receipt.logs,
     )?;
 
+    // TODO: See what kind of events were logged.
+
+    // Uninstall all filters.
+    for id in [blocks_filter_id, logs_filter_id, txns_filter_id] {
+        request("eth_uninstallFilter", mw.uninstall_filter(id).await, |ok| {
+            *ok
+        })?;
+    }
+
     Ok(())
 }
 

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -237,7 +237,7 @@ async fn run(provider: Provider<Http>, opts: Options) -> anyhow::Result<()> {
 
     tracing::info!(from = ?from.eth_addr, to = ?to.eth_addr, "ethereum address");
 
-    // Set up a filter to collect events.
+    // Set up filters to collect events.
     let logs_filter_id = request(
         "eth_newFilter",
         provider
@@ -554,13 +554,13 @@ async fn run(provider: Provider<Http>, opts: Options) -> anyhow::Result<()> {
 
     // See what kind of events were logged.
     request(
-        "eth_getFilterChanges",
+        "eth_getFilterChanges (blocks)",
         mw.get_filter_changes(blocks_filter_id).await,
         |block_hashes: &Vec<H256>| block_hashes.contains(&bh),
     )?;
 
     request(
-        "eth_getFilterChanges",
+        "eth_getFilterChanges (txs)",
         mw.get_filter_changes(txs_filter_id).await,
         |tx_hashes: &Vec<H256>| tx_hashes.contains(&tx_hash),
     )?;

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -43,8 +43,8 @@ use ethers_core::{
     k256::ecdsa::SigningKey,
     types::{
         transaction::eip2718::TypedTransaction, Address, BlockId, BlockNumber, Bytes,
-        Eip1559TransactionRequest, Filter, SyncingStatus, TransactionReceipt, H160, H256, U256,
-        U64,
+        Eip1559TransactionRequest, Filter, Log, SyncingStatus, TransactionReceipt, H160, H256,
+        U256, U64,
     },
 };
 use fendermint_rpc::message::MessageFactory;
@@ -238,6 +238,8 @@ async fn run(provider: Provider<Http>, opts: Options) -> anyhow::Result<()> {
     tracing::info!(from = ?from.eth_addr, to = ?to.eth_addr, "ethereum address");
 
     // Set up filters to collect events.
+    let mut filter_ids = Vec::new();
+
     let logs_filter_id = request(
         "eth_newFilter",
         provider
@@ -245,18 +247,21 @@ async fn run(provider: Provider<Http>, opts: Options) -> anyhow::Result<()> {
             .await,
         |_| true,
     )?;
+    filter_ids.push(logs_filter_id);
 
     let blocks_filter_id = request(
         "eth_newBlockFilter",
         provider.new_filter(FilterKind::NewBlocks).await,
         |id| *id != logs_filter_id,
     )?;
+    filter_ids.push(blocks_filter_id);
 
     let txs_filter_id = request(
         "eth_newPendingTransactionFilter",
         provider.new_filter(FilterKind::PendingTransactions).await,
-        |id| *id != logs_filter_id && *id != blocks_filter_id,
+        |id| *id != logs_filter_id,
     )?;
+    filter_ids.push(txs_filter_id);
 
     request("web3_clientVersion", provider.client_version().await, |v| {
         v.starts_with("fendermint/")
@@ -360,7 +365,7 @@ async fn run(provider: Provider<Http>, opts: Options) -> anyhow::Result<()> {
         .await
         .context("failed to make a transfer")?;
 
-    let receipt = send_transaction(&mw, transfer.clone())
+    let receipt = send_transaction(&mw, transfer.clone(), "transfer")
         .await
         .context("failed to send transfer")?;
 
@@ -475,7 +480,7 @@ async fn run(provider: Provider<Http>, opts: Options) -> anyhow::Result<()> {
     // These were set to zero in the earlier example transfer, ie. it was basically paid for by the miner (which is not at the moment charged),
     // so the test passed. Here, however, there will be a non-zero cost to pay by the deployer, and therefore those balances
     // have to be much higher than the defaults used earlier, e.g. the deployment cost 30 FIL, and we used to give 1 FIL.
-    let (contract, receipt) = deployer
+    let (contract, deploy_receipt): (_, TransactionReceipt) = deployer
         .send_with_receipt()
         .await
         .context("failed to send deployment")?;
@@ -483,10 +488,6 @@ async fn run(provider: Provider<Http>, opts: Options) -> anyhow::Result<()> {
     tracing::info!(addr = ?contract.address(), "SimpleCoin deployed");
 
     let contract = SimpleCoin::new(contract.address(), contract.client());
-
-    let _tx_hash = receipt.transaction_hash;
-    let _bn = receipt.block_number.unwrap();
-    let _bh = receipt.block_hash.unwrap();
 
     let coin_balance: TestContractCall<U256> =
         prepare_call(&mw, contract.get_balance(from.eth_addr)).await?;
@@ -541,7 +542,7 @@ async fn run(provider: Provider<Http>, opts: Options) -> anyhow::Result<()> {
     // Unfortunately the returned `bool` is not available through the Ethereum API.
     let receipt = request(
         "eth_sendRawTransaction",
-        send_transaction(&mw, coin_send.tx).await,
+        send_transaction(&mw, coin_send.tx, "coin_send").await,
         |receipt| !receipt.logs.is_empty(),
     )?;
 
@@ -556,19 +557,32 @@ async fn run(provider: Provider<Http>, opts: Options) -> anyhow::Result<()> {
     request(
         "eth_getFilterChanges (blocks)",
         mw.get_filter_changes(blocks_filter_id).await,
-        |block_hashes: &Vec<H256>| block_hashes.contains(&bh),
+        |block_hashes: &Vec<H256>| {
+            [bh, deploy_receipt.block_hash.unwrap()]
+                .iter()
+                .all(|h| block_hashes.contains(h))
+        },
     )?;
 
     request(
         "eth_getFilterChanges (txs)",
         mw.get_filter_changes(txs_filter_id).await,
-        |tx_hashes: &Vec<H256>| tx_hashes.contains(&tx_hash),
+        |tx_hashes: &Vec<H256>| {
+            [&tx_hash, &deploy_receipt.transaction_hash]
+                .iter()
+                .all(|h| tx_hashes.contains(h))
+        },
     )?;
 
-    // TODO: query logs_filter_id
+    // TODO: Parse logs with the contract.
+    request(
+        "eth_getFilterChanges (logs)",
+        mw.get_filter_changes(logs_filter_id).await,
+        |logs: &Vec<Log>| !logs.is_empty(),
+    )?;
 
     // Uninstall all filters.
-    for id in [blocks_filter_id, logs_filter_id, txs_filter_id] {
+    for id in filter_ids {
         request("eth_uninstallFilter", mw.uninstall_filter(id).await, |ok| {
             *ok
         })?;
@@ -598,13 +612,14 @@ async fn make_transfer(mw: &TestMiddleware, to: &TestAccount) -> anyhow::Result<
 async fn send_transaction(
     mw: &TestMiddleware,
     tx: TypedTransaction,
+    label: &str,
 ) -> anyhow::Result<TransactionReceipt> {
     // `send_transaction` will fill in the missing fields like `from` and `nonce` (which involves querying the API).
     let receipt = mw
         .send_transaction(tx, None)
         .await
         .context("failed to send transaction")?
-        .log_msg("Pending transaction")
+        .log_msg(format!("Pending transaction: {label}"))
         .retries(5)
         .await?
         .context("Missing receipt")?;

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -210,15 +210,15 @@ impl TestAccount {
 // - eth_syncing
 // - web3_clientVersion
 // - eth_getLogs
+// - eth_newFilter
+// - eth_newBlockFilter
+// - eth_newPendingTransactionFilter
+// - eth_getFilterChanges
+// - eth_uninstallFilter
 //
 // DOING:
 //
 // TODO:
-// - eth_newBlockFilter
-// - eth_newPendingTransactionFilter
-// - eth_newFilter
-// - eth_uninstallFilter
-// - eth_getFilterChanges
 // - eth_subscribe
 // - eth_unsubscribe
 //

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -758,7 +758,7 @@ where
                     }
 
                     let mut tx_logs = from_tm::to_logs(
-                        tx_result,
+                        &tx_result.events,
                         block_hash,
                         block_number,
                         tx_hash,

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -74,8 +74,8 @@ pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRo
         // eth_signTransaction
         // eth_submitHashrate
         // eth_submitWork
-        syncing
-        // eth_uninstallFilter
+        syncing,
+        uninstallFilter
     });
 
     let server = with_methods!(server, web3, {

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -48,7 +48,7 @@ pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRo
         getBlockReceipts,
         getCode,
         // eth_getCompilers
-        // eth_getFilterChanges
+        getFilterChanges,
         // eth_getFilterLogs
         getLogs,
         getStorageAt,

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -6,7 +6,7 @@
 
 use jsonrpc_v2::{MapRouter, ServerBuilder};
 use paste::paste;
-use tendermint_rpc::HttpClient;
+use tendermint_rpc::WebSocketClient;
 
 mod eth;
 mod net;
@@ -18,7 +18,7 @@ macro_rules! with_methods {
             $server
                 $(.with_method(
                     stringify!([< $module _ $method >]),
-                    $module :: [< $method:snake >] ::<HttpClient>
+                    $module :: [< $method:snake >] ::<WebSocketClient>
                 ))*
         }
     };

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -64,9 +64,9 @@ pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRo
         // eth_getWork
         // eth_hashrate
         // eth_mining
-        // eth_newBlockFilter
-        // eth_newFilter
-        // eth_newPendingTransactionFilter
+        newBlockFilter,
+        newFilter,
+        newPendingTransactionFilter,
         protocolVersion,
         sendRawTransaction,
         // eth_sendTransaction

--- a/fendermint/eth/api/src/conv/from_tm.rs
+++ b/fendermint/eth/api/src/conv/from_tm.rs
@@ -13,7 +13,7 @@ use fvm_shared::chainid::ChainID;
 use fvm_shared::{bigint::BigInt, econ::TokenAmount};
 use lazy_static::lazy_static;
 use tendermint::abci::response::DeliverTx;
-use tendermint::abci::EventAttribute;
+use tendermint::abci::{self, EventAttribute};
 use tendermint::crypto::sha256::Sha256;
 use tendermint_rpc::endpoint;
 
@@ -222,7 +222,7 @@ pub fn to_eth_receipt(
     let log_index_start = cumulative_event_count.saturating_sub(result.tx_result.events.len());
 
     let logs = to_logs(
-        &result.tx_result,
+        &result.tx_result.events,
         block_hash,
         block_number,
         transaction_hash,
@@ -345,7 +345,7 @@ fn maybe_contract_address(deliver_tx: &DeliverTx) -> Option<EthAddress> {
 }
 
 pub fn to_logs(
-    tx_result: &DeliverTx,
+    events: &Vec<abci::Event>,
     block_hash: et::H256,
     block_number: et::U64,
     transaction_hash: et::H256,
@@ -353,7 +353,7 @@ pub fn to_logs(
     log_index_start: usize,
 ) -> anyhow::Result<Vec<et::Log>> {
     let mut logs = Vec::new();
-    for (idx, event) in tx_result.events.iter().enumerate() {
+    for (idx, event) in events.iter().enumerate() {
         // TODO: Lotus looks up an Ethereum address based on the actor ID:
         // https://github.com/filecoin-project/lotus/blob/6cc506f5cf751215be6badc94a960251c6453202/node/impl/full/eth.go#L1987
         let address = event

--- a/fendermint/eth/api/src/conv/from_tm.rs
+++ b/fendermint/eth/api/src/conv/from_tm.rs
@@ -345,7 +345,7 @@ fn maybe_contract_address(deliver_tx: &DeliverTx) -> Option<EthAddress> {
 }
 
 pub fn to_logs(
-    events: &Vec<abci::Event>,
+    events: &[abci::Event],
     block_hash: et::H256,
     block_number: et::U64,
     transaction_hash: et::H256,

--- a/fendermint/eth/api/src/filters.rs
+++ b/fendermint/eth/api/src/filters.rs
@@ -4,6 +4,14 @@
 use ethers_core::types as et;
 
 /// Check whether to keep a log according to the topic filter.
+///
+/// A note on specifying topic filters: Topics are order-dependent.
+/// A transaction with a log with topics [A, B] will be matched by the following topic filters:
+/// * [] "anything"
+/// * [A] "A in first position (and anything after)"
+/// * [null, B] "anything in first position AND B in second position (and anything after)"
+/// * [A, B] "A in first position AND B in second position (and anything after)"
+/// * [[A, B], [A, B]] "(A OR B) in first position AND (A OR B) in second position (and anything after)"
 pub fn matches_topics(filter: &et::Filter, log: &et::Log) -> bool {
     for i in 0..4 {
         if let Some(topics) = &filter.topics[i] {

--- a/fendermint/eth/api/src/filters.rs
+++ b/fendermint/eth/api/src/filters.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use ethers_core::types as et;
+use tendermint_rpc::{event::Event, query::Query};
 
 /// Check whether to keep a log according to the topic filter.
 ///
@@ -27,4 +28,55 @@ pub fn matches_topics(filter: &et::Filter, log: &et::Log) -> bool {
         }
     }
     true
+}
+
+pub type FilterId = et::U256;
+
+pub enum FilterKind {
+    Logs(Box<et::Filter>),
+    NewBlocks,
+    PendingTransactions,
+}
+
+impl From<FilterKind> for Query {
+    fn from(value: FilterKind) -> Self {
+        todo!()
+    }
+}
+
+/// Accumulate changes between polls.
+pub struct FilterState {
+    id: FilterId,
+}
+
+impl FilterState {
+    pub fn new(id: FilterId) -> Self {
+        Self { id }
+    }
+
+    pub fn id(&self) -> &FilterId {
+        &self.id
+    }
+
+    /// Accumulate the events.
+    pub fn update(&mut self, _event: Event) {
+        todo!()
+    }
+
+    /// The subscription returned an error and will no longer be polled for data.
+    /// Propagate the error to the reader next time it comes to check on the filter.
+    pub fn finish(&mut self, _error: Option<anyhow::Error>) {
+        todo!()
+    }
+
+    /// Indicate whether the reader has been too slow at polling the filter
+    /// and that it should be removed.
+    pub fn is_timed_out(&self) -> bool {
+        todo!()
+    }
+
+    /// Indicate that the reader has unsubscribed from the filter.
+    pub fn is_unsubscribed(&self) -> bool {
+        todo!()
+    }
 }

--- a/fendermint/eth/api/src/lib.rs
+++ b/fendermint/eth/api/src/lib.rs
@@ -3,7 +3,6 @@
 
 use anyhow::anyhow;
 use axum::routing::{get, post};
-use fendermint_rpc::client::FendermintClient;
 use jsonrpc_v2::Data;
 use std::{net::ToSocketAddrs, sync::Arc};
 use tendermint_rpc::WebSocketClient;
@@ -16,15 +15,8 @@ mod gas;
 mod handlers;
 mod state;
 
-pub use error::{error, JsonRpcError};
-
-// Made generic in the client type so we can mock it if we want to test API
-// methods without having to spin up a server. In those tests the methods
-// below would not be used, so those aren't generic; we'd directly invoke
-// e.g. `fendermint_eth_api::apis::eth::accounts` with some mock client.
-pub struct JsonRpcState<C> {
-    pub client: FendermintClient<C>,
-}
+use error::{error, JsonRpcError};
+use state::JsonRpcState;
 
 type JsonRpcData<C> = Data<JsonRpcState<C>>;
 type JsonRpcServer = Arc<jsonrpc_v2::Server<jsonrpc_v2::MapRouter>>;
@@ -36,9 +28,7 @@ pub async fn listen<A: ToSocketAddrs>(
     client: WebSocketClient,
 ) -> anyhow::Result<()> {
     if let Some(listen_addr) = listen_addr.to_socket_addrs()?.next() {
-        let state = JsonRpcState {
-            client: FendermintClient::new(client),
-        };
+        let state = JsonRpcState::new(client);
         let server = make_server(state);
         let router = make_router(server);
         let server = axum::Server::try_bind(&listen_addr)?.serve(router.into_make_service());

--- a/fendermint/eth/api/src/lib.rs
+++ b/fendermint/eth/api/src/lib.rs
@@ -4,7 +4,7 @@
 use anyhow::anyhow;
 use axum::routing::{get, post};
 use jsonrpc_v2::Data;
-use std::{net::ToSocketAddrs, sync::Arc};
+use std::{net::ToSocketAddrs, sync::Arc, time::Duration};
 use tendermint_rpc::WebSocketClient;
 
 mod apis;
@@ -26,9 +26,10 @@ type JsonRpcResult<T> = Result<T, JsonRpcError>;
 pub async fn listen<A: ToSocketAddrs>(
     listen_addr: A,
     client: WebSocketClient,
+    filter_timeout: Duration,
 ) -> anyhow::Result<()> {
     if let Some(listen_addr) = listen_addr.to_socket_addrs()?.next() {
-        let state = JsonRpcState::new(client);
+        let state = JsonRpcState::new(client, filter_timeout);
         let server = make_server(state);
         let router = make_router(server);
         let server = axum::Server::try_bind(&listen_addr)?.serve(router.into_make_service());

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -17,7 +17,6 @@ use futures::StreamExt;
 use fvm_ipld_encoding::{de::DeserializeOwned, RawBytes};
 use fvm_shared::{chainid::ChainID, econ::TokenAmount, error::ExitCode, message::Message};
 use tendermint::block::Height;
-use tendermint_rpc::query::Query;
 use tendermint_rpc::{
     endpoint::{block, block_by_hash, block_results, commit, header, header_by_hash},
     Client,

--- a/fendermint/rpc/src/client.rs
+++ b/fendermint/rpc/src/client.rs
@@ -9,6 +9,7 @@ use fendermint_vm_message::chain::ChainMessage;
 use tendermint::abci::response::DeliverTx;
 use tendermint::block::Height;
 use tendermint_rpc::{endpoint::abci_query::AbciQuery, Client, HttpClient, Scheme, Url};
+use tendermint_rpc::{WebSocketClient, WebSocketClientDriver};
 
 use fendermint_vm_message::query::FvmQuery;
 
@@ -64,6 +65,16 @@ pub fn http_client(url: Url, proxy_url: Option<Url>) -> anyhow::Result<HttpClien
         }
     };
     Ok(client)
+}
+
+/// Create a Tendermint WebSocket client.
+///
+/// The caller must start the driver in a background task.
+pub async fn ws_client(url: Url) -> anyhow::Result<(WebSocketClient, WebSocketClientDriver)> {
+    // TODO: Doesn't handle proxy.
+    tracing::debug!("Using WS client to submit request to: {}", url);
+    let (client, driver) = WebSocketClient::new(url).await?;
+    Ok((client, driver))
 }
 
 /// Unauthenticated Fendermint client.

--- a/fendermint/rpc/src/client.rs
+++ b/fendermint/rpc/src/client.rs
@@ -82,7 +82,7 @@ pub struct FendermintClient<C = HttpClient> {
     inner: C,
 }
 
-impl<C: Client> FendermintClient<C> {
+impl<C> FendermintClient<C> {
     pub fn new(inner: C) -> Self {
         Self { inner }
     }
@@ -101,12 +101,12 @@ impl FendermintClient<HttpClient> {
 }
 
 /// Get to the underlying Tendermint client if necessary, for example to query the state of transactions.
-pub trait TendermintClient<C: Client> {
+pub trait TendermintClient<C> {
     /// The underlying Tendermint client.
     fn underlying(&self) -> &C;
 }
 
-impl<C: Client> TendermintClient<C> for FendermintClient<C> {
+impl<C> TendermintClient<C> for FendermintClient<C> {
     fn underlying(&self) -> &C {
         &self.inner
     }
@@ -128,10 +128,7 @@ pub struct BoundFendermintClient<C = HttpClient> {
     message_factory: MessageFactory,
 }
 
-impl<C> BoundFendermintClient<C>
-where
-    C: Client,
-{
+impl<C> BoundFendermintClient<C> {
     pub fn new(inner: C, message_factory: MessageFactory) -> Self {
         Self {
             inner,
@@ -146,10 +143,7 @@ impl<C> BoundClient for BoundFendermintClient<C> {
     }
 }
 
-impl<C> TendermintClient<C> for BoundFendermintClient<C>
-where
-    C: Client,
-{
+impl<C> TendermintClient<C> for BoundFendermintClient<C> {
     fn underlying(&self) -> &C {
         &self.inner
     }

--- a/fendermint/testing/smoke-test/Makefile.toml
+++ b/fendermint/testing/smoke-test/Makefile.toml
@@ -165,7 +165,7 @@ docker run \
   --user $(id -u) \
   --network ${NETWORK_NAME} \
   --publish 8545:${ETHAPI_HOST_PORT} \
-  --env TENDERMINT_RPC_URL=http://${CMT_CONTAINER_NAME}:26657 \
+  --env TENDERMINT_WS_URL=ws://${CMT_CONTAINER_NAME}:26657/websocket \
   --env LOG_LEVEL=debug \
   --env RUST_BACKTRACE=1 \
   ${FM_DOCKER_IMAGE} \


### PR DESCRIPTION
Closes #137 

Adds API methods related to filters:
* eth_newFilter
* eth_newBlockFilter
* eth_pendingTransactionFilter
* eth_uninstallFilter
* eth_getFilterChanges

Caveats:
* Instead of pending transactions, we return transactions which are included in blocks, as that's what we are able to subscribe to
* Logs returned in subscriptions don't have `block_hash`, `transaction_index` and `log_start_index` fields as these would require further queries to the API, with caching to avoid hammering the node.

TODO: 
* Check how Etherscan deals with the extra fields in logs.
* Follow up with a test to parse the logs with the ethers machinery.