### PR TITLE
CHORE: Skip tests on draft PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,12 @@ on:
   pull_request:
     branches:
       - '**'
+    # To add ready_for_review as a trigger we need to list all the defaults.
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 env:
   CARGO_INCREMENTAL: '0'
@@ -39,6 +45,8 @@ jobs:
 
   # Test matrix, running tasks from the Makefile.
   tests:
+    # Skip tests on draft PRs, they take a long time, and drafts are for visibility.
+    if: ${{ !github.event.pull_request.draft }}
     needs: [pre-compile-checks]
     name: ${{ matrix.make.name }} (${{ matrix.os }}, ${{ matrix.rust }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The PR changes the CI workflow to skip running the test matrix if the PR is in the _Draft_ state. 

### Motivation 

I usually like to open draft PRs as soon as possible for visibility, but frequently find myself cancelling PR runs just to save the resources - they run long, and sometimes I know the tests won't pass. 

We still run pre-compile checks to catch simple things like formatting errors which are quick and easy  to check.

