### PR TITLE
FM-140: Replace Mutex with Channel

### DIFF
--- a/fendermint/eth/api/Cargo.toml
+++ b/fendermint/eth/api/Cargo.toml
@@ -17,6 +17,7 @@ lazy_static = { workspace = true }
 libsecp256k1 = { workspace = true }
 paste = { workspace = true }
 serde = { workspace = true }
+rand = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 tendermint = { workspace = true }

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -858,3 +858,19 @@ pub async fn get_filter_changes<C>(
         error(ExitCode::USR_NOT_FOUND, "filter not found")
     }
 }
+
+pub async fn get_filter_logs<C>(
+    data: JsonRpcData<C>,
+    Params((filter_id,)): Params<(FilterId,)>,
+) -> JsonRpcResult<Vec<et::Log>> {
+    if let Some(accum) = data.take_filter_changes(filter_id)? {
+        match accum {
+            FilterRecords::Logs(logs) => Ok(logs),
+            FilterRecords::NewBlocks(_) | FilterRecords::PendingTransactions(_) => {
+                error(ExitCode::USR_ILLEGAL_STATE, "not a log filter")
+            }
+        }
+    } else {
+        error(ExitCode::USR_NOT_FOUND, "filter not found")
+    }
+}

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -831,7 +831,7 @@ pub async fn uninstall_filter<C>(
     data: JsonRpcData<C>,
     Params((filter_id,)): Params<(FilterId,)>,
 ) -> JsonRpcResult<bool> {
-    Ok(data.uninstall_filter(filter_id))
+    Ok(data.uninstall_filter(filter_id).await?)
 }
 
 pub async fn get_filter_changes<C>(
@@ -848,7 +848,7 @@ pub async fn get_filter_changes<C>(
         Ok(values)
     }
 
-    if let Some(accum) = data.take_filter_changes(filter_id)? {
+    if let Some(accum) = data.take_filter_changes(filter_id).await? {
         match accum {
             FilterRecords::Logs(logs) => to_json(logs),
             FilterRecords::NewBlocks(hashes) => to_json(hashes),
@@ -859,11 +859,12 @@ pub async fn get_filter_changes<C>(
     }
 }
 
+/// Returns an array of all logs matching filter with given id.
 pub async fn get_filter_logs<C>(
     data: JsonRpcData<C>,
     Params((filter_id,)): Params<(FilterId,)>,
 ) -> JsonRpcResult<Vec<et::Log>> {
-    if let Some(accum) = data.take_filter_changes(filter_id)? {
+    if let Some(accum) = data.take_filter_changes(filter_id).await? {
         match accum {
             FilterRecords::Logs(logs) => Ok(logs),
             FilterRecords::NewBlocks(_) | FilterRecords::PendingTransactions(_) => {

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -49,7 +49,7 @@ pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRo
         getCode,
         // eth_getCompilers
         getFilterChanges,
-        // eth_getFilterLogs
+        getFilterLogs,
         getLogs,
         getStorageAt,
         getTransactionByBlockHashAndIndex,

--- a/fendermint/eth/api/src/filters.rs
+++ b/fendermint/eth/api/src/filters.rs
@@ -1,15 +1,25 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::time::{Duration, Instant};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use ethers_core::types as et;
 use fendermint_vm_actor_interface::eam::EthAddress;
+use futures::StreamExt;
 use fvm_shared::address::Address;
 use tendermint_rpc::{
     event::{Event, EventData},
     query::{EventType, Query},
+    Subscription,
+};
+use tokio::sync::{
+    mpsc::{Receiver, Sender},
+    RwLock,
 };
 
 use crate::conv::from_tm;
@@ -41,6 +51,18 @@ pub fn matches_topics(filter: &et::Filter, log: &et::Log) -> bool {
 }
 
 pub type FilterId = et::U256;
+pub type FilterMap = Arc<RwLock<HashMap<FilterId, Sender<FilterCommand>>>>;
+
+pub enum FilterCommand {
+    /// Update the records with an event, coming from one of the Tendermint subscriptions.
+    Update(Event),
+    /// One of the subscriptions has ended, potentially with an error.
+    Finish(Option<tendermint_rpc::Error>),
+    /// Take the accumulated records, coming from the API consumer.
+    Take(tokio::sync::oneshot::Sender<anyhow::Result<Option<FilterRecords>>>),
+    /// The API consumer is no longer interested in taking the records.
+    Uninstall,
+}
 
 pub enum FilterKind {
     NewBlocks,
@@ -171,26 +193,89 @@ impl From<&FilterRecords> for FilterRecords {
 
 /// Accumulate changes between polls.
 pub struct FilterState {
-    _id: FilterId,
+    id: FilterId,
     timeout: Duration,
     last_poll: Instant,
     finished: Option<Option<anyhow::Error>>,
     records: FilterRecords,
+    rx: Receiver<FilterCommand>,
 }
 
 impl FilterState {
-    pub fn new(id: FilterId, timeout: Duration, kind: &FilterKind) -> Self {
-        Self {
-            _id: id,
+    pub fn new(
+        id: FilterId,
+        timeout: Duration,
+        kind: &FilterKind,
+    ) -> (Self, Sender<FilterCommand>) {
+        let (tx, rx) = tokio::sync::mpsc::channel(10);
+        let s = Self {
+            id,
             timeout,
             last_poll: Instant::now(),
             finished: None,
             records: FilterRecords::from(kind),
+            rx,
+        };
+        (s, tx)
+    }
+
+    pub fn id(&self) -> FilterId {
+        self.id
+    }
+
+    /// Consume commands until some end condition is met.
+    ///
+    /// In the end the filter removes itself from the registry.
+    pub async fn run(mut self, filters: FilterMap) {
+        let id = self.id;
+
+        tracing::info!(?id, "handling filter events");
+        while let Some(cmd) = self.rx.recv().await {
+            match cmd {
+                FilterCommand::Update(event) => {
+                    if self.is_finished() {
+                        continue;
+                    }
+                    if self.is_timed_out() {
+                        tracing::debug!(?id, "filter timed out");
+                        return self.remove(filters).await;
+                    }
+                    if let Err(err) = self.update(event) {
+                        tracing::error!(?id, "failed to update filter: {err}");
+                        self.finish(Some(anyhow!("failed to update filter: {err}")));
+                    }
+                }
+                FilterCommand::Finish(err) => {
+                    tracing::info!(?id, "filter producer finished: {err:?}");
+                    self.finish(err.map(|e| anyhow!("subscription failed: {e}")))
+                }
+                FilterCommand::Uninstall => {
+                    tracing::error!(?id, "filter uninstalled");
+                    return self.remove(filters).await;
+                }
+                FilterCommand::Take(tx) => {
+                    let result = self.try_take();
+                    let remove = match result {
+                        Ok(None) | Err(_) => true,
+                        Ok(Some(_)) => false,
+                    };
+                    let _ = tx.send(result);
+                    if remove {
+                        tracing::info!(?id, "filter finished");
+                        return self.remove(filters).await;
+                    }
+                }
+            }
         }
+        // All producers have been dropped, so there is no way for new commands to arrive.
+    }
+
+    async fn remove(self, filters: FilterMap) {
+        filters.write().await.remove(&self.id);
     }
 
     /// Accumulate the events.
-    pub fn update(&mut self, event: Event) -> anyhow::Result<()> {
+    fn update(&mut self, event: Event) -> anyhow::Result<()> {
         match (&mut self.records, &event.data) {
             (
                 FilterRecords::NewBlocks(ref mut hashes),
@@ -290,7 +375,7 @@ impl FilterState {
     ///
     /// If there are no changes but there was an error, return that.
     /// If the producers have stopped, return `None`.
-    pub fn try_take(&mut self) -> anyhow::Result<Option<FilterRecords>> {
+    fn try_take(&mut self) -> anyhow::Result<Option<FilterRecords>> {
         self.last_poll = Instant::now();
 
         let mut records = FilterRecords::from(&self.records);
@@ -312,7 +397,7 @@ impl FilterState {
     /// Signal that the producers are finished, or that the reader is no longer intersted.
     ///
     /// Propagate the error to the reader next time it comes to check on the filter.
-    pub fn finish(&mut self, error: Option<anyhow::Error>) {
+    fn finish(&mut self, error: Option<anyhow::Error>) {
         // Keep any already existing error.
         let error = self.finished.take().flatten().or(error);
 
@@ -321,14 +406,52 @@ impl FilterState {
 
     /// Indicate whether the reader has been too slow at polling the filter
     /// and that it should be removed.
-    pub fn is_timed_out(&self) -> bool {
+    fn is_timed_out(&self) -> bool {
         Instant::now().duration_since(self.last_poll) > self.timeout
     }
 
     /// Indicate that that the filter takes no more data.
-    pub fn is_finished(&self) -> bool {
+    fn is_finished(&self) -> bool {
         self.finished.is_some()
     }
+}
+
+/// Spawn a Tendermint subscription handler in a new task.
+pub async fn run_subscription(id: FilterId, mut sub: Subscription, tx: Sender<FilterCommand>) {
+    let query = sub.query().to_string();
+    tracing::debug!(?id, query, "polling filter subscription");
+    while let Some(result) = sub.next().await {
+        match result {
+            Ok(event) => {
+                if let Err(_) = tx.send(FilterCommand::Update(event)).await {
+                    // Filter has been uninstalled.
+                    tracing::debug!(
+                        ?id,
+                        query,
+                        "filter no longer listening, quiting subscription"
+                    );
+                    return;
+                }
+            }
+            Err(err) => {
+                tracing::error!(
+                    ?id,
+                    query,
+                    error = ?err,
+                    "filter subscription error"
+                );
+                let _ = tx.send(FilterCommand::Finish(Some(err))).await;
+                return;
+            }
+        }
+    }
+    tracing::debug!(?id, query, "filter subscription finished");
+    let _ = tx.send(FilterCommand::Finish(None)).await;
+
+    // Dropping the `Subscription` should cause the client to unsubscribe,
+    // if this was the last one interested in that query; we don't have to
+    // call the unsubscribe method explicitly.
+    // See https://docs.rs/tendermint-rpc/0.31.1/tendermint_rpc/client/struct.WebSocketClient.html
 }
 
 #[cfg(test)]

--- a/fendermint/eth/api/src/filters.rs
+++ b/fendermint/eth/api/src/filters.rs
@@ -423,7 +423,7 @@ pub async fn run_subscription(id: FilterId, mut sub: Subscription, tx: Sender<Fi
     while let Some(result) = sub.next().await {
         match result {
             Ok(event) => {
-                if let Err(_) = tx.send(FilterCommand::Update(event)).await {
+                if tx.send(FilterCommand::Update(event)).await.is_err() {
                     // Filter has been uninstalled.
                     tracing::debug!(
                         ?id,

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -3,8 +3,6 @@
 
 //! Tendermint RPC helper methods for the implementation of the APIs.
 
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{anyhow, Context};
@@ -13,7 +11,6 @@ use fendermint_rpc::client::{FendermintClient, TendermintClient};
 use fendermint_rpc::query::QueryClient;
 use fendermint_vm_actor_interface::{evm, system};
 use fendermint_vm_message::{chain::ChainMessage, conv::from_eth::to_fvm_address};
-use futures::StreamExt;
 use fvm_ipld_encoding::{de::DeserializeOwned, RawBytes};
 use fvm_shared::{chainid::ChainID, econ::TokenAmount, error::ExitCode, message::Message};
 use rand::Rng;
@@ -23,16 +20,17 @@ use tendermint_rpc::{
     Client,
 };
 use tendermint_rpc::{Subscription, SubscriptionClient};
+use tokio::sync::mpsc::Sender;
 
-use crate::filters::{FilterId, FilterKind, FilterRecords, FilterState};
+use crate::filters::{
+    run_subscription, FilterCommand, FilterId, FilterKind, FilterMap, FilterRecords, FilterState,
+};
 use crate::{
     conv::from_tm::{
         map_rpc_block_txs, message_hash, to_chain_message, to_eth_block, to_eth_transaction,
     },
     error, JsonRpcResult,
 };
-
-type FilterMap = Arc<Mutex<HashMap<FilterId, Arc<Mutex<FilterState>>>>>;
 
 // Made generic in the client type so we can mock it if we want to test API
 // methods without having to spin up a server. In those tests the methods
@@ -280,10 +278,10 @@ where
     C: SubscriptionClient,
 {
     /// Create a new filter with the next available ID and insert it into the filters collection.
-    fn new_filter_state(&self, filter: &FilterKind) -> (FilterId, Arc<Mutex<FilterState>>) {
-        let mut filters = self.filters.lock().expect("lock poisoned");
+    async fn insert_filter(&self, filter: &FilterKind) -> (FilterState, Sender<FilterCommand>) {
+        let mut filters = self.filters.write().await;
 
-        // Choose an unpredictable filter, so
+        // Choose an unpredictable filter, so it's not so easy to clear out someone else's logs.
         let mut id: et::U256;
         loop {
             id = FilterId::from(rand::thread_rng().gen::<u64>());
@@ -292,11 +290,12 @@ where
             }
         }
 
-        let state = FilterState::new(id, self.filter_timeout, filter);
-        let state = Arc::new(Mutex::new(state));
-        filters.insert(id, state.clone());
+        let (state, tx) = FilterState::new(id, self.filter_timeout, filter);
 
-        (id, state)
+        // Inserting happens here, while removal will be handled by the `FilterState` itself.
+        filters.insert(id, tx.clone());
+
+        (state, tx)
     }
 
     /// Create a new filter, subscribe with Tendermint and start handlers in the background.
@@ -317,10 +316,15 @@ where
             subs.push(sub);
         }
 
-        let (id, state) = self.new_filter_state(&filter);
+        let (state, tx) = self.insert_filter(&filter).await;
+        let id = state.id();
+        let filters = self.filters.clone();
+
+        tokio::spawn(async move { state.run(filters).await });
 
         for sub in subs {
-            spawn_subscription_handler(self.filters.clone(), id, state.clone(), sub);
+            let tx = tx.clone();
+            tokio::spawn(async move { run_subscription(id, sub, tx).await });
         }
 
         Ok(id)
@@ -328,103 +332,38 @@ where
 }
 
 impl<C> JsonRpcState<C> {
-    pub fn uninstall_filter(&self, filter_id: FilterId) -> bool {
-        let removed = {
-            let mut filters = self.filters.lock().expect("lock poisoned");
-            filters.remove(&filter_id)
-        };
+    pub async fn uninstall_filter(&self, filter_id: FilterId) -> anyhow::Result<bool> {
+        let filters = self.filters.read().await;
 
-        if let Some(filter) = removed {
+        if let Some(tx) = filters.get(&filter_id) {
             // Signal to the background tasks that they can unsubscribe.
-            let mut filter = filter.lock().expect("lock poisoned");
-            filter.finish(None);
-            true
+            tx.send(FilterCommand::Uninstall)
+                .await
+                .map_err(|e| anyhow!("failed to send command: {e}"))?;
+            Ok(true)
         } else {
-            false
+            Ok(false)
         }
     }
 
-    /// Take the currently accumulated changes, and remove the filter if it's finished.
-    pub fn take_filter_changes(
+    /// Take the currently accumulated changes.
+    pub async fn take_filter_changes(
         &self,
         filter_id: FilterId,
     ) -> anyhow::Result<Option<FilterRecords>> {
-        let mut filters = self.filters.lock().expect("lock poisoned");
+        let filters = self.filters.read().await;
 
-        let result = match filters.get(&filter_id) {
+        match filters.get(&filter_id) {
             None => Ok(None),
-            Some(state) => {
-                let mut state = state.lock().expect("lock poisoned");
-                state.try_take()
+            Some(tx) => {
+                let (tx_res, rx_res) = tokio::sync::oneshot::channel();
+
+                tx.send(FilterCommand::Take(tx_res))
+                    .await
+                    .map_err(|e| anyhow!("failed to send command: {e}"))?;
+
+                rx_res.await.context("failed to receive response")?
             }
-        };
-
-        let keep = match result {
-            Ok(Some(_)) => true,
-            Ok(None) => false,
-            Err(_) => false,
-        };
-
-        if !keep {
-            // Filter won't produce more data, remove it from the registry.
-            filters.remove(&filter_id);
         }
-
-        result
     }
-}
-
-/// Spawn a subscription handler in a new task.
-fn spawn_subscription_handler(
-    filters: FilterMap,
-    id: FilterId,
-    state: Arc<Mutex<FilterState>>,
-    mut sub: Subscription,
-) {
-    tokio::spawn(async move {
-        tracing::debug!(
-            ?id,
-            query = sub.query().to_string(),
-            "polling filter subscription"
-        );
-        while let Some(result) = sub.next().await {
-            tracing::debug!(?id, ?result, "next filter event");
-            let mut state = state.lock().expect("lock poisoned");
-
-            if state.is_finished() {
-                tracing::debug!(?id, "filter already finished");
-                return;
-            } else if state.is_timed_out() {
-                tracing::warn!(?id, "removing timed out filter");
-                // Clean up because the reader won't do it.
-                filters.lock().expect("lock poisoned").remove(&id);
-                state.finish(Some(anyhow!("filter timeout")));
-                return;
-            } else {
-                match result {
-                    Ok(event) => {
-                        if let Err(err) = state.update(event) {
-                            tracing::error!(?id, "failed to update filter: {err}");
-                            state.finish(Some(anyhow!("update failed: {err}")));
-                            return;
-                        }
-                        tracing::debug!(?id, "filter updated");
-                    }
-                    Err(err) => {
-                        tracing::error!(?id, "filter subscription failed: {err}");
-                        state.finish(Some(anyhow!("subscription failed: {err}")));
-                        return;
-                    }
-                }
-            }
-        }
-        // Mark the state as finished, but don't remove; let the poller consume whatever is left.
-        tracing::debug!(?id, "finishing filter");
-        state.lock().expect("lock poisoned").finish(None)
-
-        // Dropping the `Subscription` should cause the client to unsubscribe,
-        // if this was the last one interested in that query; we don't have to
-        // call the unsubscribe method explicitly.
-        // See https://docs.rs/tendermint-rpc/0.31.1/tendermint_rpc/client/struct.WebSocketClient.html
-    });
 }


### PR DESCRIPTION
Closes #140 
Adds to #137 

Changes:
* Added eth_getFilterLogs
* Randomized filter ID to be unpredictable
* Changed the subscription/filter to use channels for communication, rather than locking mutexes