### PR TITLE
Migrate Top-down

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2216,6 +2216,7 @@ dependencies = [
  "dirs",
  "fendermint_abci",
  "fendermint_eth_api",
+ "fendermint_ipc",
  "fendermint_rocksdb",
  "fendermint_rpc",
  "fendermint_storage",
@@ -2296,6 +2297,19 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "fendermint_ipc"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "ipc-sdk",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2494,6 +2508,7 @@ dependencies = [
  "cid",
  "ethers",
  "ethers-core",
+ "fendermint_ipc",
  "fendermint_testing",
  "fendermint_vm_actor_interface",
  "fendermint_vm_encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "fendermint/testing",
   "fendermint/testing/*-test",
   "fendermint/vm/*",
+  "fendermint/ipc",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -56,7 +57,7 @@ serde_tuple = "0.5"
 serde_with = "2.3" 
 tempfile = "3.3" 
 thiserror = "1" 
-tokio = {version = "1", features = ["rt-multi-thread", "macros"]} 
+tokio = {version = "1", features = ["rt-multi-thread", "macros", "time"]}
 tracing = "0.1" 
 tracing-subscriber = "0.3" 
 
@@ -104,3 +105,4 @@ tendermint-proto = { version = "0.31" }
 
 # Using the IPC SDK without the `fil-actor` feature so as not to depend on the actor `Runtime`.
 ipc-sdk = { git = "https://github.com/consensus-shipyard/ipc-actors.git", default-features = false, branch = "main" }
+ipc-gateway = { git = "https://github.com/consensus-shipyard/ipc-actors.git", features = [] }

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -41,6 +41,7 @@ fendermint_vm_core = { path = "../vm/core" }
 fendermint_vm_interpreter = { path = "../vm/interpreter", features = ["bundle"] }
 fendermint_vm_message = { path = "../vm/message" }
 fendermint_vm_genesis = { path = "../vm/genesis" }
+fendermint_ipc = { path = "../ipc" }
 
 cid = { workspace = true }
 fvm = { workspace = true }

--- a/fendermint/ipc/Cargo.toml
+++ b/fendermint/ipc/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fendermint_ipc"
+version = "0.1.0"
+edition = "2021"
+description = "Interfacing with IPC"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tokio = { workspace = true }
+anyhow = { workspace = true }
+ipc-sdk = { workspace = true }
+async-trait = { workspace = true }
+tracing = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/fendermint/ipc/src/lib.rs
+++ b/fendermint/ipc/src/lib.rs
@@ -1,0 +1,18 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+//! Interfacing with IPC, provides utility functions
+
+mod message;
+mod parent;
+pub mod pof;
+
+pub use message::IPCMessage;
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// The number of blocks to delay reporting when creating the pof
+    chain_head_delay: u64,
+
+    /// Parent syncing cron period, in seconds
+    polling_interval: u64,
+}

--- a/fendermint/ipc/src/message.rs
+++ b/fendermint/ipc/src/message.rs
@@ -1,0 +1,16 @@
+//! IPC messages
+
+use crate::pof::IPCParentFinality;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Serialize, Deserialize)]
+pub enum IPCMessage {
+    TopDown(IPCParentFinality),
+    BottomUp,
+}
+
+impl From<IPCMessage> for Vec<u8> {
+    fn from(value: IPCMessage) -> Self {
+        serde_json::to_vec(&value).expect("should not happen")
+    }
+}

--- a/fendermint/ipc/src/parent.rs
+++ b/fendermint/ipc/src/parent.rs
@@ -1,0 +1,29 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+//! Parent syncing related functions
+
+use async_trait::async_trait;
+
+/// Obtain the latest state information required for IPC from the parent subnet
+#[async_trait]
+pub trait ParentSyncer {
+    /// Get the latest height
+    async fn latest_height(&self) -> anyhow::Result<u64>;
+    /// Get the block hash at the target height
+    async fn block_hash(&self, height: u64) -> anyhow::Result<Vec<u8>>;
+}
+
+/// Constantly syncing with parent through polling
+pub struct PollingParentSyncer {}
+
+#[async_trait]
+impl ParentSyncer for PollingParentSyncer {
+    async fn latest_height(&self) -> anyhow::Result<u64> {
+        todo!()
+    }
+
+    async fn block_hash(&self, _height: u64) -> anyhow::Result<Vec<u8>> {
+        todo!()
+    }
+}

--- a/fendermint/ipc/src/pof.rs
+++ b/fendermint/ipc/src/pof.rs
@@ -1,0 +1,104 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+//! IPC proof of finality related functions
+
+use crate::parent::{ParentSyncer, PollingParentSyncer};
+use crate::Config;
+use anyhow::anyhow;
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+use tokio::task::JoinHandle;
+
+type LockedProof = Arc<RwLock<IPCParentFinality>>;
+
+/// The proof for POF.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct IPCParentFinality {
+    /// The latest chain height
+    height: u64,
+    /// The block hash. For FVM, it is a Cid. For Evm, it is bytes32.
+    block_hash: Vec<u8>,
+    // /// new top-down messages finalized in this PoF
+    // top_down_msgs: Vec<CrossMsg>,
+    // /// latest configuration information from the parent.
+    // config: MembershipSet,
+}
+
+/// The proof of finality util struct
+pub struct ProofOfFinality {
+    config: Config,
+    started: Arc<AtomicBool>,
+    latest_proof: LockedProof,
+
+    handle: Option<JoinHandle<anyhow::Result<()>>>,
+}
+
+impl ProofOfFinality {
+    pub fn get_proof(&self) -> IPCParentFinality {
+        let finality = self.latest_proof.read().unwrap();
+        finality.clone()
+    }
+
+    /// Start the proof of finality listener in the background
+    pub fn start(&mut self) -> anyhow::Result<()> {
+        match self
+            .started
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        {
+            Ok(_) => {}
+            Err(_) => return Err(anyhow!("already started")),
+        }
+
+        let syncer = PollingParentSyncer {};
+        let config = self.config.clone();
+        let proof = self.latest_proof.clone();
+
+        let handle = tokio::spawn(async move { sync_with_parent(config, syncer, proof).await });
+
+        self.handle = Some(handle);
+
+        Ok(())
+    }
+}
+
+macro_rules! log_error_only {
+    ($r:expr) => {
+        match $r {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::error!("cannot sync with parent: {e}");
+                continue;
+            }
+        }
+    };
+}
+
+async fn sync_with_parent<T: ParentSyncer>(
+    config: Config,
+    parent_syncer: T,
+    lock: LockedProof,
+) -> anyhow::Result<()> {
+    let mut interval = tokio::time::interval(Duration::from_secs(config.polling_interval));
+
+    loop {
+        interval.tick().await;
+
+        let latest_height = log_error_only!(parent_syncer.latest_height().await);
+        if latest_height < config.chain_head_delay {
+            continue;
+        }
+
+        let height_to_fetch = latest_height - config.chain_head_delay;
+        let block_hash = parent_syncer.block_hash(height_to_fetch).await?;
+
+        let candidate = IPCParentFinality {
+            height: height_to_fetch,
+            block_hash,
+        };
+
+        let mut proof = lock.write().unwrap();
+        *proof = candidate;
+    }
+}

--- a/fendermint/vm/message/Cargo.toml
+++ b/fendermint/vm/message/Cargo.toml
@@ -30,6 +30,7 @@ rand = { workspace = true, optional = true }
 fendermint_vm_encoding = { path = "../encoding" }
 fendermint_vm_actor_interface = { path = "../actor_interface" }
 fendermint_testing = { path = "../../testing", optional = true }
+fendermint_ipc = { path = "../../ipc" }
 
 [dev-dependencies]
 ethers = { workspace = true }

--- a/fendermint/vm/message/src/chain.rs
+++ b/fendermint/vm/message/src/chain.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use cid::Cid;
 use serde::{Deserialize, Serialize};
+use fendermint_ipc::IPCMessage;
 
 use crate::signed::SignedMessage;
 
@@ -31,6 +32,8 @@ pub enum ChainMessage {
     // This should ensure that even if low-power validator poposed a CID, the others aren't neglecting it.
     // To remember after a restart who the original proposer was, the proposed CIDs have to go onto the ledger.
     ForExecution(Cid),
+
+    IPC(IPCMessage)
 }
 
 #[cfg(feature = "arb")]


### PR DESCRIPTION
Migrate the top down message execution to new design with Fendermint.