### PR TITLE
FM-184: Proposal interpreter

### DIFF
--- a/fendermint/abci/src/application.rs
+++ b/fendermint/abci/src/application.rs
@@ -69,7 +69,7 @@ pub trait Application {
         Ok(response::PrepareProposal { txs })
     }
 
-    /// Opporunity for the application to inspect the proposal before voting on it.
+    /// Opportunity for the application to inspect the proposal before voting on it.
     ///
     /// The application should accept the proposal unless there's something wrong with it.
     ///

--- a/fendermint/abci/src/application.rs
+++ b/fendermint/abci/src/application.rs
@@ -11,6 +11,8 @@ use tendermint::abci::{request, response, Request, Response};
 use tower::Service;
 use tower_abci::BoxError;
 
+use crate::util::take_until_max_size;
+
 /// Allow returning a result from the methods, so the [`Application`]
 /// implementation doesn't have to be full of `.expect("failed...")`
 /// or `.unwrap()` calls. It is still good practice to use for example
@@ -62,16 +64,8 @@ pub trait Application {
         &self,
         request: request::PrepareProposal,
     ) -> AbciResult<response::PrepareProposal> {
-        let max_tx_bytes: usize = request.max_tx_bytes.try_into().unwrap();
-        let mut size: usize = 0;
-        let mut txs = Vec::new();
-        for tx in request.txs {
-            if size.saturating_add(tx.len()) > max_tx_bytes {
-                break;
-            }
-            size += tx.len();
-            txs.push(tx);
-        }
+        let txs = take_until_max_size(request.txs, request.max_tx_bytes.try_into().unwrap());
+
         Ok(response::PrepareProposal { txs })
     }
 

--- a/fendermint/abci/src/lib.rs
+++ b/fendermint/abci/src/lib.rs
@@ -3,3 +3,4 @@
 mod application;
 
 pub use application::{AbciResult, Application, ApplicationService};
+pub mod util;

--- a/fendermint/abci/src/util.rs
+++ b/fendermint/abci/src/util.rs
@@ -1,0 +1,19 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+/// Take the first transactions until the first one that would exceed the maximum limit.
+///
+/// The function does not skip or reorder transaction even if a later one would stay within the limit.
+pub fn take_until_max_size<T: AsRef<[u8]>>(txs: Vec<T>, max_tx_bytes: usize) -> Vec<T> {
+    let mut size: usize = 0;
+    let mut out = Vec::new();
+    for tx in txs {
+        let bz: &[u8] = tx.as_ref();
+        if size.saturating_add(bz.len()) > max_tx_bytes {
+            break;
+        }
+        size += bz.len();
+        out.push(tx);
+    }
+    out
+}

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -22,7 +22,7 @@ use fendermint_vm_interpreter::fvm::state::{
 use fendermint_vm_interpreter::fvm::{FvmApplyRet, FvmGenesisOutput};
 use fendermint_vm_interpreter::signed::InvalidSignature;
 use fendermint_vm_interpreter::{
-    CheckInterpreter, ExecInterpreter, GenesisInterpreter, QueryInterpreter,
+    CheckInterpreter, ExecInterpreter, GenesisInterpreter, ProposalInterpreter, QueryInterpreter,
 };
 use fvm::engine::MultiEngine;
 use fvm_ipld_blockstore::Blockstore;
@@ -309,6 +309,15 @@ where
     S::Namespace: Sync + Send,
     DB: KVWritable<S> + KVReadable<S> + Clone + Send + Sync + 'static,
     SS: Blockstore + Clone + Send + Sync + 'static,
+    I: GenesisInterpreter<
+        State = FvmGenesisState<SS>,
+        Genesis = Vec<u8>,
+        Output = FvmGenesisOutput,
+    >,
+    I: ProposalInterpreter<
+        State = (), // TODO
+        Message = Vec<u8>,
+    >,
     I: ExecInterpreter<
         State = FvmExecState<SS>,
         Message = Vec<u8>,
@@ -325,11 +334,6 @@ where
         State = FvmQueryState<SS>,
         Query = BytesMessageQuery,
         Output = BytesMessageQueryRet,
-    >,
-    I: GenesisInterpreter<
-        State = FvmGenesisState<SS>,
-        Genesis = Vec<u8>,
-        Output = FvmGenesisOutput,
     >,
 {
     /// Provide information about the ABCI application.

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -29,7 +29,8 @@ async fn run(settings: Settings) -> anyhow::Result<()> {
     );
     let interpreter = SignedMessageInterpreter::new(interpreter);
     let interpreter = ChainMessageInterpreter::new(interpreter);
-    let interpreter = BytesMessageInterpreter::new(interpreter, ProposalPrepareMode::AppendOnly);
+    let interpreter =
+        BytesMessageInterpreter::new(interpreter, ProposalPrepareMode::AppendOnly, false);
 
     let ns = Namespaces::default();
     let db = open_db(&settings, &ns).context("error opening DB")?;

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -6,7 +6,9 @@ use fendermint_abci::ApplicationService;
 use fendermint_app::{App, AppStore};
 use fendermint_rocksdb::{blockstore::NamespaceBlockstore, namespaces, RocksDb, RocksDbConfig};
 use fendermint_vm_interpreter::{
-    bytes::BytesMessageInterpreter, chain::ChainMessageInterpreter, fvm::FvmMessageInterpreter,
+    bytes::{BytesMessageInterpreter, ProposalPrepareMode},
+    chain::ChainMessageInterpreter,
+    fvm::FvmMessageInterpreter,
     signed::SignedMessageInterpreter,
 };
 use tracing::info;
@@ -27,7 +29,7 @@ async fn run(settings: Settings) -> anyhow::Result<()> {
     );
     let interpreter = SignedMessageInterpreter::new(interpreter);
     let interpreter = ChainMessageInterpreter::new(interpreter);
-    let interpreter = BytesMessageInterpreter::new(interpreter);
+    let interpreter = BytesMessageInterpreter::new(interpreter, ProposalPrepareMode::AppendOnly);
 
     let ns = Namespaces::default();
     let db = open_db(&settings, &ns).context("error opening DB")?;

--- a/fendermint/vm/interpreter/src/bytes.rs
+++ b/fendermint/vm/interpreter/src/bytes.rs
@@ -19,7 +19,7 @@ pub type BytesMessageQueryRet = Result<FvmQueryRet, fvm_ipld_encoding::Error>;
 /// Close to what the ABCI sends: (Path, Bytes).
 pub type BytesMessageQuery = (String, Vec<u8>);
 
-/// Behavour of proposal preparation. It's an otimisation to cut down needless serialization
+/// Behavour of proposal preparation. It's an optimisation to cut down needless serialization
 /// when we know we aren't doing anything with the messages.
 #[derive(Debug, Default, Clone)]
 pub enum ProposalPrepareMode {

--- a/fendermint/vm/interpreter/src/chain.rs
+++ b/fendermint/vm/interpreter/src/chain.rs
@@ -7,7 +7,7 @@ use fendermint_vm_message::{chain::ChainMessage, signed::SignedMessage};
 
 use crate::{
     signed::{SignedMessageApplyRet, SignedMessageCheckRet},
-    CheckInterpreter, ExecInterpreter, GenesisInterpreter, QueryInterpreter,
+    CheckInterpreter, ExecInterpreter, GenesisInterpreter, ProposalInterpreter, QueryInterpreter,
 };
 
 /// A message a user is not supposed to send.
@@ -31,6 +31,40 @@ pub struct ChainMessageInterpreter<I> {
 impl<I> ChainMessageInterpreter<I> {
     pub fn new(inner: I) -> Self {
         Self { inner }
+    }
+}
+
+#[async_trait]
+impl<I> ProposalInterpreter for ChainMessageInterpreter<I>
+where
+    I: Sync + Send,
+{
+    // TODO: The state can include the IPLD Resolver mempool, for example by using STM
+    // to implement a shared memory space.
+    type State = ();
+    type Message = ChainMessage;
+
+    /// Check whether there are any "ready" messages in the IPLD resolution mempool which can be appended to the proposal.
+    ///
+    /// We could also use this to select the most profitable user transactions, within the gas limit. We can also take into
+    /// account the transactions which are part of top-down or bottom-up checkpoints, to stay within gas limits.
+    async fn prepare(
+        &self,
+        _state: Self::State,
+        msgs: Vec<Self::Message>,
+    ) -> anyhow::Result<Vec<Self::Message>> {
+        // For now this is just a placeholder.
+        Ok(msgs)
+    }
+
+    /// Perform finality checks on top-down transactions and availability checks on bottom-up transactions.
+    async fn process(
+        &self,
+        _state: Self::State,
+        _msgs: Vec<Self::Message>,
+    ) -> anyhow::Result<bool> {
+        // For now this is just a placeholder.
+        Ok(true)
     }
 }
 


### PR DESCRIPTION
Closes #184 

The PR introduces a `ProposalInterpreter` similar to the ones which already exist, so that we can keep the `app.rs` free of much of our application logic, and farm it out into the layers where the different types and representations of messages are handled. 

Currently it does nothing new, accepts everything. The goal was to introduce this necessary boilerplate and agree on the abstractions.

My motivation was to help https://github.com/consensus-shipyard/fendermint/pull/181 focus on the top-down message without having to decode messages in the application root.