### PR TITLE
FM-195: Implement ProposalInterpreter::prepare for BottomUp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "async-stm"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f502cd40d617759c2e1125ff6565aa05ed21ec097e2ae7fed0266a8ecef34d0"
+checksum = "0d3ab5947b620817e28fbc8e8592e862a679f75ed1e8a940a91c7c24b79c38c3"
 dependencies = [
  "parking_lot 0.12.1",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ license-file = "LICENSE-APACHE"
 anyhow = "1"
 arbitrary = { version = "1", features = ["derive"] }
 arbtest = "0.2"
-async-stm = "0.2"
+async-stm = "0.3"
 async-trait = "0.1"
 axum = { version = "0.6", features = ["ws"] }
 base64 = "0.21"

--- a/fendermint/vm/resolver/src/pool.rs
+++ b/fendermint/vm/resolver/src/pool.rs
@@ -91,9 +91,8 @@ where
 
         if items.contains_key(&key) {
             let status = items.get(&key).cloned().unwrap();
-            status.items.update(|mut items| {
+            status.items.update_mut(|items| {
                 items.insert(item);
-                items
             })?;
             Ok(status)
         } else {

--- a/fendermint/vm/resolver/src/pool.rs
+++ b/fendermint/vm/resolver/src/pool.rs
@@ -1,7 +1,7 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::hash::Hash;
+use std::{collections::HashSet, hash::Hash};
 
 use async_stm::{
     queues::{tchan::TChan, TQueueLike},
@@ -21,6 +21,8 @@ pub type ResolveKey = (SubnetID, Cid);
 #[derive(Clone)]
 pub struct ResolveStatus<T> {
     /// Indicate whether the content has been resolved.
+    ///
+    /// If needed we can expand on this to include failure states.
     is_resolved: TVar<bool>,
     /// The collection of items that all resolve to the same root CID and subnet.
     items: TVar<im::HashSet<T>>,
@@ -33,7 +35,6 @@ where
     pub fn new(item: T) -> Self {
         let mut items = im::HashSet::new();
         items.insert(item);
-
         Self {
             is_resolved: TVar::new(false),
             items: TVar::new(items),
@@ -110,7 +111,21 @@ where
         Ok(self.items.read()?.get(&key).cloned())
     }
 
-    // TODO #195: Implement methods to collect resolved items, ready for execution.
+    /// Collect resolved items, ready for execution.
+    ///
+    /// The items removed are not removed, in case they need to be proposed again.
+    pub fn collect_resolved(&self) -> StmResult<HashSet<T>> {
+        let mut resolved = HashSet::new();
+        let items = self.items.read()?;
+        for item in items.values() {
+            if item.is_resolved()? {
+                let items = item.items.read()?;
+                resolved.extend(items.iter().cloned());
+            }
+        }
+        Ok(resolved)
+    }
+
     // TODO #197: Implement methods to remove executed items.
 }
 
@@ -120,7 +135,7 @@ mod tests {
     use cid::Cid;
     use ipc_sdk::subnet_id::SubnetID;
 
-    #[derive(Clone, Hash, Eq, PartialEq)]
+    #[derive(Clone, Hash, Eq, PartialEq, Debug)]
     struct TestItem {
         subnet_id: SubnetID,
         cid: Cid,
@@ -209,6 +224,24 @@ mod tests {
             assert!(status1.items.read()?.contains(&item));
             assert!(status1.is_resolved()?);
             assert!(status2.is_resolved()?);
+            Ok(())
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn collect_resolved() {
+        let pool = ResolvePool::new();
+        let item = TestItem::dummy(0);
+
+        atomically(|| {
+            let status = pool.add(item.clone())?;
+            status.is_resolved.write(true)?;
+
+            let resolved1 = pool.collect_resolved()?;
+            let resolved2 = pool.collect_resolved()?;
+            assert_eq!(resolved1, resolved2);
+            assert!(resolved1.contains(&item));
             Ok(())
         })
         .await;


### PR DESCRIPTION
Closes #195 
Depends on #202 

Added a `ResolvePool::collect_resolved` method to gather all resolved items, which are appended to the messages as checkpoints proposed for execution by the `ChainMessageInterpreter` in the `ProposalInterpreter::prepare` method implementation.