### PR TITLE
fix: getBlock null bloom

### DIFF
--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -575,8 +575,6 @@ where
     let sighash = tx.sighash();
     let msghash = et::TxHash::from(ethers_core::utils::keccak256(rlp.as_raw()));
 
-    tracing::debug!(?sighash, ?msghash, "received raw transaction");
-
     let msg = to_fvm_message(tx, false)?;
     let msg = SignedMessage {
         message: msg,
@@ -585,6 +583,7 @@ where
     let msg = ChainMessage::Signed(msg);
     let bz: Vec<u8> = MessageFactory::serialize(&msg)?;
     let res: tx_sync::Response = data.tm().broadcast_tx_sync(bz).await?;
+    tracing::debug!(?sighash, eth_hash = ?msghash, tm_hash = ?res.hash, "received raw transaction");
     if res.code.is_ok() {
         // The following hash would be okay for ethers-rs,and we could use it to look up the TX with Tendermint,
         // but ethers.js would reject it because it doesn't match what Ethereum would use.

--- a/fendermint/eth/api/src/conv/from_tm.rs
+++ b/fendermint/eth/api/src/conv/from_tm.rs
@@ -129,7 +129,7 @@ pub fn to_eth_block(
         uncles_hash: *EMPTY_UNCLE_HASH,
         receipts_root: *EMPTY_ROOT_HASH,
         extra_data: et::Bytes::default(),
-        logs_bloom: None,
+        logs_bloom: Some(et::Bloom::from_slice(&*EMPTY_ETH_BLOOM)),
         withdrawals_root: None,
         withdrawals: None,
         seal_fields: Vec::new(),


### PR DESCRIPTION
This PR: 
- Fixes an error for which `logs_bloom` was being set to `null` when serializing the response for `eth_getBlockBy...` which made some tooling to crash in the deserialization of the response because it expects a mandatory `logs_bloom` field.
- Improves logging for debugging purposes.