### PR TITLE
FM-196: Implement ProposalInterpreter::process for BottomUp

### DIFF
--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -330,10 +330,7 @@ where
         Genesis = Vec<u8>,
         Output = FvmGenesisOutput,
     >,
-    I: ProposalInterpreter<
-        State = (), // TODO
-        Message = Vec<u8>,
-    >,
+    I: ProposalInterpreter<State = CheckpointPool, Message = Vec<u8>>,
     I: ExecInterpreter<
         State = (CheckpointPool, FvmExecState<SS>),
         Message = Vec<u8>,
@@ -517,7 +514,7 @@ where
 
         let txs = self
             .interpreter
-            .prepare((), txs)
+            .prepare(self.resolve_pool.clone(), txs)
             .await
             .context("failed to prepare proposal")?;
 
@@ -536,7 +533,7 @@ where
 
         let accept = self
             .interpreter
-            .process((), txs)
+            .process(self.resolve_pool.clone(), txs)
             .await
             .context("failed to process proposal")?;
 


### PR DESCRIPTION
Closes #196 
Depends on #201 and #185

Implements `ProposalInterpreter::process` method for `ChainMessageInterpreter` by looking up proposed checkpoints for execution in the `ResolvePool` and checking that the item is present and resolved, otherwise we don't vote for the proposal.