### PR TITLE
Improve gas estimation logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3628,8 +3628,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc-v2"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b2a38e4b2dc33f5bfe487781a5e82d0c60ab2b7f2fa1f132cbac177e9c708"
+source = "git+https://github.com/cryptoAtwill/jsonrpc-v2?branch=expose_inner_error#887262b2816fea3362c425209196005daa0c00f6"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,68 +19,69 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 license-file = "LICENSE-APACHE"
 
-
 [workspace.dependencies]
-anyhow = "1"
-arbitrary = { version = "1", features = ["derive"] }
-arbtest = "0.2"
-async-stm = "0.2"
-async-trait = "0.1"
-axum = { version = "0.6", features = ["ws"] }
-base64 = "0.21"
-blake2b_simd = "1.0"
-bytes = "1.4"
-clap = { version = "4.1", features = ["derive", "env"] }
-config = "0.13"
-dirs = "5.0"
-ethers = { version = "2.0", features = ["abigen", "ws"] }
-ethers-core = { version = "2.0" }
-fnv = "1.0"
-futures = "0.3"
-hex = "0.4"
-jsonrpc-v2 = { version = "0.11", default-features = false, features = ["bytes-v10"] }
-k256 = "0.11"                                                                         # Same as tendermint-rs
-lazy_static = "1.4"
-libsecp256k1 = "0.7"
-multihash = { version = "0.16.1", default-features = false }
-num-traits = "0.2"
-paste = "1"
-prost = { version = "0.11" }
-quickcheck = "1"
-quickcheck_macros = "1"
-rand = "0.8"
-rand_chacha = "0.3"
-regex = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1" }
-serde_tuple = "0.5"
-serde_with = "2.3"
-tempfile = "3.3"
-thiserror = "1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
-tracing = "0.1"
-tracing-subscriber = "0.3"
-
+anyhow = "1" 
+arbitrary = {version = "1", features = ["derive"]} 
+arbtest = "0.2" 
+async-stm = "0.2" 
+async-trait = "0.1" 
+axum = {version = "0.6", features = ["ws"]} 
+base64 = "0.21" 
+blake2b_simd = "1.0" 
+bytes = "1.4" 
+clap = {version = "4.1", features = ["derive", "env"]} 
+config = "0.13" 
+dirs = "5.0" 
+ethers = {version = "2.0", features = ["abigen", "ws"]} 
+ethers-core = {version = "2.0"} 
+fnv = "1.0" 
+futures = "0.3" 
+hex = "0.4" 
+jsonrpc-v2 = {version = "0.11", default-features = false, features = ["bytes-v10"]} 
+k256 = "0.11" # Same as tendermint-rs
+lazy_static = "1.4" 
+libsecp256k1 = "0.7" 
+multihash = {version = "0.16.1", default-features = false} 
+num-traits = "0.2" 
+paste = "1" 
+prost = {version = "0.11"} 
+quickcheck = "1" 
+quickcheck_macros = "1" 
+rand = "0.8" 
+rand_chacha = "0.3" 
+regex = "1" 
+serde = {version = "1", features = ["derive"]} 
+serde_json = {version = "1"} 
+serde_tuple = "0.5" 
+serde_with = "2.3" 
+tempfile = "3.3" 
+thiserror = "1" 
+tokio = {version = "1", features = ["rt-multi-thread", "macros"]} 
+tracing = "0.1" 
+tracing-subscriber = "0.3" 
 
 # Stable FVM dependencies from crates.io
-fvm = { version = "=3.3", default-features = false }     # no opencl feature or it fails on CI
+fvm = {version = "=3.3", default-features = false}# no opencl feature or it fails on CI
 fvm_ipld_blockstore = "0.1"
-fvm_ipld_encoding = "0.3"
 fvm_ipld_car = "0.6"
+fvm_ipld_encoding = "0.3"
 fvm_ipld_hamt = "0.6"
-fvm_shared = { version = "=3.3", features = ["crypto"] }
+fvm_shared = {version = "=3.3", features = ["crypto"]}
 
 # Using 0.8 because of ref-fvm.
 # 0.9 would be better because of its updated quickcheck dependency.
 # 0.10 breaks some API.
-cid = { version = "0.8", features = ["serde-codec", "std"] }
+cid = {version = "0.8", features = ["serde-codec", "std"]}
 
 # Depending on the release cycle, this dependency might want an earlier version of the FVM.
 # We can work around it by hardcoding the method hashes; currently there is only one.
 # frc42_dispatch = "3.2"
 
 # Using the same tendermint-rs dependency as tower-abci. From both we are interested in v037 modules.
-tower-abci = { version = "0.7" }
-tendermint = { version = "0.31", features = ["secp256k1"] }
-tendermint-rpc = { version = "0.31", features = ["secp256k1", "http-client", "websocket-client"] }
-tendermint-proto = { version = "0.31" }
+tendermint = {version = "0.31", features = ["secp256k1"]}
+tendermint-proto = {version = "0.31"}
+tendermint-rpc = {version = "0.31", features = ["secp256k1", "http-client", "websocket-client"]}
+tower-abci = {version = "0.7"}
+
+[patch.crates-io]
+jsonrpc-v2 = {git = "https://github.com/cryptoAtwill/jsonrpc-v2", branch = "expose_inner_error"}

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -539,6 +539,10 @@ where
                 }
             },
         };
+        println!(
+            "-- Deliver Response status: {:?} - info: {:?}",
+            response.code, response.info
+        );
 
         Ok(response)
     }

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -539,10 +539,14 @@ where
                 }
             },
         };
-        println!(
-            "-- Deliver Response status: {:?} - info: {:?}",
-            response.code, response.info
-        );
+
+        if response.code != 0.into() {
+            tracing::error!(
+                "deliver_tx failed: {:?} - {:?}",
+                response.code,
+                response.info
+            );
+        }
 
         Ok(response)
     }

--- a/fendermint/eth/api/src/handlers/http.rs
+++ b/fendermint/eth/api/src/handlers/http.rs
@@ -20,8 +20,7 @@ pub async fn handle(
 
     // NOTE: Any authorization can come here.
 
-    tracing::debug!("RPC request: {request:?}");
-    println!("** RPC request: {request:?}");
+    tracing::info!("RPC request: {request:?}");
 
     let id = request.id_ref().map(id_to_string).unwrap_or_default();
     let method = request.method_ref().to_owned();
@@ -38,13 +37,12 @@ pub async fn handle(
         Ok(result) => {
             tracing::debug!(method, id, result, "RPC call success");
 
-            println!("-- RPC response success!: {method:?} - {result:?}");
+            tracing::debug!("RPC response success: {method:?} - {result:?}");
             (StatusCode::OK, response_headers, result)
         }
         Err(err) => {
             let msg = err.to_string();
             tracing::error!(method, id, msg, "RPC call failure");
-            println!("xx RPC response failure!: {method:?} - {msg:?}");
             (StatusCode::INTERNAL_SERVER_ERROR, response_headers, msg)
         }
     }

--- a/fendermint/eth/api/src/handlers/http.rs
+++ b/fendermint/eth/api/src/handlers/http.rs
@@ -21,6 +21,7 @@ pub async fn handle(
     // NOTE: Any authorization can come here.
 
     tracing::debug!("RPC request: {request:?}");
+    println!("** RPC request: {request:?}");
 
     let id = request.id_ref().map(id_to_string).unwrap_or_default();
     let method = request.method_ref().to_owned();
@@ -36,11 +37,14 @@ pub async fn handle(
     match call_rpc_str(&state.rpc_server, request).await {
         Ok(result) => {
             tracing::debug!(method, id, result, "RPC call success");
+
+            println!("-- RPC response success!: {method:?} - {result:?}");
             (StatusCode::OK, response_headers, result)
         }
         Err(err) => {
             let msg = err.to_string();
             tracing::error!(method, id, msg, "RPC call failure");
+            println!("xx RPC response failure!: {method:?} - {msg:?}");
             (StatusCode::INTERNAL_SERVER_ERROR, response_headers, msg)
         }
     }
@@ -62,3 +66,8 @@ async fn call_rpc_str(
     let response = server.handle(request).await;
     Ok(serde_json::to_string(&response)?)
 }
+
+// RPC request: RequestObject { jsonrpc: V2, method: "eth_estimateGas", params: Some(Value(Array [Object {"data": Null, "from": String("0x6be1ccf648c74800380d0520d797a170c808b624"), "gasPrice": String("0x0"), "value": String("0x0")}])), id: Some(Some(Num(1314076190650))) }
+// RPC request: RequestObject { jsonrpc: V2, method: "eth_blockNumber", params: Some(Value(Array [])), id: Some(Some(Num(4225860438222755))) }
+// RPC request: RequestObject { jsonrpc: V2, method: "eth_getBlockByNumber", params: Some(Value(Array [String("0x3cd"), Bool(false)])), id: Some(Some(Num(4225860438222756))) }
+// RPC request: RequestObject { jsonrpc: V2, method: "eth_feeHistory", params: Some(Value(Array [String("0x5"), String("0x3cd"), Array [Number(10), Number(20), Number(30)]])), id: Some(Some(Num(4225860438222757))) }

--- a/fendermint/vm/interpreter/src/fvm/query.rs
+++ b/fendermint/vm/interpreter/src/fvm/query.rs
@@ -3,7 +3,9 @@
 use async_trait::async_trait;
 use fendermint_vm_message::query::{ActorState, FvmQuery, GasEstimate, StateParams};
 use fvm_ipld_blockstore::Blockstore;
-use fvm_shared::{ActorID, BLOCK_GAS_LIMIT};
+use fvm_shared::{
+    bigint::BigInt, econ::TokenAmount, error::ExitCode, message::Message, ActorID, BLOCK_GAS_LIMIT,
+};
 
 use crate::QueryInterpreter;
 
@@ -64,24 +66,19 @@ where
                 FvmQueryRet::Call(ret)
             }
             FvmQuery::EstimateGas(mut msg) => {
-                // TODO: Figure out how to relate the token balance to a gas limit.
-                //       Do we look at `state.state_params.base_fee`? What about `gas_premium` and `gas_limit`?
-
-                // XXX: This value is for Filecoin, and it's not even used by the FVM, but at least it should not have a problem with it.
+                // Setting BlockGasLimit as initial limit for gas estimation
                 msg.gas_limit = BLOCK_GAS_LIMIT;
 
-                // TODO: This actually fails if the caller doesn't have enough gas.
-                //       Should we modify the state tree up front to give it more?
-                let apply_ret = state.call(*msg)?;
+                // Populate gas message parameters.
+                // If message fails with BLOCK_GAS_LIMIT as the message gas limit
+                // it means that there is an error in the execution of the message
+                // we could optionally propagate that error if needed as done in Lotus.
+                // (but why would you want to estimate the gas of a message that can't
+                // be executed?)
+                let mut msg = self.estimate_gassed_msg(&state, msg)?;
 
-                let est = GasEstimate {
-                    exit_code: apply_ret.msg_receipt.exit_code,
-                    info: apply_ret
-                        .failure_info
-                        .map(|x| x.to_string())
-                        .unwrap_or_default(),
-                    gas_limit: apply_ret.msg_receipt.gas_used,
-                };
+                // perform a gas search for an accurate value
+                let est = self.gas_search(&state, &mut msg)?;
 
                 FvmQueryRet::EstimateGas(est)
             }
@@ -97,5 +94,134 @@ where
             }
         };
         Ok((state, res))
+    }
+}
+
+impl<DB> FvmMessageInterpreter<DB>
+where
+    DB: Blockstore + 'static + Send + Sync + Clone,
+{
+    /// Overestimation rate applied to gas to ensure that the
+    /// message goes through in the gas estimation.
+    const GAS_OVERESTIMATION_RATE: f64 = 1.25;
+    /// Default gas premium value. Inferred through a quick search through
+    /// InvokeEVM messages in filfox. The default value is only used if
+    /// the user hasn't specified a gas premium.
+    const DEFAULT_GAS_PREMIUM: u64 = 20000;
+    /// Gas search step increase used to find the optimal gas limit.
+    const GAS_SEARCH_STEP: f64 = 1.2;
+
+    fn estimate_gassed_msg(
+        &self,
+        state: &FvmQueryState<DB>,
+        msg: Box<Message>,
+    ) -> anyhow::Result<Message> {
+        let mut out = (*msg).clone();
+        // estimate the gas limit and assign it to the message
+        // do not reuse the cache
+        let ret = state.call_with_cache(*msg.clone(), false)?;
+        if ret.msg_receipt.exit_code != ExitCode::OK {
+            return Err(anyhow::anyhow!(
+                "message execution failed with error code {}",
+                ret.msg_receipt.exit_code
+            ));
+        }
+        out.gas_limit = (ret.msg_receipt.gas_used as f64 * Self::GAS_OVERESTIMATION_RATE) as u64;
+        if out.gas_premium.is_zero() {
+            // TODO: Instead of assigning a default value here, we should analyze historical
+            // blocks from the current height to estimate an accurate value for this premium.
+            // To achieve this we would need to perform a set of ABCI queries.
+            // In the meantime, this value should be good enough to make sure that the
+            // message is included in a block.
+            out.gas_premium = TokenAmount::from_nano(BigInt::from(Self::DEFAULT_GAS_PREMIUM));
+        }
+        if out.gas_fee_cap.is_zero() {
+            // Compute the fee cap from gas premium and applying an additional overestimation.
+            let overestimated_limit = (out.gas_limit as f64 * Self::GAS_OVERESTIMATION_RATE) as u64;
+            out.gas_fee_cap = std::cmp::min(
+                TokenAmount::from_atto(BigInt::from(overestimated_limit)) + &out.gas_premium,
+                TokenAmount::from_atto(BLOCK_GAS_LIMIT),
+            );
+
+            // TODO: In Lotus historical values of the base fee and a more accurate overestimation is performed
+            // for the fee cap. If we issues with messages going through let's consider the historical analysis.
+        }
+
+        Ok(out)
+    }
+
+    // This function performs a simpler implementation of the gas search than the one used in Lotus.
+    // Instead of using historical information of the gas limit for other messages, it searches
+    // for a valid gas limit for the current message in isolation.
+    fn gas_search(
+        &self,
+        state: &FvmQueryState<DB>,
+        msg: &mut Message,
+    ) -> anyhow::Result<GasEstimate> {
+        let mut curr_limit = msg.gas_limit;
+
+        while {
+            let ret = self.estimation_call_with_limit(state, msg, curr_limit)?;
+            if ret.is_some() {
+                return Ok(ret.unwrap());
+            }
+
+            curr_limit = (curr_limit as f64 * Self::GAS_SEARCH_STEP) as u64;
+            if curr_limit > BLOCK_GAS_LIMIT {
+                return Ok(GasEstimate {
+                    exit_code: ExitCode::OK,
+                    info: "".to_string(),
+                    gas_limit: BLOCK_GAS_LIMIT,
+                });
+            }
+            true
+        } {}
+
+        // TODO: For a more accurate gas estimation we could track the low and the high
+        // of the search and make higher steps (e.g. `GAS_SEARCH_STEP = 2`).
+        // Once an interval is found of [low, high] for which the message
+        // succeeds, we make a finer-grained within that interval.
+        // At this point, I don't think is worth being that accurate as long as it works.
+
+        Err(anyhow::anyhow!(
+            "gas search failed. no valid gas limit found"
+        ))
+    }
+
+    fn estimation_call_with_limit(
+        &self,
+        state: &FvmQueryState<DB>,
+        msg: &Message,
+        limit: u64,
+    ) -> anyhow::Result<Option<GasEstimate>> {
+        let mut msg = msg.clone();
+        msg.gas_limit = limit;
+        // set message nonce to zero so the right one is picked up
+        msg.sequence = 0;
+        println!("message being applied: {:?}", msg);
+
+        let apply_ret = state.call_with_cache(msg, false)?;
+
+        let ret = GasEstimate {
+            exit_code: apply_ret.msg_receipt.exit_code,
+            info: apply_ret
+                .failure_info
+                .map(|x| x.to_string())
+                .unwrap_or_default(),
+            gas_limit: apply_ret.msg_receipt.gas_used,
+        };
+
+        if ret.exit_code == ExitCode::OK {
+            return Ok(Some(ret));
+        }
+
+        if ret.exit_code != ExitCode::SYS_OUT_OF_GAS {
+            return Err(anyhow::anyhow!(
+                "message execution failed in gas search with error code {:?}",
+                ret.exit_code
+            ));
+        }
+
+        Ok(None)
     }
 }

--- a/fendermint/vm/interpreter/src/fvm/state/query.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/query.rs
@@ -91,13 +91,19 @@ where
     }
 
     /// If we know the query is over the state, cache the state tree.
-    fn with_exec_state<T, F>(&self, f: F) -> anyhow::Result<T>
+    /// If we enable the reuse_cache flag we will reuse the cache from a previous
+    /// message execution, if false, we start from the fresh state of the `FvmQueryState`.
+    /// Enable `reuse_cache` when you want to execute a batch of messages sequentially,
+    /// for independent message execution disable this flag.
+    fn with_exec_state<T, F>(&self, reuse_cache: bool, f: F) -> anyhow::Result<T>
     where
         F: FnOnce(&mut FvmExecState<ReadOnlyBlockstore<DB>>) -> anyhow::Result<T>,
     {
         let mut cache = self.exec_state.borrow_mut();
-        if let Some(exec_state) = cache.as_mut() {
-            return f(exec_state);
+        if reuse_cache {
+            if let Some(exec_state) = cache.as_mut() {
+                return f(exec_state);
+            }
         }
 
         let mut exec_state = FvmExecState::new(
@@ -143,14 +149,25 @@ where
     /// The results are never going to be flushed, so it's semantically read-only,
     /// but it might write into the buffered block store the FVM creates. Running
     /// multiple such messages results in their buffered effects stacking up.
-    pub fn call(&self, mut msg: FvmMessage) -> anyhow::Result<ApplyRet> {
+    pub fn call(&self, msg: FvmMessage) -> anyhow::Result<ApplyRet> {
+        // the default behavior of call is to reuse the cache and stack the results.
+        // for isolated execution of message without cache, use directly `call_with_cache`
+        self.call_with_cache(msg, true)
+    }
+
+    /// Run a "read-only" message with the option of reusing the cache or not.
+    pub fn call_with_cache(
+        &self,
+        mut msg: FvmMessage,
+        reuse_cache: bool,
+    ) -> anyhow::Result<ApplyRet> {
         // If the sequence is zero, treat it as a signal to use whatever is in the state.
         if msg.sequence.is_zero() {
             if let Some((_, state)) = self.actor_state(&msg.from)? {
                 msg.sequence = state.sequence;
             }
         }
-        self.with_exec_state(|s| {
+        self.with_exec_state(reuse_cache, |s| {
             if msg.from == SYSTEM_ACTOR_ADDR {
                 // Explicit execution requires `from` to be an account kind.
                 s.execute_implicit(msg)


### PR DESCRIPTION
Depends on: #161 

This PR improves the gas estimation logic. Instead of directly pre-executing the message to get the estimated gas of the call we: 
- Estimate the exact gas used for the execution. 
- Apply an overestimation. 
- Perform a gas search to see if the gas limit needs to be increased over the previous overestimation. 
Without this, tools like Metamask and Remix didn't estimate the gas correctly and message never went through. This approach is not as accurate as the fine-grained one used in Lotus, but for our use case is good enough to ensure that the transaction is included in the next block.  

Additionally, the gas estimation also populates the gas premium and gas limit of the transaction when not set. 

For the gas estimation logic, I had to include a new `call_with_cache` method to allow enabling and disabling the cache to determine if in the subsequent execution of message the results should be conveniently buffered or not. 