### PR TITLE
FM-138: Ethereum API methods: eth_subscribe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2013,6 +2013,7 @@ dependencies = [
  "bytes",
  "enr",
  "ethers-core",
+ "futures-channel",
  "futures-core",
  "futures-timer",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bytes = "1.4"
 clap = { version = "4.1", features = ["derive", "env"] }
 config = "0.13"
 dirs = "5.0"
-ethers = { version = "2.0", features = ["abigen"] }
+ethers = { version = "2.0", features = ["abigen", "ws"] }
 ethers-core = { version = "2.0" }
 fnv = "1.0"
 futures = "0.3"

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -127,13 +127,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_max_level(opts.log_level())
         .init();
 
-    tracing::debug!("Running the tests over HTTP...");
+    tracing::info!("Running the tests over HTTP...");
     let provider = Provider::<Http>::try_from(opts.http_endpoint())?;
     run(provider, &opts).await?;
 
-    // tracing::debug!("Running the tests over WS...");
-    // let provider = Provider::<Ws>::connect(opts.ws_endpoint()).await?;
-    // run(provider, &opts).await?;
+    tracing::info!("Running the tests over WS...");
+    let provider = Provider::<Ws>::connect(opts.ws_endpoint()).await?;
+    run(provider, &opts).await?;
 
     Ok(())
 }

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -34,7 +34,6 @@ use tendermint_rpc::{
 use crate::conv::from_eth::{to_fvm_message, to_tm_hash};
 use crate::conv::from_tm::{self, message_hash, to_chain_message, to_cumulative};
 use crate::filters::{matches_topics, FilterId, FilterKind, FilterRecords};
-use crate::state::WebSocketId;
 use crate::{
     conv::{
         from_eth::to_fvm_address,
@@ -909,7 +908,7 @@ where
 /// Unsubscribe from the filter registered by this websocket.
 pub async fn unsubscribe<C>(
     data: JsonRpcData<C>,
-    Params((filter_id, _web_socket_id)): Params<(FilterId, WebSocketId)>,
+    Params((filter_id,)): Params<(FilterId,)>,
 ) -> JsonRpcResult<bool> {
     uninstall_filter(data, Params((filter_id,))).await
 }

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -24,7 +24,6 @@ use fvm_shared::address::Address;
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::{chainid::ChainID, error::ExitCode};
 use jsonrpc_v2::Params;
-use serde::{Deserialize, Serialize};
 use tendermint_rpc::endpoint::{self, status};
 use tendermint_rpc::SubscriptionClient;
 use tendermint_rpc::{
@@ -35,6 +34,7 @@ use tendermint_rpc::{
 use crate::conv::from_eth::{to_fvm_message, to_tm_hash};
 use crate::conv::from_tm::{self, message_hash, to_chain_message, to_cumulative};
 use crate::filters::{matches_topics, FilterId, FilterKind, FilterRecords};
+use crate::state::WebSocketId;
 use crate::{
     conv::{
         from_eth::to_fvm_address,
@@ -542,16 +542,6 @@ where
     }
 }
 
-/// The client either sends one or two items in the array, depending on whether a block ID is specified.
-/// This is to keep it backwards compatible with nodes that do not support the block ID parameter.
-/// If we were using `Option`, they would have to send `null`; this way it works with both 1 or 2 parameters.
-#[derive(Deserialize)]
-#[serde(untagged)]
-pub enum EstimateGasParams {
-    One((TypedTransaction,)),
-    Two((TypedTransaction, et::BlockId)),
-}
-
 /// Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.
 /// The transaction will not be added to the blockchain.
 /// Note that the estimate may be significantly more than the amount of gas actually used by the transaction, f
@@ -838,22 +828,11 @@ pub async fn get_filter_changes<C>(
     data: JsonRpcData<C>,
     Params((filter_id,)): Params<(FilterId,)>,
 ) -> JsonRpcResult<Vec<serde_json::Value>> {
-    fn to_json<R: Serialize>(values: Vec<R>) -> JsonRpcResult<Vec<serde_json::Value>> {
-        let values: Vec<serde_json::Value> = values
-            .into_iter()
-            .map(serde_json::to_value)
-            .collect::<Result<Vec<_>, _>>()
-            .context("failed to convert events to JSON")?;
-
-        Ok(values)
-    }
-
-    if let Some(accum) = data.take_filter_changes(filter_id).await? {
-        match accum {
-            FilterRecords::Logs(logs) => to_json(logs),
-            FilterRecords::NewBlocks(hashes) => to_json(hashes),
-            FilterRecords::PendingTransactions(hashes) => to_json(hashes),
-        }
+    if let Some(records) = data.take_filter_changes(filter_id).await? {
+        let records = records
+            .to_json_vec()
+            .context("failed to convert filter changes")?;
+        Ok(records)
     } else {
         error(ExitCode::USR_NOT_FOUND, "filter not found")
     }
@@ -873,5 +852,97 @@ pub async fn get_filter_logs<C>(
         }
     } else {
         error(ExitCode::USR_NOT_FOUND, "filter not found")
+    }
+}
+
+/// Subscribe to a filter and send the data to a websocket.
+pub async fn subscribe<C>(
+    data: JsonRpcData<C>,
+    Params(params): Params<SubscribeParams>,
+) -> JsonRpcResult<FilterId>
+where
+    C: SubscriptionClient + Sync + Send,
+{
+    match params {
+        SubscribeParams::One((tag, web_socket_id)) => match tag.as_str() {
+            "newHeads" => {
+                // Subscribe to `Block<TxHash>`
+                let ws_sender = data.get_web_socket(&web_socket_id).await?;
+                let id = data
+                    .new_subscription(FilterKind::NewBlocks, ws_sender)
+                    .await
+                    .context("failed to add block subscription")?;
+                Ok(id)
+            }
+            "newPendingTransactions" => {
+                // Subscribe to `TxHash`
+                let ws_sender = data.get_web_socket(&web_socket_id).await?;
+                let id = data
+                    .new_subscription(FilterKind::PendingTransactions, ws_sender)
+                    .await
+                    .context("failed to add transaction subscription")?;
+                Ok(id)
+            }
+            other => {
+                return error(
+                    ExitCode::USR_ILLEGAL_ARGUMENT,
+                    format!("unknown subscription: {other}"),
+                )
+            }
+        },
+        SubscribeParams::Two((tag, filter, web_socket_id)) => match tag.as_str() {
+            "logs" => {
+                // Subscribe to `Log`
+                let ws_sender = data.get_web_socket(&web_socket_id).await?;
+                let id = data
+                    .new_subscription(FilterKind::Logs(Box::new(filter)), ws_sender)
+                    .await
+                    .context("failed to add transaction subscription")?;
+                Ok(id)
+            }
+            other => {
+                return error(
+                    ExitCode::USR_ILLEGAL_ARGUMENT,
+                    format!("unknown subscription: {other}"),
+                )
+            }
+        },
+    }
+}
+
+/// Unsubscribe from the filter registered by this websocket.
+pub async fn unsubscribe<C>(
+    data: JsonRpcData<C>,
+    Params((filter_id, _web_socket_id)): Params<(FilterId, WebSocketId)>,
+) -> JsonRpcResult<bool> {
+    uninstall_filter(data, Params((filter_id,))).await
+}
+
+use params::{EstimateGasParams, SubscribeParams};
+
+mod params {
+    use ethers_core::types as et;
+    use ethers_core::types::transaction::eip2718::TypedTransaction;
+    use serde::Deserialize;
+
+    use crate::state::WebSocketId;
+
+    /// The client either sends one or two items in the array, depending on whether a block ID is specified.
+    /// This is to keep it backwards compatible with nodes that do not support the block ID parameter.
+    /// If we were using `Option`, they would have to send `null`; this way it works with both 1 or 2 parameters.
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    pub enum EstimateGasParams {
+        One((TypedTransaction,)),
+        Two((TypedTransaction, et::BlockId)),
+    }
+
+    /// The client either sends one or two items in the array, depending on whether it's subscribing to block,
+    /// transactions or logs. To that we add the web socket ID.
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    pub enum SubscribeParams {
+        One((String, WebSocketId)),
+        Two((String, et::Filter, WebSocketId)),
     }
 }

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -89,3 +89,8 @@ pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRo
         peerCount
     })
 }
+
+/// Indicate whether a method requires a WebSocket connection.
+pub fn is_streaming_method(method: &str) -> bool {
+    matches!(method, "eth_subscribe" | "eth_unsubscribe")
+}

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -94,5 +94,5 @@ pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRo
 
 /// Indicate whether a method requires a WebSocket connection.
 pub fn is_streaming_method(method: &str) -> bool {
-    matches!(method, "eth_subscribe" | "eth_unsubscribe")
+    method == "eth_subscribe"
 }

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -75,7 +75,9 @@ pub fn register_methods(server: ServerBuilder<MapRouter>) -> ServerBuilder<MapRo
         // eth_submitHashrate
         // eth_submitWork
         syncing,
-        uninstallFilter
+        uninstallFilter,
+        subscribe,
+        unsubscribe
     });
 
     let server = with_methods!(server, web3, {

--- a/fendermint/eth/api/src/error.rs
+++ b/fendermint/eth/api/src/error.rs
@@ -5,8 +5,8 @@ use fvm_shared::error::ExitCode;
 
 #[derive(Debug, Clone)]
 pub struct JsonRpcError {
-    code: i64,
-    message: String,
+    pub code: i64,
+    pub message: String,
 }
 
 impl From<anyhow::Error> for JsonRpcError {

--- a/fendermint/eth/api/src/filters.rs
+++ b/fendermint/eth/api/src/filters.rs
@@ -3,6 +3,7 @@
 
 use std::{
     collections::HashMap,
+    pin::Pin,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -10,8 +11,9 @@ use std::{
 use anyhow::{anyhow, Context};
 use ethers_core::types as et;
 use fendermint_vm_actor_interface::eam::EthAddress;
-use futures::StreamExt;
-use fvm_shared::address::Address;
+use futures::{Future, StreamExt};
+use fvm_shared::{address::Address, error::ExitCode};
+use serde::Serialize;
 use tendermint_rpc::{
     event::{Event, EventData},
     query::{EventType, Query},
@@ -22,7 +24,7 @@ use tokio::sync::{
     RwLock,
 };
 
-use crate::conv::from_tm;
+use crate::{conv::from_tm, error::JsonRpcError, state::WebSocketSender};
 
 /// Check whether to keep a log according to the topic filter.
 ///
@@ -53,13 +55,15 @@ pub fn matches_topics(filter: &et::Filter, log: &et::Log) -> bool {
 pub type FilterId = et::U256;
 pub type FilterMap = Arc<RwLock<HashMap<FilterId, Sender<FilterCommand>>>>;
 
+pub type BlockHash = et::H256;
+
 pub enum FilterCommand {
     /// Update the records with an event, coming from one of the Tendermint subscriptions.
     Update(Event),
     /// One of the subscriptions has ended, potentially with an error.
     Finish(Option<tendermint_rpc::Error>),
     /// Take the accumulated records, coming from the API consumer.
-    Take(tokio::sync::oneshot::Sender<anyhow::Result<Option<FilterRecords>>>),
+    Take(tokio::sync::oneshot::Sender<anyhow::Result<Option<FilterRecords<BlockHash>>>>),
     /// The API consumer is no longer interested in taking the records.
     Uninstall,
 }
@@ -155,13 +159,34 @@ impl FilterKind {
 /// Accumulator for filter data.
 ///
 /// The type expected can be seen in [ethers::providers::Provider::watch_blocks].
-pub enum FilterRecords {
-    NewBlocks(Vec<et::H256>),
-    PendingTransactions(Vec<et::H256>),
+pub enum FilterRecords<B> {
+    NewBlocks(Vec<B>),
+    PendingTransactions(Vec<et::TxHash>),
     Logs(Vec<et::Log>),
 }
 
-impl FilterRecords {
+impl<B> FilterRecords<B>
+where
+    B: Serialize,
+{
+    pub fn new(value: &FilterKind) -> Self {
+        match value {
+            FilterKind::NewBlocks => Self::NewBlocks(vec![]),
+            FilterKind::PendingTransactions => Self::PendingTransactions(vec![]),
+            FilterKind::Logs(_) => Self::Logs(vec![]),
+        }
+    }
+
+    fn take(&mut self) -> Self {
+        let mut records = match self {
+            Self::NewBlocks(_) => Self::NewBlocks(vec![]),
+            Self::PendingTransactions(_) => Self::PendingTransactions(vec![]),
+            Self::Logs(_) => Self::Logs(vec![]),
+        };
+        std::mem::swap(self, &mut records);
+        records
+    }
+
     pub fn is_empty(&self) -> bool {
         match self {
             Self::NewBlocks(xs) => xs.is_empty(),
@@ -169,126 +194,32 @@ impl FilterRecords {
             Self::Logs(xs) => xs.is_empty(),
         }
     }
-}
 
-impl From<&FilterKind> for FilterRecords {
-    fn from(value: &FilterKind) -> Self {
-        match value {
-            FilterKind::NewBlocks => Self::NewBlocks(vec![]),
-            FilterKind::PendingTransactions => Self::PendingTransactions(vec![]),
-            FilterKind::Logs(_) => Self::Logs(vec![]),
+    pub fn to_json_vec(&self) -> anyhow::Result<Vec<serde_json::Value>> {
+        match self {
+            Self::Logs(xs) => to_json_vec(xs),
+            Self::NewBlocks(xs) => to_json_vec(xs),
+            Self::PendingTransactions(xs) => to_json_vec(xs),
         }
-    }
-}
-
-impl From<&FilterRecords> for FilterRecords {
-    fn from(value: &FilterRecords) -> Self {
-        match value {
-            Self::NewBlocks(_) => Self::NewBlocks(vec![]),
-            Self::PendingTransactions(_) => Self::PendingTransactions(vec![]),
-            Self::Logs(_) => Self::Logs(vec![]),
-        }
-    }
-}
-
-/// Accumulate changes between polls.
-pub struct FilterState {
-    id: FilterId,
-    timeout: Duration,
-    last_poll: Instant,
-    finished: Option<Option<anyhow::Error>>,
-    records: FilterRecords,
-    rx: Receiver<FilterCommand>,
-}
-
-impl FilterState {
-    pub fn new(
-        id: FilterId,
-        timeout: Duration,
-        kind: &FilterKind,
-    ) -> (Self, Sender<FilterCommand>) {
-        let (tx, rx) = tokio::sync::mpsc::channel(10);
-        let s = Self {
-            id,
-            timeout,
-            last_poll: Instant::now(),
-            finished: None,
-            records: FilterRecords::from(kind),
-            rx,
-        };
-        (s, tx)
-    }
-
-    pub fn id(&self) -> FilterId {
-        self.id
-    }
-
-    /// Consume commands until some end condition is met.
-    ///
-    /// In the end the filter removes itself from the registry.
-    pub async fn run(mut self, filters: FilterMap) {
-        let id = self.id;
-
-        tracing::info!(?id, "handling filter events");
-        while let Some(cmd) = self.rx.recv().await {
-            match cmd {
-                FilterCommand::Update(event) => {
-                    if self.is_finished() {
-                        continue;
-                    }
-                    if self.is_timed_out() {
-                        tracing::debug!(?id, "filter timed out");
-                        return self.remove(filters).await;
-                    }
-                    if let Err(err) = self.update(event) {
-                        tracing::error!(?id, "failed to update filter: {err}");
-                        self.finish(Some(anyhow!("failed to update filter: {err}")));
-                    }
-                }
-                FilterCommand::Finish(err) => {
-                    tracing::info!(?id, "filter producer finished: {err:?}");
-                    self.finish(err.map(|e| anyhow!("subscription failed: {e}")))
-                }
-                FilterCommand::Uninstall => {
-                    tracing::error!(?id, "filter uninstalled");
-                    return self.remove(filters).await;
-                }
-                FilterCommand::Take(tx) => {
-                    let result = self.try_take();
-                    let remove = match result {
-                        Ok(None) | Err(_) => true,
-                        Ok(Some(_)) => false,
-                    };
-                    let _ = tx.send(result);
-                    if remove {
-                        tracing::info!(?id, "filter finished");
-                        return self.remove(filters).await;
-                    }
-                }
-            }
-        }
-        // All producers have been dropped, so there is no way for new commands to arrive.
-    }
-
-    async fn remove(self, filters: FilterMap) {
-        filters.write().await.remove(&self.id);
     }
 
     /// Accumulate the events.
-    fn update(&mut self, event: Event) -> anyhow::Result<()> {
-        match (&mut self.records, &event.data) {
+    async fn update<F>(&mut self, event: Event, f: F) -> anyhow::Result<()>
+    where
+        F: FnOnce(tendermint::Block) -> Pin<Box<dyn Future<Output = anyhow::Result<B>> + Send>>,
+    {
+        match (self, event.data) {
             (
-                FilterRecords::NewBlocks(ref mut hashes),
+                Self::NewBlocks(ref mut blocks),
                 EventData::NewBlock {
                     block: Some(block), ..
                 },
             ) => {
-                let h = block.header().hash();
-                let h = et::H256::from_slice(h.as_bytes());
-                hashes.push(h);
+                let b: B = f(block).await?;
+                blocks.push(b);
             }
             (
-                FilterRecords::PendingTransactions(ref mut hashes),
+                Self::PendingTransactions(ref mut hashes),
                 EventData::NewBlock {
                     block: Some(block), ..
                 },
@@ -299,7 +230,7 @@ impl FilterState {
                     hashes.push(h);
                 }
             }
-            (FilterRecords::Logs(ref mut logs), EventData::Tx { tx_result }) => {
+            (Self::Logs(ref mut logs), EventData::Tx { tx_result }) => {
                 // An example of an `Event`:
                 // Event {
                 //     query: "tm.event = 'Tx'",
@@ -370,16 +301,221 @@ impl FilterState {
         }
         Ok(())
     }
+}
 
+fn to_json_vec<R: Serialize>(records: &[R]) -> anyhow::Result<Vec<serde_json::Value>> {
+    let values: Vec<serde_json::Value> = records
+        .into_iter()
+        .map(serde_json::to_value)
+        .collect::<Result<Vec<_>, _>>()
+        .context("failed to convert records to JSON")?;
+
+    Ok(values)
+}
+
+pub struct FilterDriver {
+    id: FilterId,
+    state: FilterState,
+    rx: Receiver<FilterCommand>,
+}
+
+enum FilterState {
+    Poll(PollState),
+    Subscription(SubscriptionState),
+}
+
+/// Accumulate changes between polls.
+///
+/// Polling returns batches.
+struct PollState {
+    timeout: Duration,
+    last_poll: Instant,
+    finished: Option<Option<anyhow::Error>>,
+    records: FilterRecords<BlockHash>,
+}
+
+/// Send changes to a WebSocket as soon as they happen, one by one, not in batches.
+struct SubscriptionState {
+    kind: FilterKind,
+    ws_sender: WebSocketSender,
+}
+
+impl FilterDriver {
+    pub fn new(
+        id: FilterId,
+        timeout: Duration,
+        kind: FilterKind,
+        ws_sender: Option<WebSocketSender>,
+    ) -> (Self, Sender<FilterCommand>) {
+        let (tx, rx) = tokio::sync::mpsc::channel(10);
+        let state = match ws_sender {
+            Some(ws_sender) => FilterState::Subscription(SubscriptionState { kind, ws_sender }),
+            None => FilterState::Poll(PollState {
+                timeout,
+                last_poll: Instant::now(),
+                finished: None,
+                records: FilterRecords::new(&kind),
+            }),
+        };
+        let r = Self { id, state, rx };
+        (r, tx)
+    }
+
+    pub fn id(&self) -> FilterId {
+        self.id
+    }
+
+    /// Consume commands until some end condition is met.
+    ///
+    /// In the end the filter removes itself from the registry.
+    pub async fn run(mut self, filters: FilterMap) {
+        let id = self.id;
+
+        tracing::info!(?id, "handling filter events");
+        while let Some(cmd) = self.rx.recv().await {
+            match self.state {
+                FilterState::Poll(ref mut state) => {
+                    match cmd {
+                        FilterCommand::Update(event) => {
+                            if state.is_timed_out() {
+                                tracing::debug!(?id, "filter timed out");
+                                return self.remove(filters).await;
+                            }
+                            if state.is_finished() {
+                                // Not returning to allow the consumer to get final results.
+                                continue;
+                            }
+
+                            let res = state
+                                .records
+                                .update(event, |block| {
+                                    Box::pin(async move {
+                                        Ok(et::H256::from_slice(block.header().hash().as_bytes()))
+                                    })
+                                })
+                                .await;
+
+                            if let Err(err) = res {
+                                tracing::error!(?id, "failed to update filter: {err}");
+                                state.finish(Some(anyhow!("failed to update filter: {err}")));
+                            }
+                        }
+                        FilterCommand::Finish(err) => {
+                            tracing::debug!(?id, "filter producer finished: {err:?}");
+                            state.finish(err.map(|e| anyhow!("subscription failed: {e}")))
+                        }
+                        FilterCommand::Take(tx) => {
+                            let result = state.try_take();
+                            let remove = match result {
+                                Ok(None) | Err(_) => true,
+                                Ok(Some(_)) => false,
+                            };
+                            let _ = tx.send(result);
+                            if remove {
+                                tracing::debug!(?id, "filter finished");
+                                return self.remove(filters).await;
+                            }
+                        }
+                        FilterCommand::Uninstall => {
+                            tracing::debug!(?id, "filter uninstalled");
+                            return self.remove(filters).await;
+                        }
+                    }
+                }
+                FilterState::Subscription(ref state) => match cmd {
+                    FilterCommand::Update(event) => {
+                        let mut records = FilterRecords::<et::Block<et::TxHash>>::new(&state.kind);
+
+                        let res = records
+                            .update(event, |block| {
+                                todo!("need to make API queries to fill out all the fields")
+                            })
+                            .await;
+
+                        match res {
+                            Err(e) => {
+                                tracing::error!("failed to process events: {e}");
+                                send_error(
+                                    &state.ws_sender,
+                                    ExitCode::USR_UNSPECIFIED,
+                                    format!("failed to process events: {e}"),
+                                );
+                            }
+                            Ok(()) => match records.to_json_vec() {
+                                Err(e) => tracing::error!("failed to convert events to JSON: {e}"),
+                                Ok(records) => {
+                                    for rec in records {
+                                        if state.ws_sender.send(rec).is_err() {
+                                            tracing::debug!(?id, "web socket no longer listening");
+                                            return self.remove(filters).await;
+                                        }
+                                    }
+                                }
+                            },
+                        }
+                    }
+                    FilterCommand::Finish(err) => {
+                        tracing::debug!(?id, "subscription producer finished: {err:?}");
+                        // We have already sent all updates to the socket.
+
+                        // Make best effort to notify the socket.
+                        if let Some(err) = err {
+                            send_error(
+                                &state.ws_sender,
+                                ExitCode::USR_UNSPECIFIED,
+                                format!("subscription finished with error: {err}"),
+                            );
+                        }
+
+                        // We know at least one subscription has failed, so might as well quit.
+                        return self.remove(filters).await;
+                    }
+                    FilterCommand::Take(tx) => {
+                        // This should not be used, but because we treat subscriptions and filters
+                        // under the same umbrella, it is possible to send a request to get changes.
+                        // Respond with empty, because all of the changes were already sent to the socket.
+                        let _ = tx.send(Ok(Some(FilterRecords::new(&state.kind))));
+                    }
+                    FilterCommand::Uninstall => {
+                        tracing::debug!(?id, "subscription uninstalled");
+                        return self.remove(filters).await;
+                    }
+                },
+            }
+        }
+    }
+
+    async fn remove(self, filters: FilterMap) {
+        filters.write().await.remove(&self.id);
+    }
+}
+
+fn send_error(ws_sender: &WebSocketSender, exit_code: ExitCode, msg: String) {
+    let err = JsonRpcError {
+        code: exit_code.value().into(),
+        message: msg,
+    };
+    let err = jsonrpc_v2::Error::from(err);
+
+    match serde_json::to_value(err) {
+        Err(e) => tracing::error!("failed to convert JSON-RPC error to JSON: {e}"),
+        Ok(json) => {
+            // Ignoring the case where the socket is no longer there.
+            // Assuming that there will be another event to trigger removal.
+            let _ = ws_sender.send(json);
+        }
+    }
+}
+
+impl PollState {
     /// Take all the accumulated changes.
     ///
     /// If there are no changes but there was an error, return that.
     /// If the producers have stopped, return `None`.
-    fn try_take(&mut self) -> anyhow::Result<Option<FilterRecords>> {
+    fn try_take(&mut self) -> anyhow::Result<Option<FilterRecords<BlockHash>>> {
         self.last_poll = Instant::now();
 
-        let mut records = FilterRecords::from(&self.records);
-        std::mem::swap(&mut self.records, &mut records);
+        let records = self.records.take();
 
         if records.is_empty() {
             if let Some(ref mut finished) = self.finished {
@@ -417,6 +553,8 @@ impl FilterState {
 }
 
 /// Spawn a Tendermint subscription handler in a new task.
+///
+/// The subscription sends [Event] records to the driver over a channel.
 pub async fn run_subscription(id: FilterId, mut sub: Subscription, tx: Sender<FilterCommand>) {
     let query = sub.query().to_string();
     tracing::debug!(?id, query, "polling filter subscription");

--- a/fendermint/eth/api/src/handlers/http.rs
+++ b/fendermint/eth/api/src/handlers/http.rs
@@ -8,8 +8,7 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use jsonrpc_v2::{Id, RequestObject as JsonRpcRequestObject};
 
-use crate::handlers::call_rpc_str;
-use crate::{apis, AppState};
+use crate::{apis, AppState, JsonRpcServer};
 
 /// Handle JSON-RPC calls.
 pub async fn handle(
@@ -53,4 +52,13 @@ fn id_to_string(id: &jsonrpc_v2::Id) -> String {
         Id::Str(s) => (**s).to_owned(),
         Id::Num(n) => n.to_string(),
     }
+}
+
+// Calls an RPC method and returns the full response as a string.
+async fn call_rpc_str(
+    server: &JsonRpcServer,
+    request: jsonrpc_v2::RequestObject,
+) -> anyhow::Result<String> {
+    let response = server.handle(request).await;
+    Ok(serde_json::to_string(&response)?)
 }

--- a/fendermint/eth/api/src/handlers/http.rs
+++ b/fendermint/eth/api/src/handlers/http.rs
@@ -9,12 +9,12 @@ use axum::response::IntoResponse;
 use jsonrpc_v2::{Id, RequestObject as JsonRpcRequestObject};
 
 use crate::handlers::call_rpc_str;
-use crate::JsonRpcServer;
+use crate::AppState;
 
 /// Handle JSON-RPC calls.
 pub async fn handle(
     _headers: HeaderMap,
-    axum::extract::State(server): axum::extract::State<JsonRpcServer>,
+    axum::extract::State(state): axum::extract::State<AppState>,
     axum::Json(request): axum::Json<JsonRpcRequestObject>,
 ) -> impl IntoResponse {
     let response_headers = [("content-type", "application/json-rpc;charset=utf-8")];
@@ -26,7 +26,7 @@ pub async fn handle(
     let id = request.id_ref().map(id_to_string).unwrap_or_default();
     let method = request.method_ref().to_owned();
 
-    match call_rpc_str(&server, request).await {
+    match call_rpc_str(&state.rpc_server, request).await {
         Ok(result) => {
             tracing::debug!(method, id, result, "RPC call success");
             (StatusCode::OK, response_headers, result)

--- a/fendermint/eth/api/src/handlers/mod.rs
+++ b/fendermint/eth/api/src/handlers/mod.rs
@@ -1,16 +1,5 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::JsonRpcServer;
-
 pub mod http;
 pub mod ws;
-
-// Calls an RPC method and returns the full response as a string.
-async fn call_rpc_str(
-    server: &JsonRpcServer,
-    request: jsonrpc_v2::RequestObject,
-) -> anyhow::Result<String> {
-    let response = server.handle(request).await;
-    Ok(serde_json::to_string(&response)?)
-}

--- a/fendermint/eth/api/src/handlers/ws.rs
+++ b/fendermint/eth/api/src/handlers/ws.rs
@@ -4,7 +4,6 @@
 
 // Based on https://github.com/ChainSafe/forest/blob/v0.8.2/node/rpc/src/rpc_ws_handler.rs
 
-use anyhow::Context;
 use axum::{
     extract::{
         ws::{Message, WebSocket},
@@ -17,7 +16,7 @@ use futures::{stream::SplitSink, SinkExt, StreamExt};
 use fvm_shared::error::ExitCode;
 use jsonrpc_v2::RequestObject as JsonRpcRequest;
 
-use crate::{apis, handlers::call_rpc_str, AppState, JsonRpcServer};
+use crate::{apis, handlers::call_rpc_str, state::WebSocketId, AppState, JsonRpcServer};
 
 pub async fn handle(
     _headers: HeaderMap,
@@ -36,92 +35,108 @@ async fn rpc_ws_handler_inner(state: AppState, socket: WebSocket) {
     let (mut sender, mut receiver) = socket.split();
 
     // Create a channel over which the application can send messages to this socket.
-    let (socket_tx, _socket_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (app_tx, mut app_rx) = tokio::sync::mpsc::unbounded_channel();
 
-    let web_socket_id = state.rpc_state.add_web_socket(socket_tx).await;
+    let web_socket_id = state.rpc_state.add_web_socket(app_tx).await;
 
-    // TODO: Use tokio select!
+    loop {
+        tokio::select! {
+            Some(Ok(message)) = receiver.next() => {
+                handle_incoming(web_socket_id, &state.rpc_server, &mut sender, message).await
+            },
+            Some(json) = app_rx.recv() => {
+                handle_outgoing(&mut sender, json).await
+            },
+            else => break,
+        }
+    }
 
-    while let Some(Ok(message)) = receiver.next().await {
-        tracing::debug!("Received new WS RPC message: {:?}", message);
+    // Clean up.
+    state.rpc_state.remove_web_socket(&web_socket_id).await;
+}
 
-        if let Message::Text(request_text) = message {
-            tracing::debug!("WS RPC Request: {}", request_text);
+/// Handle an incoming request.
+async fn handle_incoming(
+    web_socket_id: WebSocketId,
+    rpc_server: &JsonRpcServer,
+    sender: &mut SplitSink<WebSocket, Message>,
+    message: Message,
+) {
+    tracing::debug!("Received new WS RPC message: {:?}", message);
 
-            if !request_text.is_empty() {
-                tracing::debug!("RPC Request Received: {:?}", &request_text);
+    if let Message::Text(request_text) = message {
+        tracing::debug!("WS RPC Request: {}", request_text);
 
-                match serde_json::from_str::<serde_json::Value>(&request_text) {
-                    Ok(mut json) => {
-                        // If the method requires web sockets, append the ID of the socket to the parameters.
-                        let is_streaming = match json.get("method") {
-                            Some(serde_json::Value::String(method)) => {
-                                apis::is_streaming_method(method)
-                            }
-                            _ => false,
-                        };
+        if !request_text.is_empty() {
+            tracing::debug!("RPC Request Received: {:?}", &request_text);
 
-                        if is_streaming {
-                            match json.get_mut("params") {
-                                Some(serde_json::Value::Array(ref mut params)) => {
-                                    params.push(serde_json::Value::Number(
-                                        serde_json::Number::from(web_socket_id),
-                                    ))
-                                }
-                                _ => {
-                                    tracing::debug!(
+            match serde_json::from_str::<serde_json::Value>(&request_text) {
+                Ok(mut json) => {
+                    // If the method requires web sockets, append the ID of the socket to the parameters.
+                    let is_streaming = match json.get("method") {
+                        Some(serde_json::Value::String(method)) => {
+                            apis::is_streaming_method(method)
+                        }
+                        _ => false,
+                    };
+
+                    if is_streaming {
+                        match json.get_mut("params") {
+                            Some(serde_json::Value::Array(ref mut params)) => params.push(
+                                serde_json::Value::Number(serde_json::Number::from(web_socket_id)),
+                            ),
+                            _ => {
+                                tracing::debug!(
                                         "JSON-RPC streaming request has no or unexpected params: {json}"
                                     )
-                                }
                             }
                         }
+                    }
 
-                        match serde_json::from_value::<JsonRpcRequest>(json) {
-                            Ok(req) => {
-                                match rpc_ws_call(&state.rpc_server, &mut sender, req).await {
-                                    Ok(()) => {
-                                        tracing::debug!("WS RPC task success.");
-                                    }
-                                    Err(e) => {
-                                        tracing::warn!("failed to send response to WS: {e}");
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                send_error(
-                                    &mut sender,
-                                    format!(
-                                        "Error deserializing WS payload as JSON-RPC request: {e}"
-                                    ),
-                                )
-                                .await;
-                            }
+                    match serde_json::from_value::<JsonRpcRequest>(json) {
+                        Ok(req) => {
+                            send_call_result(rpc_server, sender, req).await;
+                        }
+                        Err(e) => {
+                            send_error(
+                                sender,
+                                ExitCode::USR_SERIALIZATION,
+                                format!("Error deserializing WS payload as JSON-RPC request: {e}"),
+                            )
+                            .await;
                         }
                     }
-                    Err(e) => {
-                        send_error(
-                            &mut sender,
-                            format!("Error deserializing WS payload as JSON: {e}"),
-                        )
-                        .await;
-                    }
+                }
+                Err(e) => {
+                    send_error(
+                        sender,
+                        ExitCode::USR_SERIALIZATION,
+                        format!("Error deserializing WS payload as JSON: {e}"),
+                    )
+                    .await;
                 }
             }
         }
-
-        state.rpc_state.remove_web_socket(&web_socket_id).await;
     }
-
-    // TODO: Remove web socket.
 }
 
-async fn send_error(sender: &mut SplitSink<WebSocket, Message>, msg: String) {
+/// Send a message from the application, result of an async subscription.
+async fn handle_outgoing(sender: &mut SplitSink<WebSocket, Message>, json: serde_json::Value) {
+    match serde_json::to_string(&json) {
+        Ok(response) => {
+            send_response(sender, response).await;
+        }
+        Err(e) => {
+            tracing::error!("Failed to convert to JSON: {}", e);
+            send_error(sender, ExitCode::USR_UNSPECIFIED, e.to_string()).await;
+        }
+    }
+}
+
+async fn send_error(sender: &mut SplitSink<WebSocket, Message>, exit_code: ExitCode, msg: String) {
     tracing::error!("{}", msg);
     if let Err(e) = sender
-        .send(Message::Text(error_str(
-            ExitCode::USR_SERIALIZATION.value() as i64,
-            msg,
-        )))
+        .send(Message::Text(error_str(exit_code.value() as i64, msg)))
         .await
     {
         tracing::warn!("failed to send error response to WS: {e}");
@@ -129,30 +144,29 @@ async fn send_error(sender: &mut SplitSink<WebSocket, Message>, msg: String) {
 }
 
 /// Call the RPC method and respond through the Web Socket.
-async fn rpc_ws_call(
+async fn send_call_result(
     server: &JsonRpcServer,
     sender: &mut SplitSink<WebSocket, Message>,
     request: jsonrpc_v2::RequestObject,
-) -> anyhow::Result<()> {
+) {
     let method = request.method_ref();
 
     tracing::debug!("RPC WS called method: {}", method);
 
     match call_rpc_str(server, request).await {
-        Ok(response) => sender
-            .send(Message::Text(response))
-            .await
-            .context("failed to send success result to WS"),
+        Ok(response) => {
+            send_response(sender, response).await;
+        }
         Err(e) => {
             tracing::error!("RPC call failed: {}", e);
-            sender
-                .send(Message::Text(error_str(
-                    ExitCode::USR_UNSPECIFIED.value() as i64,
-                    e.to_string(),
-                )))
-                .await
-                .context("failed to send error result to WS")
+            send_error(sender, ExitCode::USR_UNSPECIFIED, e.to_string()).await;
         }
+    }
+}
+
+async fn send_response(sender: &mut SplitSink<WebSocket, Message>, response: String) {
+    if let Err(e) = sender.send(Message::Text(response)).await {
+        tracing::warn!("failed to send response to WS: {e}");
     }
 }
 

--- a/fendermint/eth/api/src/handlers/ws.rs
+++ b/fendermint/eth/api/src/handlers/ws.rs
@@ -208,8 +208,7 @@ mod tests {
     #[test]
     fn can_parse_request() {
         let text = "{\"id\":0,\"jsonrpc\":\"2.0\",\"method\":\"eth_newFilter\",\"params\":[{\"topics\":[]}]}";
-        let _value =
-            serde_json::from_str::<serde_json::Value>(&text).expect("should parse as JSON");
+        let _value = serde_json::from_str::<serde_json::Value>(text).expect("should parse as JSON");
         // The following would fail because `V2` expects an `&str` but the `from_value` deserialized returns `String`.
         // let _request = serde_json::from_value::<jsonrpc_v2::RequestObject>(value)
         //     .expect("should parse as JSON-RPC request");

--- a/fendermint/eth/api/src/lib.rs
+++ b/fendermint/eth/api/src/lib.rs
@@ -18,9 +18,17 @@ mod state;
 use error::{error, JsonRpcError};
 use state::JsonRpcState;
 
+/// This is passed to every method handler. It's generic in the client type to facilitate testing with mocks.
 type JsonRpcData<C> = Data<JsonRpcState<C>>;
 type JsonRpcServer = Arc<jsonrpc_v2::Server<jsonrpc_v2::MapRouter>>;
 type JsonRpcResult<T> = Result<T, JsonRpcError>;
+
+/// This is the state we will pass to [axum] so that we can extract it in handlers.
+#[derive(Clone)]
+pub struct AppState {
+    pub rpc_server: JsonRpcServer,
+    pub rpc_state: Arc<JsonRpcState<WebSocketClient>>,
+}
 
 /// Start listening to JSON-RPC requests.
 pub async fn listen<A: ToSocketAddrs>(
@@ -29,9 +37,13 @@ pub async fn listen<A: ToSocketAddrs>(
     filter_timeout: Duration,
 ) -> anyhow::Result<()> {
     if let Some(listen_addr) = listen_addr.to_socket_addrs()?.next() {
-        let state = JsonRpcState::new(client, filter_timeout);
-        let server = make_server(state);
-        let router = make_router(server);
+        let rpc_state = Arc::new(JsonRpcState::new(client, filter_timeout));
+        let rpc_server = make_server(rpc_state.clone());
+        let app_state = AppState {
+            rpc_server,
+            rpc_state,
+        };
+        let router = make_router(app_state);
         let server = axum::Server::try_bind(&listen_addr)?.serve(router.into_make_service());
 
         tracing::info!(?listen_addr, "bound Ethereum API");
@@ -43,16 +55,16 @@ pub async fn listen<A: ToSocketAddrs>(
 }
 
 /// Register method handlers with the JSON-RPC server construct.
-fn make_server(state: JsonRpcState<WebSocketClient>) -> JsonRpcServer {
-    let server = jsonrpc_v2::Server::new().with_data(Data(Arc::new(state)));
+fn make_server(state: Arc<JsonRpcState<WebSocketClient>>) -> JsonRpcServer {
+    let server = jsonrpc_v2::Server::new().with_data(Data(state));
     let server = apis::register_methods(server);
     server.finish()
 }
 
-/// Register routes in the `axum` router to handle JSON-RPC and WebSocket calls.
-fn make_router(server: JsonRpcServer) -> axum::Router {
+/// Register routes in the `axum` HTTP router to handle JSON-RPC and WebSocket calls.
+fn make_router(state: AppState) -> axum::Router {
     axum::Router::new()
         .route("/", post(handlers::http::handle))
         .route("/", get(handlers::ws::handle))
-        .with_state(server)
+        .with_state(state)
 }

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -29,7 +29,7 @@ use crate::filters::{
     run_subscription, BlockHash, FilterCommand, FilterDriver, FilterId, FilterKind, FilterMap,
     FilterRecords,
 };
-use crate::handlers::ws::Notification;
+use crate::handlers::ws::MethodNotification;
 use crate::{
     conv::from_tm::{
         map_rpc_block_txs, message_hash, to_chain_message, to_eth_block, to_eth_transaction,
@@ -38,7 +38,7 @@ use crate::{
 };
 
 pub type WebSocketId = usize;
-pub type WebSocketSender = UnboundedSender<Notification>;
+pub type WebSocketSender = UnboundedSender<MethodNotification>;
 
 // Made generic in the client type so we can mock it if we want to test API
 // methods without having to spin up a server. In those tests the methods

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -26,7 +26,8 @@ use tokio::sync::mpsc::{Sender, UnboundedSender};
 use tokio::sync::RwLock;
 
 use crate::filters::{
-    run_subscription, FilterCommand, FilterId, FilterKind, FilterMap, FilterRecords, FilterState,
+    run_subscription, BlockHash, FilterCommand, FilterDriver, FilterId, FilterKind, FilterMap,
+    FilterRecords,
 };
 use crate::{
     conv::from_tm::{
@@ -36,6 +37,7 @@ use crate::{
 };
 
 pub type WebSocketId = usize;
+pub type WebSocketSender = UnboundedSender<serde_json::Value>;
 
 // Made generic in the client type so we can mock it if we want to test API
 // methods without having to spin up a server. In those tests the methods
@@ -46,7 +48,7 @@ pub struct JsonRpcState<C> {
     filter_timeout: Duration,
     filters: FilterMap,
     next_web_socket_id: AtomicUsize,
-    web_sockets: RwLock<HashMap<WebSocketId, UnboundedSender<serde_json::Value>>>,
+    web_sockets: RwLock<HashMap<WebSocketId, WebSocketSender>>,
 }
 
 impl<C> JsonRpcState<C> {
@@ -66,17 +68,26 @@ impl<C> JsonRpcState<C> {
     }
 
     /// Register the sender of a web socket.
-    pub async fn add_web_socket(&self, tx: UnboundedSender<serde_json::Value>) -> WebSocketId {
+    pub async fn add_web_socket(&self, tx: WebSocketSender) -> WebSocketId {
         let next_id = self.next_web_socket_id.fetch_add(1, Ordering::Relaxed);
         let mut guard = self.web_sockets.write().await;
         guard.insert(next_id, tx);
         next_id
     }
 
-    /// Register the sender of a web socket.
+    /// Remove the sender of a web socket.
     pub async fn remove_web_socket(&self, id: &WebSocketId) {
         let mut guard = self.web_sockets.write().await;
         guard.remove(id);
+    }
+
+    /// Get the sender of a web socket.
+    pub async fn get_web_socket(&self, id: &WebSocketId) -> anyhow::Result<WebSocketSender> {
+        let guard = self.web_sockets.read().await;
+        guard
+            .get(id)
+            .cloned()
+            .ok_or_else(|| anyhow!("web socket not found"))
     }
 }
 
@@ -301,7 +312,11 @@ where
     C: SubscriptionClient,
 {
     /// Create a new filter with the next available ID and insert it into the filters collection.
-    async fn insert_filter(&self, filter: &FilterKind) -> (FilterState, Sender<FilterCommand>) {
+    async fn insert_filter_driver(
+        &self,
+        kind: FilterKind,
+        ws_sender: Option<WebSocketSender>,
+    ) -> (FilterDriver, Sender<FilterCommand>) {
         let mut filters = self.filters.write().await;
 
         // Choose an unpredictable filter, so it's not so easy to clear out someone else's logs.
@@ -313,17 +328,21 @@ where
             }
         }
 
-        let (state, tx) = FilterState::new(id, self.filter_timeout, filter);
+        let (driver, tx) = FilterDriver::new(id, self.filter_timeout, kind, ws_sender);
 
         // Inserting happens here, while removal will be handled by the `FilterState` itself.
         filters.insert(id, tx.clone());
 
-        (state, tx)
+        (driver, tx)
     }
 
-    /// Create a new filter, subscribe with Tendermint and start handlers in the background.
-    pub async fn new_filter(&self, filter: FilterKind) -> anyhow::Result<FilterId> {
-        let queries = filter
+    /// Create a new filter driver, subscribe with Tendermint and start handlers in the background.
+    async fn new_filter_driver(
+        &self,
+        kind: FilterKind,
+        ws_sender: Option<WebSocketSender>,
+    ) -> anyhow::Result<FilterId> {
+        let queries = kind
             .to_queries()
             .context("failed to convert filter to queries")?;
 
@@ -339,7 +358,7 @@ where
             subs.push(sub);
         }
 
-        let (state, tx) = self.insert_filter(&filter).await;
+        let (state, tx) = self.insert_filter_driver(kind, ws_sender).await;
         let id = state.id();
         let filters = self.filters.clone();
 
@@ -351,6 +370,20 @@ where
         }
 
         Ok(id)
+    }
+
+    /// Create a new filter, subscribe with Tendermint and start handlers in the background.
+    pub async fn new_filter(&self, kind: FilterKind) -> anyhow::Result<FilterId> {
+        self.new_filter_driver(kind, None).await
+    }
+
+    /// Create a new subscription, subscribe with Tendermint and start handlers in the background.
+    pub async fn new_subscription(
+        &self,
+        kind: FilterKind,
+        ws_sender: WebSocketSender,
+    ) -> anyhow::Result<FilterId> {
+        self.new_filter_driver(kind, Some(ws_sender)).await
     }
 }
 
@@ -373,7 +406,7 @@ impl<C> JsonRpcState<C> {
     pub async fn take_filter_changes(
         &self,
         filter_id: FilterId,
-    ) -> anyhow::Result<Option<FilterRecords>> {
+    ) -> anyhow::Result<Option<FilterRecords<BlockHash>>> {
         let filters = self.filters.read().await;
 
         match filters.get(&filter_id) {

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -76,7 +76,7 @@ impl<C> JsonRpcState<C> {
     /// Register the sender of a web socket.
     pub async fn remove_web_socket(&self, id: &WebSocketId) {
         let mut guard = self.web_sockets.write().await;
-        guard.remove(&id);
+        guard.remove(id);
     }
 }
 

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -29,6 +29,7 @@ use crate::filters::{
     run_subscription, BlockHash, FilterCommand, FilterDriver, FilterId, FilterKind, FilterMap,
     FilterRecords,
 };
+use crate::handlers::ws::Notification;
 use crate::{
     conv::from_tm::{
         map_rpc_block_txs, message_hash, to_chain_message, to_eth_block, to_eth_transaction,
@@ -37,7 +38,7 @@ use crate::{
 };
 
 pub type WebSocketId = usize;
-pub type WebSocketSender = UnboundedSender<serde_json::Value>;
+pub type WebSocketSender = UnboundedSender<Notification>;
 
 // Made generic in the client type so we can mock it if we want to test API
 // methods without having to spin up a server. In those tests the methods

--- a/fendermint/rpc/src/client.rs
+++ b/fendermint/rpc/src/client.rs
@@ -78,6 +78,7 @@ pub async fn ws_client(url: Url) -> anyhow::Result<(WebSocketClient, WebSocketCl
 }
 
 /// Unauthenticated Fendermint client.
+#[derive(Clone)]
 pub struct FendermintClient<C = HttpClient> {
     inner: C,
 }


### PR DESCRIPTION
Closes #138 
Part of #99

Implements two new methods:
* eth_subscribe
* eth_unsubscribe

The filter system now can work either in polling or push based fashion.

The ethers example has been modified to exercise the JSON-RPC requests over both HTTP and WS protocols. 

TODO:
- [x] Subscribe to blocks, transactions and logs in the WS scenario, run the examples, then check that some stuff has been collected.