### PR TITLE
FM-216: Index transaction by Ethereum hash (take 2)

### DIFF
--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -590,7 +590,7 @@ where
                         method_num = ret.fvm.method_num,
                         "tx delivered"
                     );
-                    to_deliver_tx(ret)
+                    to_deliver_tx(ret.fvm, ret.eco_hash)
                 }
             },
         };

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -590,7 +590,7 @@ where
                         method_num = ret.fvm.method_num,
                         "tx delivered"
                     );
-                    to_deliver_tx(ret.fvm, ret.eco_hash)
+                    to_deliver_tx(ret.fvm, ret.domain_hash)
                 }
             },
         };

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -46,8 +46,8 @@ use ethers_core::{
     k256::ecdsa::SigningKey,
     types::{
         transaction::eip2718::TypedTransaction, Address, BlockId, BlockNumber, Bytes,
-        Eip1559TransactionRequest, Filter, Log, SyncingStatus, TransactionReceipt, H160, H256,
-        U256, U64,
+        Eip1559TransactionRequest, Filter, Log, SyncingStatus, TransactionReceipt, TxHash, H160,
+        H256, U256, U64,
     },
 };
 use fendermint_rpc::message::MessageFactory;
@@ -405,8 +405,18 @@ where
     // However, ethers.js actually asserts this and we cannot disable it, rendering that, or any similar tool, unusable if we rely on
     // the default Tendermint transaction hash, which is a Sha256 hash of the entire payload (which includes the signature),
     // not a Keccak256 of the unsigned RLP.
-    // let expected_hash = todo!("we need to reproduce the signature to get the full RLP");
-    // assert_eq!(tx_hash, expected_hash, "Ethereum hash should match");
+
+    let expected_hash = {
+        let sig = mw
+            .signer()
+            .sign_transaction(&transfer)
+            .await
+            .context("failed to sign transaction")?;
+
+        let rlp = transfer.rlp_signed(&sig);
+        TxHash::from(ethers_core::utils::keccak256(rlp))
+    };
+    assert_eq!(tx_hash, expected_hash, "Ethereum hash should match");
 
     // Get a block with transactions by number.
     let block = request(

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -405,7 +405,8 @@ where
     // However, ethers.js actually asserts this and we cannot disable it, rendering that, or any similar tool, unusable if we rely on
     // the default Tendermint transaction hash, which is a Sha256 hash of the entire payload (which includes the signature),
     // not a Keccak256 of the unsigned RLP.
-    assert_eq!(tx_hash, transfer.sighash(), "Ethereum hash should match");
+    // let expected_hash = todo!("we need to reproduce the signature to get the full RLP");
+    // assert_eq!(tx_hash, expected_hash, "Ethereum hash should match");
 
     // Get a block with transactions by number.
     let block = request(

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -502,8 +502,9 @@ where
         .context("failed to decode RLP as signed TypedTransaction")?;
 
     let sighash = tx.sighash();
+    let msghash = et::TxHash::from(ethers_core::utils::keccak256(rlp.as_raw()));
 
-    tracing::debug!(?sighash, "received raw transaction");
+    tracing::debug!(?sighash, ?msghash, "received raw transaction");
 
     let msg = to_fvm_message(tx, false)?;
     let msg = SignedMessage {
@@ -517,7 +518,7 @@ where
         // The following hash would be okay for ethers-rs,and we could use it to look up the TX with Tendermint,
         // but ethers.js would reject it because it doesn't match what Ethereum would use.
         // Ok(et::TxHash::from_slice(res.hash.as_bytes()))
-        Ok(sighash)
+        Ok(msghash)
     } else {
         error(
             ExitCode::new(res.code.value()),

--- a/fendermint/eth/api/src/conv/from_tm.rs
+++ b/fendermint/eth/api/src/conv/from_tm.rs
@@ -13,7 +13,7 @@ use fvm_shared::chainid::ChainID;
 use fvm_shared::{bigint::BigInt, econ::TokenAmount};
 use lazy_static::lazy_static;
 use tendermint::abci::response::DeliverTx;
-use tendermint::abci::{self, EventAttribute};
+use tendermint::abci::{self, Event, EventAttribute};
 use tendermint::crypto::sha256::Sha256;
 use tendermint_rpc::{endpoint, Client};
 
@@ -89,21 +89,25 @@ pub fn to_eth_block(
     // potentially through multiple hops. Let's leave that for the future and for now
     // assume that all we have is signed transactions.
     for (idx, data) in block.data().iter().enumerate() {
-        size += et::U256::from(data.len());
-        let mut sig_hash = None;
+        let result = match transaction_results.get(idx) {
+            Some(result) => result,
+            None => continue,
+        };
 
-        if let Some(result) = transaction_results.get(idx) {
-            gas_used += et::U256::from(result.gas_used);
-            gas_limit += et::U256::from(result.gas_wanted);
-            sig_hash = find_sig_hash(&result.events);
-        }
+        size += et::U256::from(data.len());
+        gas_used += et::U256::from(result.gas_used);
+        gas_limit += et::U256::from(result.gas_wanted);
 
         let msg = to_chain_message(data)?;
 
         if let ChainMessage::Signed(msg) = msg {
-            let mut tx = to_eth_transaction(msg, chain_id, sig_hash)
+            let hash = msg_hash(&chain_id, &result.events, data, Some(&msg), None);
+
+            let mut tx = to_eth_transaction(msg, chain_id, hash)
                 .context("failed to convert to eth transaction")?;
+
             tx.transaction_index = Some(et::U64::from(idx));
+
             transactions.push(tx);
         }
     }
@@ -142,19 +146,11 @@ pub fn to_eth_block(
 pub fn to_eth_transaction(
     msg: SignedMessage,
     chain_id: ChainID,
-    // If a pre-calculated hash is available, pass it in to save some time.
-    hash: Option<et::TxHash>,
+    hash: et::TxHash,
 ) -> anyhow::Result<et::Transaction> {
     // Based on https://github.com/filecoin-project/lotus/blob/6cc506f5cf751215be6badc94a960251c6453202/node/impl/full/eth.go#L2048
     let sig = to_eth_signature(msg.signature()).context("failed to convert to eth signature")?;
     let msg = msg.message;
-    let hash = if let Some(h) = hash {
-        h
-    } else {
-        SignedMessage::sig_hash(&msg, &chain_id)
-            .map(et::TxHash::from)
-            .map_err(|e| anyhow!(e))?
-    };
 
     let tx = et::Transaction {
         hash,
@@ -215,13 +211,13 @@ where
     let block_hash = et::H256::from_slice(header.hash().as_bytes());
     let block_number = et::U64::from(result.height.value());
     let transaction_index = et::U64::from(result.index);
-    let transaction_hash = find_sig_hash(&result.tx_result.events)
-        .or_else(|| {
-            SignedMessage::sig_hash(msg.message(), chain_id)
-                .ok()
-                .map(et::H256::from)
-        })
-        .unwrap_or_default();
+    let transaction_hash = msg_hash(
+        chain_id,
+        &result.tx_result.events,
+        &result.tx,
+        Some(msg),
+        Some(result.hash),
+    );
 
     let msg = &msg.message;
     // Lotus effective gas price is based on total spend divided by gas used,
@@ -477,20 +473,45 @@ pub fn to_chain_message(tx: &[u8]) -> anyhow::Result<ChainMessage> {
 ///
 /// This is here for reference only and should not be returned to Ethereum tools which expect
 /// the hash to be based on RLP and Keccak256.
-pub fn _message_hash(tx: &[u8]) -> anyhow::Result<tendermint::Hash> {
+fn message_hash(tx: &[u8]) -> tendermint::Hash {
     // based on how `tendermint::Header::hash` works.
     let hash = tendermint::crypto::default::Sha256::digest(tx);
-    let hash = tendermint::Hash::Sha256(hash);
-    Ok(hash)
+    tendermint::Hash::Sha256(hash)
 }
 
-/// Best effort to find and parse the `sig.hash` attribute emitted among the events.
-pub fn find_sig_hash(events: &[abci::Event]) -> Option<et::TxHash> {
+/// Best effort to find and parse any `eco.hash` attribute emitted among the events.
+fn find_eco_hash(events: &[abci::Event]) -> Option<et::TxHash> {
     events
         .iter()
-        .find(|e| e.kind == "sig")
+        .find(|e| e.kind == "eco")
         .and_then(|e| e.attributes.iter().find(|a| a.key == "hash"))
         .and_then(|a| hex::decode(&a.value).ok())
         .filter(|bz| bz.len() == 32)
         .map(|bz| et::TxHash::from_slice(&bz))
+}
+
+// Calculate some kind of hash for the message, preferrably one the tools expect.
+pub fn msg_hash(
+    chain_id: &ChainID,
+    events: &[Event],
+    tx: &[u8],
+    msg: Option<&SignedMessage>,
+    hash: Option<tendermint::Hash>,
+) -> et::TxHash {
+    if let Some(eco_hash) = find_eco_hash(events) {
+        return eco_hash;
+    }
+    if let Some(msg) = msg {
+        if let Ok(Some(h)) = msg.eco_hash(chain_id) {
+            return et::TxHash::from(h);
+        }
+    }
+    if let Ok(ChainMessage::Signed(msg)) = fvm_ipld_encoding::from_slice(tx) {
+        if let Ok(Some(h)) = msg.eco_hash(chain_id) {
+            return et::TxHash::from(h);
+        }
+    }
+    // If all else failed, return the default Tendermint hash.
+    let hash = hash.unwrap_or_else(|| message_hash(tx));
+    et::TxHash::from_slice(hash.as_bytes())
 }

--- a/fendermint/eth/api/src/filters.rs
+++ b/fendermint/eth/api/src/filters.rs
@@ -12,7 +12,7 @@ use anyhow::{anyhow, bail, Context};
 use ethers_core::types as et;
 use fendermint_rpc::{client::FendermintClient, query::QueryClient};
 use fendermint_vm_actor_interface::eam::EthAddress;
-use fendermint_vm_message::{chain::ChainMessage, signed::SignedMessage};
+use fendermint_vm_message::chain::ChainMessage;
 use futures::{Future, StreamExt};
 use fvm_shared::{address::Address, chainid::ChainID, error::ExitCode};
 use serde::Serialize;
@@ -28,7 +28,7 @@ use tokio::sync::{
 
 use crate::{
     cache::AddressCache,
-    conv::from_tm::{self, find_sig_hash, map_rpc_block_txs},
+    conv::from_tm::{self, map_rpc_block_txs, msg_hash},
     error::JsonRpcError,
     handlers::ws::{MethodNotification, Notification},
     state::{enrich_block, WebSocketSender},
@@ -258,7 +258,7 @@ where
             ) => {
                 for tx in &block.data {
                     if let Ok(ChainMessage::Signed(msg)) = fvm_ipld_encoding::from_slice(tx) {
-                        if let Ok(h) = SignedMessage::sig_hash(msg.message(), chain_id) {
+                        if let Ok(Some(h)) = msg.eco_hash(chain_id) {
                             hashes.push(et::TxHash::from(h))
                         }
                     }
@@ -311,7 +311,13 @@ where
                 let block_hash = et::H256::default();
                 let block_number = et::U64::from(tx_result.height);
 
-                let transaction_hash = find_sig_hash(&tx_result.result.events).unwrap_or_default();
+                let transaction_hash = msg_hash(
+                    chain_id,
+                    &tx_result.result.events,
+                    &tx_result.tx,
+                    None,
+                    None,
+                );
 
                 // TODO: The transaction index comes as None.
                 let transaction_index = et::U64::from(tx_result.index.unwrap_or_default());

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -12,6 +12,7 @@ use ethers_core::types::{self as et, BlockId};
 use fendermint_rpc::client::{FendermintClient, TendermintClient};
 use fendermint_rpc::query::QueryClient;
 use fendermint_vm_actor_interface::{evm, system};
+use fendermint_vm_message::signed::DomainHash;
 use fendermint_vm_message::{chain::ChainMessage, conv::from_eth::to_fvm_address};
 use fvm_ipld_encoding::{de::DeserializeOwned, RawBytes};
 use fvm_shared::{chainid::ChainID, econ::TokenAmount, error::ExitCode, message::Message};
@@ -248,7 +249,7 @@ where
 
                 let chain_id = ChainID::from(sp.value.chain_id);
 
-                let hash = if let Ok(Some(h)) = msg.eco_hash(&chain_id) {
+                let hash = if let Ok(Some(DomainHash::Eth(h))) = msg.domain_hash(&chain_id) {
                     et::TxHash::from(h)
                 } else {
                     return error(ExitCode::USR_ILLEGAL_ARGUMENT, "incompatible transaction");
@@ -278,7 +279,7 @@ where
         // CometBFT indexing capabilities.
 
         // Doesn't work with `Query::from(EventType::Tx).and_eq()`
-        let query = Query::eq("eco.hash", hex::encode(tx_hash.as_bytes()));
+        let query = Query::eq("eth.hash", hex::encode(tx_hash.as_bytes()));
 
         match self
             .tm()

--- a/fendermint/vm/interpreter/src/bytes.rs
+++ b/fendermint/vm/interpreter/src/bytes.rs
@@ -10,13 +10,12 @@ use fvm_ipld_encoding::Error as IpldError;
 use crate::{
     chain::{ChainMessageApplyRet, ChainMessageCheckRes},
     fvm::{FvmQuery, FvmQueryRet},
-    signed::SignedMessageApplyRet,
     CheckInterpreter, ExecInterpreter, GenesisInterpreter, ProposalInterpreter, QueryInterpreter,
 };
 
 pub type BytesMessageApplyRes = Result<ChainMessageApplyRet, IpldError>;
 pub type BytesMessageCheckRes = Result<ChainMessageCheckRes, IpldError>;
-pub type BytesMessageQueryRes = Result<FvmQueryRet<SignedMessageApplyRet>, IpldError>;
+pub type BytesMessageQueryRes = Result<FvmQueryRet, IpldError>;
 
 /// Close to what the ABCI sends: (Path, Bytes).
 pub type BytesMessageQuery = (String, Vec<u8>);
@@ -222,7 +221,7 @@ where
 #[async_trait]
 impl<I> QueryInterpreter for BytesMessageInterpreter<I>
 where
-    I: QueryInterpreter<Query = FvmQuery, Output = FvmQueryRet<SignedMessageApplyRet>>,
+    I: QueryInterpreter<Query = FvmQuery, Output = FvmQueryRet>,
 {
     type State = I::State;
     type Query = BytesMessageQuery;

--- a/fendermint/vm/interpreter/src/fvm/query.rs
+++ b/fendermint/vm/interpreter/src/fvm/query.rs
@@ -15,13 +15,13 @@ use super::{state::FvmQueryState, FvmApplyRet, FvmMessageInterpreter};
 /// and sent over the wire as it is, only its internal parts are
 /// sent in the response. The client has to know what to expect,
 /// depending on the kind of query it sent.
-pub enum FvmQueryRet<C = FvmApplyRet> {
+pub enum FvmQueryRet {
     /// Bytes from the IPLD store retult, if found.
     Ipld(Option<Vec<u8>>),
     /// The full state of an actor, if found.
     ActorState(Option<Box<(ActorID, ActorState)>>),
     /// The results of a read-only message application.
-    Call(C),
+    Call(FvmApplyRet),
     /// The estimated gas limit.
     EstimateGas(GasEstimate),
     /// Current state parameters.

--- a/fendermint/vm/message/src/signed.rs
+++ b/fendermint/vm/message/src/signed.rs
@@ -34,6 +34,16 @@ pub enum SignedMessageError {
     Ethereum(#[from] anyhow::Error),
 }
 
+/// Domain specific transaction hash.
+///
+/// Some tools like ethers.js refuse to accept Tendermint hashes,
+/// which use a different algorithm than Ethereum.
+///
+/// We can potentially extend this list to include CID based indexing.
+pub enum DomainHash {
+    Eth([u8; 32]),
+}
+
 /// Represents a wrapped message with signature bytes.
 ///
 /// This is the message that the client needs to send, but only the `message`
@@ -142,11 +152,11 @@ impl SignedMessage {
         }
     }
 
-    /// Calculate the hash that ecosystem tools expect.
-    ///
-    /// For example some Ethereum clients expect transaction hashes to be the Keccak256 hash over the signed RLP,
-    /// and they refuse to accept the default Tendermint hash as an identifier for the transaction.
-    pub fn eco_hash(&self, chain_id: &ChainID) -> Result<Option<[u8; 32]>, SignedMessageError> {
+    /// Calculate an optional hash that ecosystem tools expect.
+    pub fn domain_hash(
+        &self,
+        chain_id: &ChainID,
+    ) -> Result<Option<DomainHash>, SignedMessageError> {
         if maybe_eth_address(&self.message.from).is_some() {
             let tx = from_fvm::to_eth_transaction(self.message(), chain_id)
                 .map_err(SignedMessageError::Ethereum)?;
@@ -159,7 +169,7 @@ impl SignedMessage {
             let hash = cid::multihash::Code::Keccak256.digest(&rlp);
             let hash = hash.digest().try_into().expect("Keccak256 is 32 bytes");
 
-            Ok(Some(hash))
+            Ok(Some(DomainHash::Eth(hash)))
         } else {
             // Use the default transaction ID.
             Ok(None)


### PR DESCRIPTION
Fixes #216 

Depends on #217 

I missed the fact that Lotus returned the Keccak256 hash of the full raw transaction including the signature RLP, not the sighash. Which makes sense because in Ethereum the `from` is not reified in the transaction payload, only inferred from the signature, so without the signature two transactions doing the same thing sent from different account (with the same nonce) would not be unique unless the signature was also hashed.

This PR drop the `sig.hash` field introduced in #217 and adds an `eth.hash` field instead based on a new `SignedMessage::domain_hash(&self, chain_id)` method that returns an optional `DomainHash`, with currently only the `DomainHash::Eth` variant defined. In the API we always look for the value in events, to keep it simple - if it's not present it's not an Ethereum transaction.

I opened a new PR instead of messing up the previous one because I thought it was a well rounded change, and this is easier to review as an increment.

It looks like Lotus actually has [API methods](https://github.com/filecoin-project/lotus/blob/v1.23.1-rc2/api/api_full.go#L803C2-L804C114) for CID<->Ethereum conversions, so we can potentially extend the `DomainHash` that way. 