### PR TITLE
FM-216: Index transactions by Ethereum hash

### DIFF
--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -14,7 +14,7 @@ use fendermint_storage::{
 };
 use fendermint_vm_core::Timestamp;
 use fendermint_vm_interpreter::bytes::{
-    BytesMessageApplyRet, BytesMessageCheckRet, BytesMessageQuery, BytesMessageQueryRet,
+    BytesMessageApplyRes, BytesMessageCheckRes, BytesMessageQuery, BytesMessageQueryRes,
 };
 use fendermint_vm_interpreter::chain::{ChainMessageApplyRet, CheckpointPool, IllegalMessage};
 use fendermint_vm_interpreter::fvm::state::{
@@ -335,18 +335,18 @@ where
         State = (CheckpointPool, FvmExecState<SS>),
         Message = Vec<u8>,
         BeginOutput = FvmApplyRet,
-        DeliverOutput = BytesMessageApplyRet,
+        DeliverOutput = BytesMessageApplyRes,
         EndOutput = (),
     >,
     I: CheckInterpreter<
         State = FvmCheckState<SS>,
         Message = Vec<u8>,
-        Output = BytesMessageCheckRet,
+        Output = BytesMessageCheckRes,
     >,
     I: QueryInterpreter<
         State = FvmQueryState<SS>,
         Query = BytesMessageQuery,
-        Output = BytesMessageQueryRet,
+        Output = BytesMessageQueryRes,
     >,
 {
     /// Provide information about the ABCI application.
@@ -585,9 +585,9 @@ where
                 }
                 ChainMessageApplyRet::Signed(Ok(ret)) => {
                     tracing::info!(
-                        from = ret.from.to_string(),
-                        to = ret.to.to_string(),
-                        method_num = ret.method_num,
+                        from = ret.fvm.from.to_string(),
+                        to = ret.fvm.to.to_string(),
+                        method_num = ret.fvm.method_num,
                         "tx delivered"
                     );
                     to_deliver_tx(ret)

--- a/fendermint/app/src/tmconv.rs
+++ b/fendermint/app/src/tmconv.rs
@@ -69,7 +69,7 @@ pub fn to_deliver_tx(ret: SignedMessageApplyRet) -> response::DeliverTx {
     let data: bytes::Bytes = receipt.return_data.to_vec().into();
     let mut events = to_events("message", ret.apply_ret.events);
 
-    // Emit an event so which causes Tendermint to index our transaction with a custom hash.
+    // Emit an event which causes Tendermint to index our transaction with a custom hash.
     events.push(to_sig_hash_event(&sig_hash));
 
     response::DeliverTx {

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -70,7 +70,7 @@ const SIMPLECOIN_HEX: &'static str =
 const ENOUGH_GAS: u64 = 10_000_000_000u64;
 
 /// Disabling filters helps when inspecting docker logs. The background data received for filters is rather noisy.
-const FILTERS_ENABLED: bool = false;
+const FILTERS_ENABLED: bool = true;
 
 // Generate a statically typed interface for the contract.
 // An example of what it looks like is at https://github.com/filecoin-project/ref-fvm/blob/evm-integration-tests/testing/integration/tests/evm/src/simple_coin/simple_coin.rs
@@ -252,7 +252,11 @@ where
     // Set up filters to collect events.
     let mut filter_ids = Vec::new();
 
-    let (logs_filter_id, blocks_filter_id, txs_filter_id) = if FILTERS_ENABLED {
+    let (logs_filter_id, blocks_filter_id, txs_filter_id): (
+        Option<U256>,
+        Option<U256>,
+        Option<U256>,
+    ) = if FILTERS_ENABLED {
         let logs_filter_id = request(
             "eth_newFilter",
             provider
@@ -575,6 +579,8 @@ where
         send_transaction(&mw, coin_send.tx, "coin_send").await,
         |receipt| !receipt.logs.is_empty(),
     )?;
+
+    tracing::info!(tx_hash = ?receipt.transaction_hash, "coin sent");
 
     request(
         "eth_getLogs",

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -401,6 +401,12 @@ where
         "computed hash should match"
     );
 
+    // This equivalence is not required for ethers-rs, it's happy to use the return value from `eth_sendRawTransaction` for transaction hash.
+    // However, ethers.js actually asserts this and we cannot disable it, rendering that, or any similar tool, unusable if we rely on
+    // the default Tendermint transaction hash, which is a Sha256 hash of the entire payload (which includes the signature),
+    // not a Keccak256 of the unsigned RLP.
+    assert_eq!(tx_hash, transfer.sighash(), "Ethereum hash should match");
+
     // Get the block with transactions by hash.
     request(
         "eth_getBlockByHash w/ txns",

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -386,6 +386,12 @@ where
 
     tracing::info!(height = ?bn, ?tx_hash, "example transfer");
 
+    // This equivalence is not required for ethers-rs, it's happy to use the return value from `eth_sendRawTransaction` for transaction hash.
+    // However, ethers.js actually asserts this and we cannot disable it, rendering that, or any similar tool, unusable if we rely on
+    // the default Tendermint transaction hash, which is a Sha256 hash of the entire payload (which includes the signature),
+    // not a Keccak256 of the unsigned RLP.
+    assert_eq!(tx_hash, transfer.sighash(), "Ethereum hash should match");
+
     // Get a block with transactions by number.
     let block = request(
         "eth_getBlockByNumber w/ txns",
@@ -400,12 +406,6 @@ where
         block.unwrap().transactions[0].hash,
         "computed hash should match"
     );
-
-    // This equivalence is not required for ethers-rs, it's happy to use the return value from `eth_sendRawTransaction` for transaction hash.
-    // However, ethers.js actually asserts this and we cannot disable it, rendering that, or any similar tool, unusable if we rely on
-    // the default Tendermint transaction hash, which is a Sha256 hash of the entire payload (which includes the signature),
-    // not a Keccak256 of the unsigned RLP.
-    assert_eq!(tx_hash, transfer.sighash(), "Ethereum hash should match");
 
     // Get the block with transactions by hash.
     request(

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -396,8 +396,8 @@ where
     )?;
 
     assert_eq!(
-        block.unwrap().transactions[0].hash,
         tx_hash,
+        block.unwrap().transactions[0].hash,
         "computed hash should match"
     );
 

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -69,6 +69,9 @@ const SIMPLECOIN_HEX: &'static str =
 /// Gas limit to set for transactions.
 const ENOUGH_GAS: u64 = 10_000_000_000u64;
 
+/// Disabling filters helps when inspecting docker logs. The background data received for filters is rather noisy.
+const FILTERS_ENABLED: bool = false;
+
 // Generate a statically typed interface for the contract.
 // An example of what it looks like is at https://github.com/filecoin-project/ref-fvm/blob/evm-integration-tests/testing/integration/tests/evm/src/simple_coin/simple_coin.rs
 abigen!(
@@ -129,11 +132,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_max_level(opts.log_level())
         .init();
 
-    tracing::info!("Running the tests over HTTP...");
     let provider = Provider::<Http>::try_from(opts.http_endpoint())?;
     run_http(provider, &opts).await?;
 
-    tracing::info!("Running the tests over WS...");
     let provider = Provider::<Ws>::connect(opts.ws_endpoint()).await?;
     run_ws(provider, &opts).await?;
 
@@ -251,28 +252,38 @@ where
     // Set up filters to collect events.
     let mut filter_ids = Vec::new();
 
-    let logs_filter_id = request(
-        "eth_newFilter",
-        provider
-            .new_filter(FilterKind::Logs(&Filter::default()))
-            .await,
-        |_| true,
-    )?;
-    filter_ids.push(logs_filter_id);
+    let (logs_filter_id, blocks_filter_id, txs_filter_id) = if FILTERS_ENABLED {
+        let logs_filter_id = request(
+            "eth_newFilter",
+            provider
+                .new_filter(FilterKind::Logs(&Filter::default()))
+                .await,
+            |_| true,
+        )?;
+        filter_ids.push(logs_filter_id);
 
-    let blocks_filter_id = request(
-        "eth_newBlockFilter",
-        provider.new_filter(FilterKind::NewBlocks).await,
-        |id| *id != logs_filter_id,
-    )?;
-    filter_ids.push(blocks_filter_id);
+        let blocks_filter_id = request(
+            "eth_newBlockFilter",
+            provider.new_filter(FilterKind::NewBlocks).await,
+            |id| *id != logs_filter_id,
+        )?;
+        filter_ids.push(blocks_filter_id);
 
-    let txs_filter_id = request(
-        "eth_newPendingTransactionFilter",
-        provider.new_filter(FilterKind::PendingTransactions).await,
-        |id| *id != logs_filter_id,
-    )?;
-    filter_ids.push(txs_filter_id);
+        let txs_filter_id = request(
+            "eth_newPendingTransactionFilter",
+            provider.new_filter(FilterKind::PendingTransactions).await,
+            |id| *id != logs_filter_id,
+        )?;
+        filter_ids.push(txs_filter_id);
+
+        (
+            Some(logs_filter_id),
+            Some(blocks_filter_id),
+            Some(txs_filter_id),
+        )
+    } else {
+        (None, None, None)
+    };
 
     request("web3_clientVersion", provider.client_version().await, |v| {
         v.starts_with("fendermint/")
@@ -573,51 +584,58 @@ where
     )?;
 
     // See what kind of events were logged.
-    request(
-        "eth_getFilterChanges (blocks)",
-        mw.get_filter_changes(blocks_filter_id).await,
-        |block_hashes: &Vec<H256>| {
-            [bh, deploy_receipt.block_hash.unwrap()]
-                .iter()
-                .all(|h| block_hashes.contains(h))
-        },
-    )?;
 
-    request(
-        "eth_getFilterChanges (txs)",
-        mw.get_filter_changes(txs_filter_id).await,
-        |tx_hashes: &Vec<H256>| {
-            [&tx_hash, &deploy_receipt.transaction_hash]
-                .iter()
-                .all(|h| tx_hashes.contains(h))
-        },
-    )?;
+    if let Some(blocks_filter_id) = blocks_filter_id {
+        request(
+            "eth_getFilterChanges (blocks)",
+            mw.get_filter_changes(blocks_filter_id).await,
+            |block_hashes: &Vec<H256>| {
+                [bh, deploy_receipt.block_hash.unwrap()]
+                    .iter()
+                    .all(|h| block_hashes.contains(h))
+            },
+        )?;
+    }
 
-    let logs = request(
-        "eth_getFilterChanges (logs)",
-        mw.get_filter_changes(logs_filter_id).await,
-        |logs: &Vec<Log>| !logs.is_empty(),
-    )?;
+    if let Some(txs_filter_id) = txs_filter_id {
+        request(
+            "eth_getFilterChanges (txs)",
+            mw.get_filter_changes(txs_filter_id).await,
+            |tx_hashes: &Vec<H256>| {
+                [&tx_hash, &deploy_receipt.transaction_hash]
+                    .iter()
+                    .all(|h| tx_hashes.contains(h))
+            },
+        )?;
+    }
 
-    // eprintln!("LOGS = {logs:?}");
+    if let Some(logs_filter_id) = logs_filter_id {
+        let logs = request(
+            "eth_getFilterChanges (logs)",
+            mw.get_filter_changes(logs_filter_id).await,
+            |logs: &Vec<Log>| !logs.is_empty(),
+        )?;
 
-    // Parse `Transfer` events from the logs with the SimpleCoin contract.
-    // Based on https://github.com/filecoin-project/ref-fvm/blob/evm-integration-tests/testing/integration/tests/fevm_features/common.rs#L616
-    //      and https://github.com/filecoin-project/ref-fvm/blob/evm-integration-tests/testing/integration/tests/fevm_features/simple_coin.rs#L26
-    //      and https://github.com/filecoin-project/ref-fvm/blob/evm-integration-tests/testing/integration/tests/evm/src/simple_coin/simple_coin.rs#L103
+        // eprintln!("LOGS = {logs:?}");
 
-    // The contract has methods like `.transfer_filter()` which allows querying logs, but here we just test parsing to make sure the data is correct.
-    let transfer_events = logs
-        .into_iter()
-        .filter(|log| log.address == contract.address())
-        .map(|log| contract.decode_event::<TransferFilter>("Transfer", log.topics, log.data))
-        .collect::<Result<Vec<_>, _>>()
-        .context("failed to parse logs to transfer events")?;
+        // Parse `Transfer` events from the logs with the SimpleCoin contract.
+        // Based on https://github.com/filecoin-project/ref-fvm/blob/evm-integration-tests/testing/integration/tests/fevm_features/common.rs#L616
+        //      and https://github.com/filecoin-project/ref-fvm/blob/evm-integration-tests/testing/integration/tests/fevm_features/simple_coin.rs#L26
+        //      and https://github.com/filecoin-project/ref-fvm/blob/evm-integration-tests/testing/integration/tests/evm/src/simple_coin/simple_coin.rs#L103
 
-    assert!(!transfer_events.is_empty());
-    assert_eq!(transfer_events[0].from, from.eth_addr);
-    assert_eq!(transfer_events[0].to, to.eth_addr);
-    assert_eq!(transfer_events[0].value, coin_send_value);
+        // The contract has methods like `.transfer_filter()` which allows querying logs, but here we just test parsing to make sure the data is correct.
+        let transfer_events = logs
+            .into_iter()
+            .filter(|log| log.address == contract.address())
+            .map(|log| contract.decode_event::<TransferFilter>("Transfer", log.topics, log.data))
+            .collect::<Result<Vec<_>, _>>()
+            .context("failed to parse logs to transfer events")?;
+
+        assert!(!transfer_events.is_empty());
+        assert_eq!(transfer_events[0].from, from.eth_addr);
+        assert_eq!(transfer_events[0].to, to.eth_addr);
+        assert_eq!(transfer_events[0].value, coin_send_value);
+    }
 
     // Uninstall all filters.
     for id in filter_ids {
@@ -631,8 +649,11 @@ where
 
 /// The HTTP interface provides JSON-RPC request/response endpoints.
 async fn run_http(mut provider: Provider<Http>, opts: &Options) -> anyhow::Result<()> {
+    tracing::info!("Running the tests over HTTP...");
     adjust_provider(&mut provider);
-    run(&provider, opts).await
+    run(&provider, opts).await?;
+    tracing::info!("HTTP tests finished");
+    Ok(())
 }
 
 /// The WebSocket interface provides JSON-RPC request/response interactions
@@ -641,34 +662,43 @@ async fn run_http(mut provider: Provider<Http>, opts: &Options) -> anyhow::Resul
 /// We subscribe to notifications first, then run the same suite of request/responses
 /// as the HTTP case, finally check that we have collected events over the subscriptions.
 async fn run_ws(mut provider: Provider<Ws>, opts: &Options) -> anyhow::Result<()> {
+    tracing::info!("Running the tests over WS...");
     adjust_provider(&mut provider);
 
     // Subscriptions as well.
-    let mut block_sub = provider.subscribe_blocks().await?;
-    let mut txs_sub = provider.subscribe_pending_txs().await?;
-    let mut log_sub = provider.subscribe_logs(&Filter::default()).await?;
+    let subs = if FILTERS_ENABLED {
+        let block_sub = provider.subscribe_blocks().await?;
+        let txs_sub = provider.subscribe_pending_txs().await?;
+        let log_sub = provider.subscribe_logs(&Filter::default()).await?;
+        Some((block_sub, txs_sub, log_sub))
+    } else {
+        None
+    };
 
     run(&provider, opts).await?;
 
-    assert!(block_sub.next().await.is_some(), "blocks should arrive");
-    assert!(txs_sub.next().await.is_some(), "transactions should arrive");
-    assert!(log_sub.next().await.is_some(), "logs should arrive");
+    if let Some((mut block_sub, mut txs_sub, mut log_sub)) = subs {
+        assert!(block_sub.next().await.is_some(), "blocks should arrive");
+        assert!(txs_sub.next().await.is_some(), "transactions should arrive");
+        assert!(log_sub.next().await.is_some(), "logs should arrive");
 
-    block_sub
-        .unsubscribe()
-        .await
-        .context("failed to unsubscribe blocks")?;
+        block_sub
+            .unsubscribe()
+            .await
+            .context("failed to unsubscribe blocks")?;
 
-    txs_sub
-        .unsubscribe()
-        .await
-        .context("failed to unsubscribe txs")?;
+        txs_sub
+            .unsubscribe()
+            .await
+            .context("failed to unsubscribe txs")?;
 
-    log_sub
-        .unsubscribe()
-        .await
-        .context("failed to unsubscribe logs")?;
+        log_sub
+            .unsubscribe()
+            .await
+            .context("failed to unsubscribe logs")?;
+    }
 
+    tracing::info!("WS tests finished.");
     Ok(())
 }
 

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -31,8 +31,8 @@ use tendermint_rpc::{
     Client,
 };
 
-use crate::conv::from_eth::{to_fvm_message, to_tm_hash};
-use crate::conv::from_tm::{self, message_hash, to_chain_message, to_cumulative};
+use crate::conv::from_eth::to_fvm_message;
+use crate::conv::from_tm::{self, find_sig_hash, message_hash, to_chain_message, to_cumulative};
 use crate::filters::{matches_topics, FilterId, FilterKind, FilterRecords};
 use crate::{
     conv::{
@@ -314,27 +314,24 @@ pub async fn get_transaction_by_hash<C>(
 where
     C: Client + Sync + Send,
 {
-    let hash = to_tm_hash(&tx_hash)?;
+    if let Some(res) = data.tx_by_hash(tx_hash).await? {
+        let msg = to_chain_message(&res.tx)?;
 
-    match data.tm().tx(hash, false).await {
-        Ok(res) => {
-            let msg = to_chain_message(&res.tx)?;
-
-            if let ChainMessage::Signed(msg) = msg {
-                let header: header::Response = data.tm().header(res.height).await?;
-                let sp = data.client.state_params(Some(res.height)).await?;
-                let chain_id = ChainID::from(sp.value.chain_id);
-                let mut tx = to_eth_transaction(hash, msg, chain_id)?;
-                tx.transaction_index = Some(et::U64::from(res.index));
-                tx.block_hash = Some(et::H256::from_slice(header.header.hash().as_bytes()));
-                tx.block_number = Some(et::U64::from(res.height.value()));
-                Ok(Some(tx))
-            } else {
-                error(ExitCode::USR_ILLEGAL_ARGUMENT, "incompatible transaction")
-            }
+        if let ChainMessage::Signed(msg) = msg {
+            let header: header::Response = data.tm().header(res.height).await?;
+            let sp = data.client.state_params(Some(res.height)).await?;
+            let chain_id = ChainID::from(sp.value.chain_id);
+            let sig_hash = find_sig_hash(&res.tx_result.events);
+            let mut tx = to_eth_transaction(msg, chain_id, sig_hash)?;
+            tx.transaction_index = Some(et::U64::from(res.index));
+            tx.block_hash = Some(et::H256::from_slice(header.header.hash().as_bytes()));
+            tx.block_number = Some(et::U64::from(res.height.value()));
+            Ok(Some(tx))
+        } else {
+            error(ExitCode::USR_ILLEGAL_ARGUMENT, "incompatible transaction")
         }
-        Err(e) if e.to_string().contains("not found") => Ok(None),
-        Err(e) => error(ExitCode::USR_UNSPECIFIED, e),
+    } else {
+        Ok(None)
     }
 }
 
@@ -370,35 +367,30 @@ pub async fn get_transaction_receipt<C>(
 where
     C: Client + Sync + Send,
 {
-    let hash = to_tm_hash(&tx_hash)?;
+    if let Some(res) = data.tx_by_hash(tx_hash).await? {
+        let header: header::Response = data.tm().header(res.height).await?;
+        let block_results: block_results::Response = data.tm().block_results(res.height).await?;
+        let cumulative = to_cumulative(&block_results);
+        let state_params = data.client.state_params(Some(res.height)).await?;
+        let msg = to_chain_message(&res.tx)?;
+        if let ChainMessage::Signed(msg) = msg {
+            let receipt = to_eth_receipt(
+                &data.addr_cache,
+                &msg,
+                &res,
+                &cumulative,
+                &header.header,
+                &state_params.value.base_fee,
+            )
+            .await
+            .context("failed to convert to receipt")?;
 
-    match data.tm().tx(hash, false).await {
-        Ok(res) => {
-            let header: header::Response = data.tm().header(res.height).await?;
-            let block_results: block_results::Response =
-                data.tm().block_results(res.height).await?;
-            let cumulative = to_cumulative(&block_results);
-            let state_params = data.client.state_params(Some(res.height)).await?;
-            let msg = to_chain_message(&res.tx)?;
-            if let ChainMessage::Signed(msg) = msg {
-                let receipt = to_eth_receipt(
-                    &data.addr_cache,
-                    &msg,
-                    &res,
-                    &cumulative,
-                    &header.header,
-                    &state_params.value.base_fee,
-                )
-                .await
-                .context("failed to convert to receipt")?;
-
-                Ok(Some(receipt))
-            } else {
-                error(ExitCode::USR_ILLEGAL_ARGUMENT, "incompatible transaction")
-            }
+            Ok(Some(receipt))
+        } else {
+            error(ExitCode::USR_ILLEGAL_ARGUMENT, "incompatible transaction")
         }
-        Err(e) if e.to_string().contains("not found") => Ok(None),
-        Err(e) => error(ExitCode::USR_UNSPECIFIED, e),
+    } else {
+        Ok(None)
     }
 }
 

--- a/fendermint/eth/api/src/conv/from_eth.rs
+++ b/fendermint/eth/api/src/conv/from_eth.rs
@@ -3,18 +3,12 @@
 
 //! Helper methods to convert between Ethereum and FVM data formats.
 
-use anyhow::Context;
-use ethers_core::types::{transaction::eip2718::TypedTransaction, H256};
+use ethers_core::types::transaction::eip2718::TypedTransaction;
 
 pub use fendermint_vm_message::conv::from_eth::*;
 use fvm_shared::{error::ExitCode, message::Message};
 
 use crate::{error, JsonRpcResult};
-
-pub fn to_tm_hash(value: &H256) -> anyhow::Result<tendermint::Hash> {
-    tendermint::Hash::try_from(value.as_bytes().to_vec())
-        .context("failed to convert to Tendermint Hash")
-}
 
 pub fn to_fvm_message(tx: TypedTransaction, accept_legacy: bool) -> JsonRpcResult<Message> {
     match tx {

--- a/fendermint/eth/api/src/filters.rs
+++ b/fendermint/eth/api/src/filters.rs
@@ -101,8 +101,12 @@ impl FilterKind {
             FilterKind::PendingTransactions => Ok(vec![Query::from(EventType::NewBlock)]),
             FilterKind::Logs(filter) => {
                 // `Query::from(EventType::Tx)` doesn't seem to combine well with non-standard keys.
-                // let mut query = Query::from(EventType::Tx);
-                let mut query = Query::default();
+                // But `Query::default()` doesn't return anything if we subscribe to `Filter::default()`.
+                let mut query = if filter.has_topics() || filter.address.is_some() {
+                    Query::default()
+                } else {
+                    Query::from(EventType::Tx)
+                };
 
                 if let Some(block_hash) = filter.get_block_hash() {
                     // TODO #220: This looks wrong, tx.hash is the transaction hash, not the block.

--- a/fendermint/eth/api/src/filters.rs
+++ b/fendermint/eth/api/src/filters.rs
@@ -102,6 +102,7 @@ impl FilterKind {
                 let mut query = Query::from(EventType::Tx);
 
                 if let Some(block_hash) = filter.get_block_hash() {
+                    // TODO #220: This looks wrong, tx.hash is the transaction hash, not the block.
                     query = query.and_eq("tx.hash", hex::encode(block_hash.0));
                 }
                 if let Some(from_block) = filter.get_from_block() {

--- a/fendermint/eth/api/src/filters.rs
+++ b/fendermint/eth/api/src/filters.rs
@@ -99,7 +99,9 @@ impl FilterKind {
             // if there are events emitted by the transaction itself.
             FilterKind::PendingTransactions => Ok(vec![Query::from(EventType::NewBlock)]),
             FilterKind::Logs(filter) => {
-                let mut query = Query::from(EventType::Tx);
+                // `Query::from(EventType::Tx)` doesn't seem to combine well with non-standard keys.
+                // let mut query = Query::from(EventType::Tx);
+                let mut query = Query::default();
 
                 if let Some(block_hash) = filter.get_block_hash() {
                     // TODO #220: This looks wrong, tx.hash is the transaction hash, not the block.
@@ -249,6 +251,8 @@ where
                 },
             ) => {
                 for tx in &block.data {
+                    // TODO #216: This is not the right hash for Ethereum.
+                    // If we had the chain ID here then we can parse it and re-hash it.
                     let h = from_tm::message_hash(tx)?;
                     let h = et::H256::from_slice(h.as_bytes());
                     hashes.push(h);

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -278,8 +278,7 @@ where
             .tx_search(query, false, 1, 1, Order::Ascending)
             .await
         {
-            Ok(res) if res.txs.is_empty() => Ok(None),
-            Ok(res) => Ok(Some(res.txs.into_iter().next().expect("non-empty"))),
+            Ok(res) => Ok(res.txs.into_iter().next()),
             Err(e) => error(ExitCode::USR_UNSPECIFIED, e),
         }
     }

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -17,7 +17,7 @@ use fvm_ipld_encoding::{de::DeserializeOwned, RawBytes};
 use fvm_shared::{chainid::ChainID, econ::TokenAmount, error::ExitCode, message::Message};
 use rand::Rng;
 use tendermint::block::Height;
-use tendermint_rpc::query::{EventType, Query};
+use tendermint_rpc::query::Query;
 use tendermint_rpc::{
     endpoint::{block, block_by_hash, block_results, commit, header, header_by_hash},
     Client,
@@ -270,7 +270,8 @@ where
         // For now we can try to retrieve the transaction using the `tx_search` mechanism, and relying on
         // CometBFT indexing capabilities.
 
-        let query = Query::from(EventType::Tx).and_eq("sig.hash", hex::encode(tx_hash.as_bytes()));
+        // Doesn't work with `Query::from(EventType::Tx).and_eq()`
+        let query = Query::eq("sig.hash", hex::encode(tx_hash.as_bytes()));
 
         match self
             .tm()

--- a/fendermint/vm/core/src/chainid.rs
+++ b/fendermint/vm/core/src/chainid.rs
@@ -75,7 +75,7 @@ pub fn from_str_hashed(name: &str) -> Result<ChainID, ChainIDError> {
 
 /// Anything that has a [`ChainID`].
 pub trait HasChainID {
-    fn chain_id(&self) -> &ChainID;
+    fn chain_id(&self) -> ChainID;
 }
 
 /// Extract the root chain ID _iff_ the name is in the format of "/r<chain-id>".

--- a/fendermint/vm/interpreter/src/fvm/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/exec.rs
@@ -47,6 +47,7 @@ where
         let from = system::SYSTEM_ACTOR_ADDR;
         let to = cron::CRON_ACTOR_ADDR;
         let method_num = cron::Method::EpochTick as u64;
+
         // Cron.
         let msg = FvmMessage {
             from,

--- a/fendermint/vm/interpreter/src/fvm/query.rs
+++ b/fendermint/vm/interpreter/src/fvm/query.rs
@@ -15,13 +15,13 @@ use super::{state::FvmQueryState, FvmApplyRet, FvmMessageInterpreter};
 /// and sent over the wire as it is, only its internal parts are
 /// sent in the response. The client has to know what to expect,
 /// depending on the kind of query it sent.
-pub enum FvmQueryRet {
+pub enum FvmQueryRet<C = FvmApplyRet> {
     /// Bytes from the IPLD store retult, if found.
     Ipld(Option<Vec<u8>>),
     /// The full state of an actor, if found.
     ActorState(Option<Box<(ActorID, ActorState)>>),
     /// The results of a read-only message application.
-    Call(FvmApplyRet),
+    Call(C),
     /// The estimated gas limit.
     EstimateGas(GasEstimate),
     /// Current state parameters.

--- a/fendermint/vm/interpreter/src/fvm/state/check.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/check.rs
@@ -59,7 +59,7 @@ impl<DB> HasChainID for FvmCheckState<DB>
 where
     DB: Blockstore + 'static,
 {
-    fn chain_id(&self) -> &ChainID {
-        &self.chain_id
+    fn chain_id(&self) -> ChainID {
+        self.chain_id
     }
 }

--- a/fendermint/vm/interpreter/src/fvm/state/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/exec.rs
@@ -134,8 +134,8 @@ impl<DB> HasChainID for FvmExecState<DB>
 where
     DB: Blockstore,
 {
-    fn chain_id(&self) -> &ChainID {
-        &self.executor.context().network.chain_id
+    fn chain_id(&self) -> ChainID {
+        self.executor.context().network.chain_id
     }
 }
 

--- a/fendermint/vm/interpreter/src/fvm/state/query.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/query.rs
@@ -7,10 +7,11 @@ use anyhow::{anyhow, Context};
 
 use cid::Cid;
 use fendermint_vm_actor_interface::system::SYSTEM_ACTOR_ADDR;
+use fendermint_vm_core::chainid::HasChainID;
 use fendermint_vm_message::query::ActorState;
 use fvm::{engine::MultiEngine, executor::ApplyRet};
 use fvm_ipld_blockstore::Blockstore;
-use fvm_shared::{address::Address, clock::ChainEpoch, ActorID};
+use fvm_shared::{address::Address, chainid::ChainID, clock::ChainEpoch, ActorID};
 use num_traits::Zero;
 
 use crate::fvm::{store::ReadOnlyBlockstore, FvmMessage};
@@ -157,5 +158,14 @@ where
 
     pub fn state_params(&self) -> &FvmStateParams {
         &self.state_params
+    }
+}
+
+impl<DB> HasChainID for FvmQueryState<DB>
+where
+    DB: Blockstore + 'static,
+{
+    fn chain_id(&self) -> ChainID {
+        ChainID::from(self.state_params.chain_id)
     }
 }

--- a/fendermint/vm/interpreter/src/signed.rs
+++ b/fendermint/vm/interpreter/src/signed.rs
@@ -4,21 +4,29 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 
 use fendermint_vm_core::chainid::HasChainID;
-use fendermint_vm_message::signed::{chain_id_bytes, SignedMessage, SignedMessageError};
+use fendermint_vm_message::{
+    query::FvmQuery,
+    signed::{chain_id_bytes, SignedMessage, SignedMessageError},
+};
 use fvm_ipld_encoding::Error as IpldError;
 use fvm_shared::{chainid::ChainID, crypto::signature::Signature};
 use serde::Serialize;
 
 use crate::{
-    fvm::{FvmApplyRet, FvmCheckRet, FvmMessage},
+    fvm::{FvmApplyRet, FvmCheckRet, FvmMessage, FvmQueryRet},
     CheckInterpreter, ExecInterpreter, GenesisInterpreter, QueryInterpreter,
 };
 
 /// Message validation failed due to an invalid signature.
 pub struct InvalidSignature(pub String);
 
-pub type SignedMessageApplyRet = Result<FvmApplyRet, InvalidSignature>;
-pub type SignedMessageCheckRet = Result<FvmCheckRet, InvalidSignature>;
+pub struct SignedMessageApplyRet {
+    pub fvm: FvmApplyRet,
+    pub sig_hash: Vec<u8>,
+}
+
+pub type SignedMessageApplyRes = Result<SignedMessageApplyRet, InvalidSignature>;
+pub type SignedMessageCheckRes = Result<FvmCheckRet, InvalidSignature>;
 
 /// Different kinds of signed messages.
 ///
@@ -95,15 +103,15 @@ impl<I> SignedMessageInterpreter<I> {
 }
 
 #[async_trait]
-impl<I, S> ExecInterpreter for SignedMessageInterpreter<I>
+impl<I> ExecInterpreter for SignedMessageInterpreter<I>
 where
-    I: ExecInterpreter<Message = FvmMessage, DeliverOutput = FvmApplyRet, State = S>,
-    S: HasChainID + Send + 'static,
+    I: ExecInterpreter<Message = FvmMessage, DeliverOutput = FvmApplyRet>,
+    I::State: HasChainID,
 {
     type State = I::State;
     type Message = VerifiableMessage;
     type BeginOutput = I::BeginOutput;
-    type DeliverOutput = SignedMessageApplyRet;
+    type DeliverOutput = SignedMessageApplyRes;
     type EndOutput = I::EndOutput;
 
     async fn deliver(
@@ -115,7 +123,7 @@ where
         // async call to `inner.deliver` would be inside a match holding a reference to `state`.
         let chain_id = state.chain_id();
 
-        match msg.verify(chain_id) {
+        match msg.verify(&chain_id) {
             Err(SignedMessageError::Ipld(e)) => Err(anyhow!(e)),
             Err(SignedMessageError::Ethereum(e)) => {
                 Ok((state, Err(InvalidSignature(e.to_string()))))
@@ -125,7 +133,10 @@ where
                 Ok((state, Err(InvalidSignature(s))))
             }
             Ok(()) => {
-                let (state, ret) = self.inner.deliver(state, msg.into_message()).await?;
+                let msg = msg.into_message();
+                let sig_hash = SignedMessage::sig_hash(&msg, &chain_id)?;
+                let (state, ret) = self.inner.deliver(state, msg).await?;
+                let ret = SignedMessageApplyRet { fvm: ret, sig_hash };
                 Ok((state, Ok(ret)))
             }
         }
@@ -141,14 +152,14 @@ where
 }
 
 #[async_trait]
-impl<I, S> CheckInterpreter for SignedMessageInterpreter<I>
+impl<I> CheckInterpreter for SignedMessageInterpreter<I>
 where
-    I: CheckInterpreter<Message = FvmMessage, Output = FvmCheckRet, State = S>,
-    S: HasChainID + Send + 'static,
+    I: CheckInterpreter<Message = FvmMessage, Output = FvmCheckRet>,
+    I::State: HasChainID + Send + 'static,
 {
     type State = I::State;
     type Message = VerifiableMessage;
-    type Output = SignedMessageCheckRet;
+    type Output = SignedMessageCheckRes;
 
     async fn check(
         &self,
@@ -159,7 +170,7 @@ where
         let verify_result = if is_recheck {
             Ok(())
         } else {
-            msg.verify(state.chain_id())
+            msg.verify(&state.chain_id())
         };
 
         match verify_result {
@@ -186,18 +197,37 @@ where
 #[async_trait]
 impl<I> QueryInterpreter for SignedMessageInterpreter<I>
 where
-    I: QueryInterpreter,
+    I: QueryInterpreter<Query = FvmQuery, Output = FvmQueryRet>,
+    I::State: HasChainID,
 {
     type State = I::State;
     type Query = I::Query;
-    type Output = I::Output;
+    type Output = FvmQueryRet<SignedMessageApplyRet>;
 
     async fn query(
         &self,
         state: Self::State,
         qry: Self::Query,
     ) -> anyhow::Result<(Self::State, Self::Output)> {
-        self.inner.query(state, qry).await
+        let sig_hash = match qry {
+            FvmQuery::Call(ref msg) => SignedMessage::sig_hash(msg, &state.chain_id()).ok(),
+            _ => None,
+        };
+
+        let (state, ret) = self.inner.query(state, qry).await?;
+
+        let ret = match ret {
+            FvmQueryRet::Ipld(x) => FvmQueryRet::Ipld(x),
+            FvmQueryRet::ActorState(x) => FvmQueryRet::ActorState(x),
+            FvmQueryRet::EstimateGas(x) => FvmQueryRet::EstimateGas(x),
+            FvmQueryRet::StateParams(x) => FvmQueryRet::StateParams(x),
+            FvmQueryRet::Call(x) => FvmQueryRet::Call(SignedMessageApplyRet {
+                fvm: x,
+                sig_hash: sig_hash.unwrap_or_default(),
+            }),
+        };
+
+        Ok((state, ret))
     }
 }
 

--- a/fendermint/vm/interpreter/src/signed.rs
+++ b/fendermint/vm/interpreter/src/signed.rs
@@ -22,7 +22,7 @@ pub struct InvalidSignature(pub String);
 
 pub struct SignedMessageApplyRet {
     pub fvm: FvmApplyRet,
-    pub sig_hash: Vec<u8>,
+    pub sig_hash: [u8; 32],
 }
 
 pub type SignedMessageApplyRes = Result<SignedMessageApplyRet, InvalidSignature>;

--- a/fendermint/vm/message/src/signed.rs
+++ b/fendermint/vm/message/src/signed.rs
@@ -141,6 +141,26 @@ impl SignedMessage {
         }
     }
 
+    /// Calculate the exact hash that the client would have to sign.
+    ///
+    /// Some Ethereum clients expects this to be the transaction hash,
+    /// but it's different from the Tendermint transaction hash.
+    pub fn sig_hash(message: &Message, chain_id: &ChainID) -> Result<Vec<u8>, SignedMessageError> {
+        match Self::signable(message, chain_id)? {
+            Signable::Ethereum((hash, _)) => Ok(hash.0.to_vec()),
+            Signable::Regular(data) => {
+                // blake2b 256 hash
+                let hash = blake2b_simd::Params::new()
+                    .hash_length(32)
+                    .to_state()
+                    .update(&data)
+                    .finalize();
+
+                Ok(hash.as_array().to_vec())
+            }
+        }
+    }
+
     /// Verifies that the from address of the message generated the signature.
     pub fn verify(&self, chain_id: &ChainID) -> Result<(), SignedMessageError> {
         Self::verify_signature(&self.message, &self.signature, chain_id)

--- a/fendermint/vm/message/src/signed.rs
+++ b/fendermint/vm/message/src/signed.rs
@@ -145,9 +145,9 @@ impl SignedMessage {
     ///
     /// Some Ethereum clients expects this to be the transaction hash,
     /// but it's different from the Tendermint transaction hash.
-    pub fn sig_hash(message: &Message, chain_id: &ChainID) -> Result<Vec<u8>, SignedMessageError> {
+    pub fn sig_hash(message: &Message, chain_id: &ChainID) -> Result<[u8; 32], SignedMessageError> {
         match Self::signable(message, chain_id)? {
-            Signable::Ethereum((hash, _)) => Ok(hash.0.to_vec()),
+            Signable::Ethereum((hash, _)) => Ok(hash.0),
             Signable::Regular(data) => {
                 // blake2b 256 hash
                 let hash = blake2b_simd::Params::new()
@@ -156,7 +156,7 @@ impl SignedMessage {
                     .update(&data)
                     .finalize();
 
-                Ok(hash.as_array().to_vec())
+                Ok(hash.as_bytes().try_into().expect("should be 32 bytes"))
             }
         }
     }


### PR DESCRIPTION
Fixes #216 

- [x] Return the Ethereum hash from `eth_sendRawTransaction`
- [x] Calculate the Ethereum hash in `to_events` and add an extra indexed attribute if the transaction was an Ethereum one, or maybe add a general "sighash" field and then we can even include the CID for regular transactions
- [x] Find all other occurrences where the transacton hash is calculated (e.g. block results) and either reproduce the Ethereum signature or get it from the events if available
- [x] Change transaction lookups to use `tx_search` with the indexed attribute
- [x] Change the transaction hash in the receipts
- [x] Change the transaction hash in the PendingTransaction subscriptions
- [x] Get rid of all use of `message_hash`.

### Notes

I renamed some of the output types from the interpreters:
* if the output is some kind of an enum or record type that contains positive as well as negative results, it has a `Ret` suffix (like the `ApplyRet` type of the FVM)
* if the output is an alias for a `Result` with a custom error, and a positive going in the `Ok` side, it has a `Res` suffix

This way I could replace the `SingedMessageApplyRet` type which was a `Result<FvmApplyRet, SignatureError>` with two new types: `SignedMessageApplyRes` is now the alias for this `Result` and `SignedMessageApplyRet` is the positive case which includes the FVM result as well as the sighash of the message. 

This renaming was carried out on the other output types as well. I know `Ret` and `Res` are so close to each other it may be distracting to figure out which one we want to use where :-/ 

I put the sighash into this return value instead of recalculating it during the conversion to Tendermint delivery results so that we keep as much of our logic as we can in in the interpreters, and the `SignedMessageInterpreter` is where the parsed message as well as the chain ID were both available, and where this hash was produced anyway for signature checks. By contrast if I wanted to put it into the `FvmApplyRet` I would have had to pass the chain ID even further, and then access the `SignedMessage` type again, which seems wrong, and also inconvenient as the executor type would have needed a chain ID even where it wasn't naturally available . The result was that the hash had to be added on top of the FVM results into a new type. I added the sighash to the query results as well, to be symmetric, so one can inspect the results of a read-only `Call` query to see what they are ought to sign. 


### Testing the new indexing mechanism

I discovered that the `/tx_search` queries don't quite work the way I thought, I don't know why. 

```bash
make e2e
cd fendermint/testing/smoke-test
cargo make setup
cargo make simplecoin-example
```

Should print a transaction ID:
```console
$ cargo make simplecoin-example
...
2023-08-25T14:57:06.320826Z  INFO simplecoin: deployment transaction tx_hash=Hash::Sha256(EE139AD83994E2430E0FAE77B001DCA270B06434712A230D878455E16CB45D4E)
...
```

We can use that to search for this transaction:

```console
$  curl "localhost:26657/tx_search?query=\"tx.hash='EE139AD83994E2430E0FAE77B001DCA270B06434712A230D878455E16CB45D4E'\""
{"jsonrpc":"2.0","id":-1,"result":{"txs":[{"hash":"EE139AD83994E2430E0FAE77B001DCA270B06434712A230D878455E16CB45D4E","height":"564","index":0,"tx_result":{"code":0,"data":"gxh4VQL2WY+HJc3jpanLt3LLCBu5aU9tfVQf14vcEDd74TUQrTKY67aYYpERKw==","log":"","info":"","gas_wanted":"10000000000","gas_used":"18818504","events":[{"type":"sig","attributes":[{"key":"hash","value":"1a7a54b7cd001d275fe8f4b76ed30709f786d4642ba42f08c060db6350bbced7","index":true}]}],"codespace":""},"tx":"oWZTaWduZWSCigBCA...9t1/2bSkGJieTgAaDJMCcB"}],"total_count":"1"}}⏎  
```

It shows that the `sig.hash` event-attribute has been emitted. Check that it works:

```console
❯ curl "localhost:26657/tx_search?query=\"sig.hash='1a7a54b7cd001d275fe8f4b76ed30709f786d4642ba42f08c060db6350bbced7'\""
{"jsonrpc":"2.0","id":-1,"result":{"txs":[{"hash":"EE139AD83994E2430E0FAE77B001DCA270B06434712A230D878455E16CB45D4E","height":"564","index":0,"tx_result":{"code":0,"data":"gxh4VQL2WY+HJc3jpanLt3LLCBu5aU9tfVQf14vcEDd74TUQrTKY67aYYpERKw==","log":"","info":"","gas_wanted":"10000000000","gas_used":"18818504","events":[{"type":"sig","attributes":[{"key":"hash","value":"1a7a54b7cd001d275fe8f4b76ed30709f786d4642ba42f08c060db6350bbced7","index":true}]}],"codespace":""},"tx":"oWZTaW...okZ9t1/2bSkGJieTgAaDJMCcB"}],"total_count":"1"}}⏎ 
```

Found it. This proves that the base mechanism works, yet for the ethapi-example it has to be aligned all the way, an I'm not sure how quick this indexing is:

```console
$ cargo make ethapi-example
...
     Running `target/release/examples/ethers --secret-key-from fendermint/testing/smoke-test/test-data/fendermint/keys/emily.sk --secret-key-to fendermint/testing/smoke-test/test-data/fendermint/keys/eric.sk`
2023-08-25T15:04:43.992090Z  INFO ethers: Running the tests over HTTP...
2023-08-25T15:04:43.992530Z  INFO ethers: ethereum address from=0x90cb0f0a5ab63e0edb9468ec779c799b81a88345 to=0xd299f862762ac9db45b917152fd6c0f710f4c07c
2023-08-25T15:04:44.011000Z  INFO ethers: sending example transfer
Pending transaction: transfer: 0x14bda529ed00d484bf98fc3f9688dc60c26de5fea737146c9cf5d373063d6de5
Error: failed to send transfer

Caused by:
    Missing receipt
[cargo-make] ERROR - Error while executing command, exit code: 1
[cargo-make] WARN - Build Failed.
```

Searching for it returns the following result:

```console
$ curl "localhost:26657/tx_search?query=\"sig.hash='14bda529ed00d484bf98fc3f9688dc60c26de5fea737146c9cf5d373063d6de5'\""
{"jsonrpc":"2.0","id":-1,"result":{"txs":[{"hash":"B4BEECC5EECA8FAF7F0D4411BB6F1E286811A5AA54F8631C86D5C31C3C451623","height":"1410","index":0,"tx_result":{"code":0,"data":null,"log":"","info":"","gas_wanted":"10000000000","gas_used":"1757573","events":[{"type":"sig","attributes":[{"key":"hash","value":"14bda529ed00d484bf98fc3f9688dc60c26de5fea737146c9cf5d373063d6de5","index":true}]}],"codespace":""},"tx":"oWZTaWduZWSC...AA=="}],"total_count":"1"}}
```
So it's definitely there, and it's there while the example is retrying to fetch it. 

Checking the logs show that the application is trying with the right has even:

```console
$ docker logs smoke-ethapi
...
2023-08-25T15:14:25.669321Z DEBUG tendermint_rpc::client::transport::websocket::sealed: Outgoing request: {
  "jsonrpc": "2.0",
  "id": "937bd7f2-4fbc-49a5-9764-a31828775f64",
  "method": "tx_search",
  "params": {
    "query": "tm.event = 'Tx' AND sig.hash = '14bda529ed00d484bf98fc3f9688dc60c26de5fea737146c9cf5d373063d6de5'",
    "prove": false,
    "page": "1",
    "per_page": "1",
    "order_by": "asc"
  }
}
2023-08-25T15:14:25.669672Z DEBUG tendermint_rpc::client::transport::websocket: Generic JSON-RPC message: Wrapper { jsonrpc: Version("2.0"), id: Str("937bd7f2-4fbc-49a5-9764-a31828775f64"), result: Some(GenericJsonResponse(Object {"total_count": String("0"), "txs": Array []})), error: None }
```

Possibly the `tm.event = 'Tx'` doesn't work in this case.

After adding a `send_coin` transaction to the `simplecoin-example` I can confirm that `tm.event = 'Tx'` only seems to work with `tx.hash` but not with custom keys:

```console
❯ curl "localhost:26657/tx_search?query=\"tm.event='Tx'%20AND%20tx.hash='91BB6AA67AE2AD246F542ECE2F0D406DFD84DC77E9D30262DB45BA9A640E0919'\""
{"jsonrpc":"2.0","id":-1,"result":{"txs":[{"hash":"91BB6AA67AE2AD246F542ECE2F0D406DFD84DC77E9D30262DB45BA9A640E0919","height":"5070","index":0,"tx_result":{"code":0,"data":"WCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQ==","log":"","info":"","gas_wanted":"10000000000","gas_used":"4999808","events":[{"type":"message","attributes":[{"key":"emitter","value":"122","index":true},{"key":"t1","value":"ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef","index":true},{"key":"t2","value":"000000000000000000000000ff00000000000000000000000000000000000064","index":true},{"key":"t3","value":"000000000000000000000000ff00000000000000000000000000000000000064","index":true},{"key":"d","value":"0000000000000000000000000000000000000000000000000000000000000064","index":true}]},{"type":"sig","attributes":[{"key":"hash","value":"900ec2a720dfcdf02b08665f3660b18c4ebd68b7764bb99996dc771940fb221d","index":true}]}],"codespace":""},"tx":"oWZTaWduZWSCigBWBAohrPtwqr2nhcijFF25htXq599oC1UB1NNGuEyoh7VATZqjeX+l1/nbDPIGQBsAAAACVAvkAEBAGuUlqhVYRlhEkLmKEQAAAAAAAAAAAAAAAP8AAAAAAAAAAAAAAAAAAAAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGRYQgHjhBLvndbOG55/dHzupDQ5290dCRonN09f4njQUSJN7Rp7AwRHDypd9Cp/IhTOfeiXmcJU5oJ8lvG5WPuC6tQBAA=="}],"total_count":"1"}}⏎                
  ~/projects/consensuslab/fendermint  fm-216-index-by-eth-hash !3 ····························································································································  1.69.0 16:37:58
❯ curl "localhost:26657/tx_search?query=\"tm.event='Tx'%20AND%20message.emitter='122'\""
{"jsonrpc":"2.0","id":-1,"result":{"txs":[],"total_count":"0"}}⏎                                                                                                                                                   
  ~/projects/consensuslab/fendermint  fm-216-index-by-eth-hash !3 ····························································································································  1.69.0 16:39:02
❯ curl "localhost:26657/tx_search?query=\"message.emitter='122'\""
{"jsonrpc":"2.0","id":-1,"result":{"txs":[{"hash":"91BB6AA67AE2AD246F542ECE2F0D406DFD84DC77E9D30262DB45BA9A640E0919","height":"5070","index":0,"tx_result":{"code":0,"data":"WCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQ==","log":"","info":"","gas_wanted":"10000000000","gas_used":"4999808","events":[{"type":"message","attributes":[{"key":"emitter","value":"122","index":true},{"key":"t1","value":"ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef","index":true},{"key":"t2","value":"000000000000000000000000ff00000000000000000000000000000000000064","index":true},{"key":"t3","value":"000000000000000000000000ff00000000000000000000000000000000000064","index":true},{"key":"d","value":"0000000000000000000000000000000000000000000000000000000000000064","index":true}]},{"type":"sig","attributes":[{"key":"hash","value":"900ec2a720dfcdf02b08665f3660b18c4ebd68b7764bb99996dc771940fb221d","index":true}]}],"codespace":""},"tx":"oWZTaWduZWSCigBWBAohrPtwqr2nhcijFF25htXq599oC1UB1NNGuEyoh7VATZqjeX+l1/nbDPIGQBsAAAACVAvkAEBAGuUlqhVYRlhEkLmKEQAAAAAAAAAAAAAAAP8AAAAAAAAAAAAAAAAAAAAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGRYQgHjhBLvndbOG55/dHzupDQ5290dCRonN09f4njQUSJN7Rp7AwRHDypd9Cp/IhTOfeiXmcJU5oJ8lvG5WPuC6tQBAA=="}],"total_count":"1"}}⏎                
```