### PR TITLE
CHORE: Fix lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,17 +56,17 @@ jobs:
         os: [ubuntu-latest]
         rust: [stable, nightly]
         make:
-          - name: Lint
-            task: lint
+          - name: Clippy
+            task: check-clippy
           - name: Test
             task: test
           - name: End-to-End
             task: e2e
         exclude:
-          # Not running Lint on nightly because sometimes it seems to give false positives.
+          # Not running Clippy on nightly because sometimes it seems to give false positives.
           - rust: nightly
             make:
-              name: Lint
+              name: Clippy
           - rust: nightly
             make:
               name: End-to-end

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,10 @@ jobs:
       - name: Check code formatting
         run: make check-fmt
 
+      # This is so `make license` doesn't say "bad revision origin/main"
+      - name: Fetch origin for diff
+        run: git fetch origin
+
       - name: Check license headers
         run: make license
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,8 @@ jobs:
           - name: End-to-End
             task: e2e
         exclude:
-          - rust: stable
+          # Not running Lint on nightly because sometimes it seems to give false positives.
+          - rust: nightly
             make:
               name: Lint
           - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "fendermint/abci",
   "fendermint/app",

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,7 @@ check-fmt:
 	cargo +nightly fmt --all --check
 
 check-clippy:
-	@# `nightly` is used to stay ahead of the rules.
-	cargo +nightly clippy --all --tests -- -D clippy::all
+	cargo clippy --all --tests -- -D clippy::all
 
 docker-build: $(BUILTIN_ACTORS_BUNDLE) $(FENDERMINT_CODE) $(IPC_ACTORS_ABI)
 	mkdir -p docker/.artifacts/contracts

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ check-fmt:
 	cargo +nightly fmt --all --check
 
 check-clippy:
-	cargo clippy --all --tests -- -D clippy::all
+	@# `nightly` is used to stay ahead of the rules.
+	cargo +nightly clippy --all --tests -- -D clippy::all
 
 docker-build: $(BUILTIN_ACTORS_BUNDLE) $(FENDERMINT_CODE) $(IPC_ACTORS_ABI)
 	mkdir -p docker/.artifacts/contracts

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -418,7 +418,7 @@ where
     for (index, (tx, tx_result)) in block
         .data
         .into_iter()
-        .zip(block_results.txs_results.unwrap_or_default().into_iter())
+        .zip(block_results.txs_results.unwrap_or_default())
         .enumerate()
     {
         let msg = to_chain_message(&tx)?;

--- a/fendermint/vm/interpreter/src/bytes.rs
+++ b/fendermint/vm/interpreter/src/bytes.rs
@@ -103,8 +103,8 @@ where
 
         match self.prepare_mode {
             ProposalPrepareMode::PassThrough => Ok(chain_msgs),
-            ProposalPrepareMode::AppendOnly => Ok(vec![msgs, chain_msgs].concat()),
-            ProposalPrepareMode::PrependOnly => Ok(vec![chain_msgs, msgs].concat()),
+            ProposalPrepareMode::AppendOnly => Ok([msgs, chain_msgs].concat()),
+            ProposalPrepareMode::PrependOnly => Ok([chain_msgs, msgs].concat()),
         }
     }
 

--- a/fendermint/vm/interpreter/src/fvm/genesis.rs
+++ b/fendermint/vm/interpreter/src/fvm/genesis.rs
@@ -102,7 +102,7 @@ where
 
         // Only allocate IDs if the contracts are deployed.
         if genesis.ipc.is_some() {
-            eth_contracts.extend(IPC_CONTRACTS.clone().into_iter());
+            eth_contracts.extend(IPC_CONTRACTS.clone());
         }
 
         eth_builtin_ids.extend(eth_contracts.values().map(|c| c.actor_id));

--- a/scripts/add_license.sh
+++ b/scripts/add_license.sh
@@ -47,7 +47,7 @@ for file in $(git grep --cached -Il '' -- '*.rs'); do
 done
 
 # Look for changes that don't have the new copyright holder.
-for file in $(git diff --diff-filter=d --name-only main -- '*.rs'); do
+for file in $(git diff --diff-filter=d --name-only origin/main -- '*.rs'); do
 	if ignore "$file"; then
 		continue
 	fi


### PR DESCRIPTION
My [build](https://github.com/consensus-shipyard/fendermint/actions/runs/5964638421/job/16180310789?pr=214) started complaining about new clippy violations, ran on Rust 1.72, because we run `make lint` on `nightly` on CI. 

It turns out some of those seem to be false alarms due to a bugs in clippy, reporting that an `&mut` should be just `&`, while that's not the case. 

The PR changes CI to run Clippy on `stable`, while fixes some of the things raised while still in nightly mode. We don't run the full `make lint` any more because `make check-fmt` requires nightly, and is already part of the `Pre-compile checks` step.