### PR TITLE
FM-186: Fix rust-toolchain action version

### DIFF
--- a/.github/actions/install-tools/action.yaml
+++ b/.github/actions/install-tools/action.yaml
@@ -13,7 +13,7 @@ runs:
 
   steps:
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@master
       with:
         targets: wasm32-unknown-unknown
         toolchain: ${{ inputs.rust }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
           components: rustfmt


### PR DESCRIPTION
@aakoshh Apologies but I missed this while reviewing #188. When specifying the `toolchain`, we should use the `master` branch of the action rather than `stable` (per https://github.com/dtolnay/rust-toolchain#inputs). I don't think it breaks anything right now but better avoid unsupported combinations.