### PR TITLE
CHORE: Generate the ABI under the IPC actor solidity checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ docker/.artifacts
 cometbft
 test-network
 .idea
+.make

--- a/scripts/find-ipc-actors.sh
+++ b/scripts/find-ipc-actors.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Finds the checkout location of the IPC Solidity actors.
+
+CARGO_HOME=${CARGO_HOME}
+
+if [ -z "$CARGO_HOME" ]; then
+  CARGO_HOME=$(dirname $(dirname $(which cargo)))
+fi
+
+if [ ! -d "$CARGO_HOME" ]; then
+  >&2 echo "CARGO_HOME does not exist: $CARGO_HOME"
+  exit 1
+fi
+
+CARGO_CHECKOUTS_DIR=$CARGO_HOME/git/checkouts
+
+if [ ! -d "$CARGO_CHECKOUTS_DIR" ]; then
+  # It is possible that cargo hasn't checked out anything yet.
+  # This needs to be handled in the Makefile.
+  >&2 echo "CARGO_CHECKOUTS_DIR does not exist: $CARGO_CHECKOUTS_DIR"
+  exit 0
+fi
+
+IPC_ACTORS_BINDING=$(find $CARGO_CHECKOUTS_DIR -type f -wholename "*/ipc-solidity-actors-*/*/binding/Cargo.toml")
+
+if [ -z "$IPC_ACTORS_BINDING" ]; then
+  >&2 echo "Cannot find IPC actor bindings"
+  exit 1
+fi
+
+if [ $(echo "$IPC_ACTORS_BINDING" | wc -l) -gt 1 ]; then
+  >&2 echo -e "Found multiple IPC actor bindings:\n$IPC_ACTORS_BINDING"
+  exit 1
+fi
+
+IPC_ACTORS_DIR=$(dirname $(dirname $IPC_ACTORS_BINDING))
+
+echo $IPC_ACTORS_DIR


### PR DESCRIPTION
This is a followup for https://github.com/consensus-shipyard/fendermint/pull/297

Before that PR, `make ipc-actors-abi` checked out the `ipc-solidity-actors` repository and compiled the ABI artifacts, which were then used to:
1. generate Rust bindings and 
2. copy the contracts into the Docker file. 

Which tag to check out was defined in the `Makefile` as `IPC_ACTORS_TAG` which could be overridden as an env var.

After that PR, we no longer had to do 1), but still needed the checkout for 2). However now the `IPC_ACTORS_TAG` could have differed from the tag defined in `Cargo.toml` where the project dependency was defined.

This PR removes the need for checking out the `ipc-solidity-actors` repo by finding where `cargo` did the checkout and generating the ABI bindings there.