### PR TITLE
FM-283: Add validator account kind setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3045,7 +3045,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "tendermint",
+ "tendermint 0.31.1",
 ]
 
 [[package]]
@@ -3081,7 +3081,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tendermint",
+ "tendermint 0.31.1",
  "tendermint-rpc",
  "thiserror",
  "tokio",

--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -11,11 +11,17 @@ contracts_dir = "contracts"
 builtin_actors_bundle = "bundle.car"
 # Where to reach CometBFT for queries or broadcasting transactions.
 tendermint_rpc_url = "http://127.0.0.1:26657"
+
 # Secp256k1 private key used for signing transactions. Leave empty if not validating,
 # or if it's not needed to sign and broadcast transactions as a validator.
 # Leaving empty by default so single node deployments don't fail to start because
 # this key is not copied into place.
-validator_key = ""
+# [validator_key]
+# # Path to the secret key file in base64 format.
+# path =
+
+# # The on-chain account kind (regular|ethereum)
+# kind =
 
 [abci]
 # Number of concurrent requests allowed to reach the application.

--- a/fendermint/app/config/test.toml
+++ b/fendermint/app/config/test.toml
@@ -1,6 +1,10 @@
 # These setting are overlayed over `default.toml` in unit tests
 # to exercise parsing values that are not viable as defaults.
 
+[validator_key]
+path = "dummy.sk"
+kind = "ethereum"
+
 [resolver]
 subnet_id = "/r31415926"
 

--- a/fendermint/app/options/src/rpc.rs
+++ b/fendermint/app/options/src/rpc.rs
@@ -10,7 +10,10 @@ use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{address::Address, econ::TokenAmount, MethodNum};
 use tendermint_rpc::Url;
 
-use crate::parse::{parse_address, parse_bytes, parse_cid, parse_full_fil, parse_token_amount};
+use crate::{
+    genesis::AccountKind,
+    parse::{parse_address, parse_bytes, parse_cid, parse_full_fil, parse_token_amount},
+};
 
 #[derive(Args, Debug)]
 pub struct RpcArgs {
@@ -151,6 +154,9 @@ pub struct TransArgs {
     /// Path to the secret key of the sender to sign the transaction.
     #[arg(long, short)]
     pub secret_key: PathBuf,
+    /// Indicate whether its a regular or ethereum account.
+    #[arg(long, short, default_value = "regular")]
+    pub account_kind: AccountKind,
     /// Sender account nonce.
     #[arg(long, short = 'n')]
     pub sequence: u64,

--- a/fendermint/rpc/examples/simplecoin.rs
+++ b/fendermint/rpc/examples/simplecoin.rs
@@ -127,8 +127,7 @@ async fn main() {
         .value
         .chain_id;
 
-    let mf = MessageFactory::new(sk, sn, ChainID::from(chain_id))
-        .expect("failed to create message factor");
+    let mf = MessageFactory::new_secp256k1(sk, sn, ChainID::from(chain_id));
 
     let mut client = client.bind(mf);
 

--- a/fendermint/rpc/src/message.rs
+++ b/fendermint/rpc/src/message.rs
@@ -28,15 +28,21 @@ pub struct MessageFactory {
 }
 
 impl MessageFactory {
-    pub fn new(sk: SecretKey, sequence: u64, chain_id: ChainID) -> anyhow::Result<Self> {
-        let pk = sk.public_key();
-        let addr = Address::new_secp256k1(&pk.serialize())?;
-        Ok(Self {
+    /// Create a factor from a secret key and its corresponding address, which could be a delegated one.
+    pub fn new(sk: SecretKey, addr: Address, sequence: u64, chain_id: ChainID) -> Self {
+        Self {
             sk,
             addr,
             sequence,
             chain_id,
-        })
+        }
+    }
+
+    /// Treat the secret key as an f1 type account.
+    pub fn new_secp256k1(sk: SecretKey, sequence: u64, chain_id: ChainID) -> Self {
+        let pk = sk.public_key();
+        let addr = Address::new_secp256k1(&pk.serialize()).expect("public key is 65 bytes");
+        Self::new(sk, addr, sequence, chain_id)
     }
 
     /// Convenience method to read the secret key from a file, expected to be in Base64 format.

--- a/fendermint/vm/interpreter/src/fvm/broadcast.rs
+++ b/fendermint/vm/interpreter/src/fvm/broadcast.rs
@@ -37,14 +37,12 @@ where
 {
     pub fn new(
         client: C,
+        addr: Address,
         secret_key: SecretKey,
         gas_fee_cap: TokenAmount,
         gas_premium: TokenAmount,
     ) -> Self {
         let client = FendermintClient::new(client);
-        // TODO: We could use f410 addresses to send the transaction, but the `MessageFactory` assumes f1.
-        let addr = Address::new_secp256k1(&secret_key.public_key().serialize())
-            .expect("public key is 65 bytes");
         Self {
             client,
             secret_key,
@@ -65,8 +63,7 @@ where
             .await
             .context("failed to get broadcaster sequence")?;
 
-        let factory = MessageFactory::new(self.secret_key.clone(), sequence, chain_id)
-            .context("failed to create MessageFactory")?;
+        let factory = MessageFactory::new(self.secret_key.clone(), self.addr, sequence, chain_id);
 
         // Using the bound client as a one-shot transaction sender.
         let mut client = self.client.clone().bind(factory);


### PR DESCRIPTION
Closes #283 

Changes the `validator_key` setting from a `PathBuf` into a struct with a `path` and a `kind` field, where the kind can be `regular` or `ethereum`, which is how accounts are added to the genesis file too. This is then used to derive the `addr` which is passed to the `Broadcaster` and the `MessageFactory`, which allows validators to use f410 accounts to pay for transactions. 

I thought about introducing two of these fields, one for the validator (needs to sign the checkpoint, but there the account kind isn't needed) and an optional one for the broadcaster (can be used to override the validator key for sending transactions) but decided to hold on, since we discussed in a comment with @adlrocha that recognising validator transactions could be something we use to subsidize their transactions.