### PR TITLE
Use exec state

### DIFF
--- a/fendermint/vm/interpreter/src/fvm/query.rs
+++ b/fendermint/vm/interpreter/src/fvm/query.rs
@@ -45,7 +45,7 @@ where
         let res = match qry {
             FvmQuery::Ipld(cid) => FvmQueryRet::Ipld(state.store_get(&cid)?),
             FvmQuery::ActorState(addr) => {
-                FvmQueryRet::ActorState(state.actor_state(&addr)?.map(Box::new))
+                FvmQueryRet::ActorState(state.actor_state(false, &addr)?.map(Box::new))
             }
             FvmQuery::Call(msg) => {
                 let from = msg.from;

--- a/fendermint/vm/interpreter/src/fvm/state/query.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/query.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, Context};
 use cid::Cid;
 use fendermint_vm_actor_interface::system::SYSTEM_ACTOR_ADDR;
 use fendermint_vm_message::query::ActorState;
-use fvm::{engine::MultiEngine, executor::ApplyRet, state_tree::StateTree};
+use fvm::{engine::MultiEngine, executor::ApplyRet};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::{address::Address, clock::ChainEpoch, ActorID};
 use num_traits::Zero;
@@ -32,8 +32,6 @@ where
     block_height: ChainEpoch,
     /// State at the height we want to query.
     state_params: FvmStateParams,
-    /// Lazy loaded state tree.
-    state_tree: RefCell<Option<StateTree<ReadOnlyBlockstore<DB>>>>,
     /// Lazy loaded execution state.
     exec_state: RefCell<Option<FvmExecState<ReadOnlyBlockstore<DB>>>>,
 }
@@ -64,30 +62,10 @@ where
             multi_engine,
             block_height,
             state_params,
-            // NOTE: Not loading a state tree in case it's not needed; it would initialize the HAMT.
-            state_tree: RefCell::new(None),
             exec_state: RefCell::new(None),
         };
 
         Ok(state)
-    }
-
-    /// If we know the query is over the state, cache the state tree.
-    fn with_state_tree<T, F>(&self, f: F) -> anyhow::Result<T>
-    where
-        F: FnOnce(&StateTree<ReadOnlyBlockstore<DB>>) -> anyhow::Result<T>,
-    {
-        let mut cache = self.state_tree.borrow_mut();
-        if let Some(state_tree) = cache.as_ref() {
-            return f(state_tree);
-        }
-
-        let state_tree =
-            StateTree::new_from_root(self.store.clone(), &self.state_params.state_root)?;
-
-        let res = f(&state_tree);
-        *cache = Some(state_tree);
-        res
     }
 
     /// If we know the query is over the state, cache the state tree.
@@ -125,8 +103,9 @@ where
     }
 
     /// Get the state of an actor, if it exists.
-    pub fn actor_state(&self, addr: &Address) -> anyhow::Result<Option<(ActorID, ActorState)>> {
-        self.with_state_tree(|state_tree| {
+    pub fn actor_state(&self, use_cache: bool, addr: &Address) -> anyhow::Result<Option<(ActorID, ActorState)>> {
+        self.with_exec_state(use_cache, |exec_state| {
+            let state_tree = exec_state.state_tree_mut();
             if let Some(id) = state_tree.lookup_id(addr)? {
                 Ok(state_tree.get_actor(id)?.map(|st| {
                     let st = ActorState {
@@ -154,7 +133,7 @@ where
     pub fn call(&self, mut msg: FvmMessage, use_cache: bool) -> anyhow::Result<ApplyRet> {
         // If the sequence is zero, treat it as a signal to use whatever is in the state.
         if msg.sequence.is_zero() {
-            if let Some((_, state)) = self.actor_state(&msg.from)? {
+            if let Some((_, state)) = self.actor_state(use_cache, &msg.from)? {
                 msg.sequence = state.sequence;
             }
         }

--- a/fendermint/vm/interpreter/src/fvm/state/query.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/query.rs
@@ -103,7 +103,11 @@ where
     }
 
     /// Get the state of an actor, if it exists.
-    pub fn actor_state(&self, use_cache: bool, addr: &Address) -> anyhow::Result<Option<(ActorID, ActorState)>> {
+    pub fn actor_state(
+        &self,
+        use_cache: bool,
+        addr: &Address,
+    ) -> anyhow::Result<Option<(ActorID, ActorState)>> {
         self.with_exec_state(use_cache, |exec_state| {
             let state_tree = exec_state.state_tree_mut();
             if let Some(id) = state_tree.lookup_id(addr)? {


### PR DESCRIPTION
This addresses issue #176.

This PR removes the state_tree option and just use exec_state, which also exposes a state_tree_mut() method now, to avoid any discrepancy, and then you can chain call and actor_state calls freely.