### PR TITLE
FM-306: Create child subnet genesis from parent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4601,6 +4601,7 @@ dependencies = [
 [[package]]
 name = "ipc-identity"
 version = "0.1.0"
+source = "git+https://github.com/consensus-shipyard/ipc-agent.git?branch=dev#cdf0e7b9113615c8dd978d9b2936494efc31e0dc"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -4627,6 +4628,7 @@ dependencies = [
 [[package]]
 name = "ipc-provider"
 version = "0.1.0"
+source = "git+https://github.com/consensus-shipyard/ipc-agent.git?branch=dev#cdf0e7b9113615c8dd978d9b2936494efc31e0dc"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4665,6 +4667,7 @@ dependencies = [
 [[package]]
 name = "ipc-sdk"
 version = "0.1.0"
+source = "git+https://github.com/consensus-shipyard/ipc-agent.git?branch=dev#cdf0e7b9113615c8dd978d9b2936494efc31e0dc"
 dependencies = [
  "anyhow",
  "cid",
@@ -4688,7 +4691,7 @@ dependencies = [
 [[package]]
 name = "ipc_actors_abis"
 version = "0.1.0"
-source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=dev#ad80d9b29c98473042c42b8f9cae5c7453620c25"
+source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=dev#d0620b852c331cb12b84fda33963bf08c5634ca6"
 dependencies = [
  "anyhow",
  "ethers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4688,7 +4688,7 @@ dependencies = [
 [[package]]
 name = "ipc_actors_abis"
 version = "0.1.0"
-source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=fm-306-genesis-getters#7c10abf617a82df0a0768d21ad8c5c2f6b16f9e1"
+source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=dev#ad80d9b29c98473042c42b8f9cae5c7453620c25"
 dependencies = [
  "anyhow",
  "ethers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.2.10",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +285,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "argon2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ba4cac0a46bc1d2912652a751c47f2a9f3a7fe89bcae2275d418f5270402f9"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash 0.5.0",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +395,17 @@ name = "asn1_der"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
 
 [[package]]
 name = "async-io"
@@ -526,7 +561,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.20.1",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1059,7 +1094,7 @@ dependencies = [
  "aead 0.4.3",
  "chacha20",
  "cipher 0.3.0",
- "poly1305",
+ "poly1305 0.7.2",
  "zeroize",
 ]
 
@@ -1119,6 +1154,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -2490,7 +2526,7 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.25.0",
  "syn 2.0.38",
  "tempfile",
  "thiserror",
@@ -2568,7 +2604,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.20.1",
  "tracing",
  "tracing-futures",
  "url",
@@ -2774,6 +2810,7 @@ dependencies = [
  "fvm_ipld_encoding 0.3.3",
  "fvm_shared",
  "hex",
+ "ipc-provider",
  "ipc-sdk",
  "ipc_ipld_resolver",
  "k256 0.11.6",
@@ -2807,13 +2844,16 @@ dependencies = [
  "bytes",
  "cid",
  "clap 4.4.6",
+ "fendermint_vm_actor_interface",
  "fvm_ipld_encoding 0.3.3",
  "fvm_shared",
  "hex",
  "ipc-sdk",
  "num-traits",
+ "primitives",
  "tendermint-rpc",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -3383,6 +3423,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "forest_hash_utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3661,7 +3716,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d09e5aa7de45452676d18fcb70b750acd65faae7a4fe18fe784b4c85f869fb"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
  "anyhow",
  "cid",
  "fvm_ipld_blockstore",
@@ -4011,7 +4066,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -4284,6 +4339,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4507,9 +4575,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipc-identity"
+version = "0.1.0"
+dependencies = [
+ "ahash 0.8.3",
+ "anyhow",
+ "argon2",
+ "base64 0.21.4",
+ "blake2b_simd",
+ "bls-signatures",
+ "ethers",
+ "fvm_shared",
+ "hex",
+ "libc",
+ "libsecp256k1",
+ "log",
+ "primitives",
+ "rand 0.8.5",
+ "serde",
+ "serde_ipld_dagcbor",
+ "serde_json",
+ "thiserror",
+ "xsalsa20poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "ipc-provider"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "async-trait",
+ "base64 0.21.4",
+ "bytes",
+ "cid",
+ "ethers",
+ "ethers-contract",
+ "fil_actors_runtime 0.0.1",
+ "futures-util",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_shared",
+ "hex",
+ "ipc-identity",
+ "ipc-sdk",
+ "ipc_actors_abis",
+ "log",
+ "num-derive",
+ "num-traits",
+ "primitives",
+ "reqwest",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_tuple",
+ "strum 0.24.1",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite 0.18.0",
+ "toml 0.7.8",
+ "url",
+ "zeroize",
+]
+
+[[package]]
 name = "ipc-sdk"
 version = "0.1.0"
-source = "git+https://github.com/consensus-shipyard/ipc-agent.git?branch=dev#16d99eda5c66a3c27a353c0116567d14a536c63f"
 dependencies = [
  "anyhow",
  "cid",
@@ -4533,7 +4664,7 @@ dependencies = [
 [[package]]
 name = "ipc_actors_abis"
 version = "0.1.0"
-source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=dev#1ab4113ea235e1d5b055dce732fb5d4bdb8e025e"
+source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=fm-306-genesis-getters#7c10abf617a82df0a0768d21ad8c5c2f6b16f9e1"
 dependencies = [
  "anyhow",
  "ethers",
@@ -5759,6 +5890,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "neptune"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6087,10 +6236,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -6237,6 +6424,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6262,7 +6460,7 @@ checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
- "password-hash",
+ "password-hash 0.4.2",
  "sha2 0.10.8",
 ]
 
@@ -6538,6 +6736,17 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash 0.4.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -7142,10 +7351,12 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls 0.24.1",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -7156,6 +7367,7 @@ dependencies = [
  "serde_urlencoded",
  "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.24.1",
  "tower-service",
  "url",
@@ -8283,11 +8495,33 @@ dependencies = [
 
 [[package]]
 name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros 0.24.3",
+]
+
+[[package]]
+name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.25.2",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -8778,6 +9012,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8818,6 +9062,20 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite 0.18.0",
 ]
 
 [[package]]
@@ -9103,6 +9361,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.8.5",
  "rustls 0.20.9",
  "sha1",
@@ -9267,6 +9526,7 @@ dependencies = [
  "form_urlencoded",
  "idna 0.4.0",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -10282,6 +10542,19 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time",
+]
+
+[[package]]
+name = "xsalsa20poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a6dad357567f81cd78ee75f7c61f1b30bb2fe4390be8fb7c69e2ac8dffb6c7"
+dependencies = [
+ "aead 0.5.2",
+ "poly1305 0.8.0",
+ "salsa20",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ pin-project = "1.1.2"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 zeroize = "1.6"
+url = "2.4.1"
 
 # Stable FVM dependencies from crates.io
 
@@ -89,6 +90,7 @@ zeroize = "1.6"
 # they are 0.x cargo cannot upgrade them automatically, which leads to version conflicts.
 fvm = { version = "~3.2", default-features = false }     # no opencl feature or it fails on CI
 fvm_shared = { version = "~3.2", features = ["crypto"] }
+primitives = { git = "https://github.com/consensus-shipyard/fvm-utils" }
 
 fvm_ipld_blockstore = "0.1"
 fvm_ipld_car = "0.6"
@@ -127,10 +129,17 @@ tendermint-proto = { version = "0.31" }
 
 ipc-sdk = { git = "https://github.com/consensus-shipyard/ipc-agent.git", branch = "dev" }
 ipc_ipld_resolver = { git = "https://github.com/consensus-shipyard/ipc-ipld-resolver.git", branch = "main" }
-ipc_actors_abis = { git = "https://github.com/consensus-shipyard/ipc-solidity-actors.git", branch = "dev" }
+ipc_actors_abis = { git = "https://github.com/consensus-shipyard/ipc-solidity-actors.git", branch = "fm-306-genesis-getters" }
+ipc-provider = { git = "https://github.com/consensus-shipyard/ipc-agent.git", branch = "dev" }
 
 [patch.crates-io]
 # Use stable-only features.
 gcra = { git = "https://github.com/consensus-shipyard/gcra-rs.git", branch = "main" }
 # Contains some API changes that the upstream has not merged.
 merkle-tree-rs = { git = "https://github.com/consensus-shipyard/merkle-tree-rs.git", branch = "dev" }
+
+
+# Uncomment to point to you local versions
+[patch."https://github.com/consensus-shipyard/ipc-agent"]
+ipc-sdk = { path = "../ipc-agent/ipc/sdk" }
+ipc-provider = { path = "../ipc-agent/ipc/provider" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ tendermint-proto = { version = "0.31" }
 
 ipc-sdk = { git = "https://github.com/consensus-shipyard/ipc-agent.git", branch = "dev" }
 ipc_ipld_resolver = { git = "https://github.com/consensus-shipyard/ipc-ipld-resolver.git", branch = "main" }
-ipc_actors_abis = { git = "https://github.com/consensus-shipyard/ipc-solidity-actors.git", branch = "fm-306-genesis-getters" }
+ipc_actors_abis = { git = "https://github.com/consensus-shipyard/ipc-solidity-actors.git", branch = "dev" }
 ipc-provider = { git = "https://github.com/consensus-shipyard/ipc-agent.git", branch = "dev" }
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ gcra = { git = "https://github.com/consensus-shipyard/gcra-rs.git", branch = "ma
 merkle-tree-rs = { git = "https://github.com/consensus-shipyard/merkle-tree-rs.git", branch = "dev" }
 
 
-# Uncomment to point to you local versions
-[patch."https://github.com/consensus-shipyard/ipc-agent"]
-ipc-sdk = { path = "../ipc-agent/ipc/sdk" }
-ipc-provider = { path = "../ipc-agent/ipc/provider" }
+# Uncomment to point to your local versions
+# [patch."https://github.com/consensus-shipyard/ipc-agent"]
+# ipc-sdk = { path = "../ipc-agent/ipc/sdk" }
+# ipc-provider = { path = "../ipc-agent/ipc/provider" }

--- a/docs/running.md
+++ b/docs/running.md
@@ -667,3 +667,43 @@ $ cargo run -p fendermint_rpc --release --example simplecoin -- --secret-key tes
 ```
 
 Note that the script figures out the Alice's nonce on its own, so we don't have to pass it in. It also has an example of running an EVM view method (which is read-only) either as as a distributed read-transaction (which is included on the chain and costs gas) or a query anwered by our node without involving the blockchain. Both have their uses, depending on our level of trust.
+
+## Deploy IPC child subnet
+
+### Crate genesis from parent
+Fendermint includes a command to automatically create the genesis file for an IPC child subnet according to the information for the subnet available in its parent. Here's an example of the generation of a genesis file for a subnet that has already been bootstrapped in the parent.
+```console
+cargo run -p fendermint_app -- --network=test genesis --genesis-file test-network/genesis.json ipc child-genesis --subnet-id <CHILD_SUBNET_ID> -p <PARENT_ENDPOINT> --parent-gateway <PARENT_GATEWAY_CONTRACT> --parent-registry <PARENT_REGISTRY_CONTRACT>
+```
+
+Here's a sample execution of the command for an already bootstrapped subnet in `/r314159`:
+```console
+cargo run -p fendermint_app -- --network=test genesis --genesis-file test-network/genesis.json ipc child-genesis --subnet-id /r314159/t410fdoh27lsddz4my2v3e77qnxdp5vsjxkdfokc7sti -p https://api.calibration.node.glif.io/rpc/v1 --parent-gateway 0x56948d2CFaa2EF355B8C08Ac925202db212146D1 --parent-registry 0x6A4884D2B6A597792dC68014D4B7C117cca5668e
+```
+
+Leading to the following genesis file:
+```console
+{
+  "chain_name": "/r314159/t410fdoh27lsddz4my2v3e77qnxdp5vsjxkdfokc7sti",
+  "timestamp": 1007560,
+  "network_version": 18,
+  "base_fee": "1000",
+  "power_scale": 3,
+  "validators": [
+    {
+      "public_key": "BDOFw7mriml8177GymI8vdD+oSk+i0ZN+CWxBOtYpEzI76zGo0grhmuF7N9zS11O9UlXN96zSGJc5qNVNhQtKVU=",
+      "power": "1000000000000000000"
+    }
+  ],
+  "accounts": [],
+  "ipc": {
+    "gateway": {
+      "subnet_id": "/r314159/t410fdoh27lsddz4my2v3e77qnxdp5vsjxkdfokc7sti",
+      "bottom_up_check_period": 30,
+      "msg_fee": "1000000000000",
+      "majority_percentage": 60,
+      "min_collateral": "1000000000000000000",
+      "active_validators_limit": 100
+    }
+}
+```

--- a/docs/running.md
+++ b/docs/running.md
@@ -672,14 +672,25 @@ Note that the script figures out the Alice's nonce on its own, so we don't have 
 
 ### Crate genesis from parent
 Fendermint includes a command to automatically create the genesis file for an IPC child subnet according to the information for the subnet available in its parent. Here's an example of the generation of a genesis file for a subnet that has already been bootstrapped in the parent.
-```console
-cargo run -p fendermint_app -- --network=test genesis --genesis-file test-network/genesis.json ipc from-parent --subnet-id <CHILD_SUBNET_ID> -p <PARENT_ENDPOINT> --parent-gateway <PARENT_GATEWAY_CONTRACT> --parent-registry <PARENT_REGISTRY_CONTRACT>
+```shell
+cargo run -p fendermint_app -- \
+    --network=test \
+    genesis --genesis-file test-network/genesis.json \
+    ipc from-parent --subnet-id <CHILD_SUBNET_ID> -p <PARENT_ENDPOINT> \
+    --parent-gateway <PARENT_GATEWAY_CONTRACT> \
+    --parent-registry <PARENT_REGISTRY_CONTRACT>
 ```
 
 Here's a sample execution of the command for an already bootstrapped subnet in `/r314159`:
-```console
-cargo run -p fendermint_app -- --network=test genesis --genesis-file test-network/genesis.json ipc from-parent --subnet-id /r314159/t410fdoh27lsddz4my2v3e77qnxdp5vsjxkdfokc7sti -p https://api.calibration.node.glif.io/rpc/v1 --parent-gateway 0x56948d2CFaa2EF355B8C08Ac925202db212146D1 --parent-registry 0x6A4884D2B6A597792dC68014D4B7C117cca5668e
-```
+```shell
+cargo run -p fendermint_app -- \
+    --network=test \
+    genesis --genesis-file test-network/genesis.json \
+    ipc from-parent \
+    --subnet-id /r314159/t410fdoh27lsddz4my2v3e77qnxdp5vsjxkdfokc7sti \
+    -p https://api.calibration.node.glif.io/rpc/v1 \
+    --parent-gateway 0x56948d2CFaa2EF355B8C08Ac925202db212146D1 \
+    --parent-registry 0x6A4884D2B6A597792dC68014D4B7C117cca5668e```
 
 Leading to the following genesis file:
 ```console

--- a/docs/running.md
+++ b/docs/running.md
@@ -673,12 +673,12 @@ Note that the script figures out the Alice's nonce on its own, so we don't have 
 ### Crate genesis from parent
 Fendermint includes a command to automatically create the genesis file for an IPC child subnet according to the information for the subnet available in its parent. Here's an example of the generation of a genesis file for a subnet that has already been bootstrapped in the parent.
 ```console
-cargo run -p fendermint_app -- --network=test genesis --genesis-file test-network/genesis.json ipc child-genesis --subnet-id <CHILD_SUBNET_ID> -p <PARENT_ENDPOINT> --parent-gateway <PARENT_GATEWAY_CONTRACT> --parent-registry <PARENT_REGISTRY_CONTRACT>
+cargo run -p fendermint_app -- --network=test genesis --genesis-file test-network/genesis.json ipc from-parent --subnet-id <CHILD_SUBNET_ID> -p <PARENT_ENDPOINT> --parent-gateway <PARENT_GATEWAY_CONTRACT> --parent-registry <PARENT_REGISTRY_CONTRACT>
 ```
 
 Here's a sample execution of the command for an already bootstrapped subnet in `/r314159`:
 ```console
-cargo run -p fendermint_app -- --network=test genesis --genesis-file test-network/genesis.json ipc child-genesis --subnet-id /r314159/t410fdoh27lsddz4my2v3e77qnxdp5vsjxkdfokc7sti -p https://api.calibration.node.glif.io/rpc/v1 --parent-gateway 0x56948d2CFaa2EF355B8C08Ac925202db212146D1 --parent-registry 0x6A4884D2B6A597792dC68014D4B7C117cca5668e
+cargo run -p fendermint_app -- --network=test genesis --genesis-file test-network/genesis.json ipc from-parent --subnet-id /r314159/t410fdoh27lsddz4my2v3e77qnxdp5vsjxkdfokc7sti -p https://api.calibration.node.glif.io/rpc/v1 --parent-gateway 0x56948d2CFaa2EF355B8C08Ac925202db212146D1 --parent-registry 0x6A4884D2B6A597792dC68014D4B7C117cca5668e
 ```
 
 Leading to the following genesis file:

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -56,6 +56,7 @@ fvm_ipld_encoding = { workspace = true }
 fvm_shared = { workspace = true }
 ipc-sdk = { workspace = true }
 ipc_ipld_resolver = { workspace = true }
+ipc-provider = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/fendermint/app/options/Cargo.toml
+++ b/fendermint/app/options/Cargo.toml
@@ -21,3 +21,8 @@ cid = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_shared = { workspace = true }
 ipc-sdk = { workspace = true }
+primitives = { workspace = true }
+url = { workspace = true }
+
+
+fendermint_vm_actor_interface = { path = "../../vm/actor_interface" }

--- a/fendermint/app/options/src/genesis.rs
+++ b/fendermint/app/options/src/genesis.rs
@@ -121,7 +121,7 @@ pub struct GenesisIntoTendermintArgs {
 pub enum GenesisIpcCommands {
     /// Set all gateway parameters.
     Gateway(GenesisIpcGatewayArgs),
-    FromParent(GenesisFromParentArgs),
+    FromParent(Box<GenesisFromParentArgs>),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -160,11 +160,11 @@ pub struct GenesisFromParentArgs {
     #[arg(long, short)]
     pub parent_endpoint: url::Url,
 
-    /// IPC gateway of the parent
+    /// IPC gateway of the parent; 20 byte Ethereum address in 0x prefixed hex format
     #[arg(long, value_parser = parse_eth_address)]
     pub parent_gateway: Address,
 
-    /// IPC registry of the parent
+    /// IPC registry of the parent;  20 byte Ethereum address in 0x prefixed hex format
     #[arg(long, value_parser = parse_eth_address)]
     pub parent_registry: Address,
 

--- a/fendermint/app/options/src/genesis.rs
+++ b/fendermint/app/options/src/genesis.rs
@@ -6,8 +6,10 @@ use std::path::PathBuf;
 use clap::{Args, Subcommand, ValueEnum};
 use ipc_sdk::subnet_id::SubnetID;
 
-use super::parse::{parse_full_fil, parse_network_version, parse_percentage, parse_token_amount};
-use fvm_shared::{econ::TokenAmount, version::NetworkVersion};
+use super::parse::{
+    parse_eth_address, parse_full_fil, parse_network_version, parse_percentage, parse_token_amount,
+};
+use fvm_shared::{address::Address, econ::TokenAmount, version::NetworkVersion};
 
 #[derive(Debug, Clone, ValueEnum)]
 pub enum AccountKind {
@@ -119,6 +121,7 @@ pub struct GenesisIntoTendermintArgs {
 pub enum GenesisIpcCommands {
     /// Set all gateway parameters.
     Gateway(GenesisIpcGatewayArgs),
+    ChildGenesis(GenesisIpcChildGenesisArgs),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -129,9 +132,6 @@ pub struct GenesisIpcGatewayArgs {
 
     #[arg(long, short)]
     pub bottom_up_check_period: u64,
-
-    #[arg(long, short)]
-    pub top_down_check_period: u64,
 
     /// Minimum collateral requirement for subnet in full FIL units.
     #[arg(long, short = 'c', value_parser = parse_full_fil)]
@@ -148,4 +148,35 @@ pub struct GenesisIpcGatewayArgs {
     /// Maximum number of active validators.
     #[arg(long, short = 'v', default_value = "100")]
     pub active_validators_limit: u16,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct GenesisIpcChildGenesisArgs {
+    /// Child subnet for with the genesis file is being created
+    #[arg(long, short)]
+    pub subnet_id: SubnetID,
+
+    /// Endpoint to the RPC of the child subnet's parent
+    #[arg(long, short)]
+    pub parent_endpoint: url::Url,
+
+    /// IPC gateway of the parent
+    #[arg(long, short, value_parser = parse_eth_address)]
+    pub parent_gateway: Address,
+
+    /// IPC registry of the parent
+    #[arg(long, short, value_parser = parse_eth_address)]
+    pub parent_registry: Address,
+
+    /// Network version, governs which set of built-in actors to use.
+    #[arg(long, short = 'v', default_value = "18", value_parser = parse_network_version)]
+    pub network_version: NetworkVersion,
+
+    /// Base fee for running transactions in atto.
+    #[arg(long, short = 'f', value_parser = parse_token_amount)]
+    pub base_fee: TokenAmount,
+
+    /// Number of decimals to use during converting FIL to Power.
+    #[arg(long, short, default_value = "3")]
+    pub power_scale: i8,
 }

--- a/fendermint/app/options/src/genesis.rs
+++ b/fendermint/app/options/src/genesis.rs
@@ -121,7 +121,7 @@ pub struct GenesisIntoTendermintArgs {
 pub enum GenesisIpcCommands {
     /// Set all gateway parameters.
     Gateway(GenesisIpcGatewayArgs),
-    ChildGenesis(GenesisIpcChildGenesisArgs),
+    FromParent(GenesisFromParentArgs),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -151,7 +151,7 @@ pub struct GenesisIpcGatewayArgs {
 }
 
 #[derive(Args, Debug, Clone)]
-pub struct GenesisIpcChildGenesisArgs {
+pub struct GenesisFromParentArgs {
     /// Child subnet for with the genesis file is being created
     #[arg(long, short)]
     pub subnet_id: SubnetID,

--- a/fendermint/app/options/src/genesis.rs
+++ b/fendermint/app/options/src/genesis.rs
@@ -161,11 +161,11 @@ pub struct GenesisIpcChildGenesisArgs {
     pub parent_endpoint: url::Url,
 
     /// IPC gateway of the parent
-    #[arg(long, short, value_parser = parse_eth_address)]
+    #[arg(long, value_parser = parse_eth_address)]
     pub parent_gateway: Address,
 
     /// IPC registry of the parent
-    #[arg(long, short, value_parser = parse_eth_address)]
+    #[arg(long, value_parser = parse_eth_address)]
     pub parent_registry: Address,
 
     /// Network version, governs which set of built-in actors to use.
@@ -177,6 +177,6 @@ pub struct GenesisIpcChildGenesisArgs {
     pub base_fee: TokenAmount,
 
     /// Number of decimals to use during converting FIL to Power.
-    #[arg(long, short, default_value = "3")]
+    #[arg(long, default_value = "3")]
     pub power_scale: i8,
 }

--- a/fendermint/app/options/src/genesis.rs
+++ b/fendermint/app/options/src/genesis.rs
@@ -173,7 +173,7 @@ pub struct GenesisIpcChildGenesisArgs {
     pub network_version: NetworkVersion,
 
     /// Base fee for running transactions in atto.
-    #[arg(long, short = 'f', value_parser = parse_token_amount)]
+    #[arg(long, short = 'f', value_parser = parse_token_amount, default_value = "1000")]
     pub base_fee: TokenAmount,
 
     /// Number of decimals to use during converting FIL to Power.

--- a/fendermint/app/options/src/genesis.rs
+++ b/fendermint/app/options/src/genesis.rs
@@ -161,11 +161,11 @@ pub struct GenesisFromParentArgs {
     pub parent_endpoint: url::Url,
 
     /// IPC gateway of the parent; 20 byte Ethereum address in 0x prefixed hex format
-    #[arg(long, value_parser = parse_eth_address)]
+    #[arg(long, value_parser = parse_eth_address, default_value = "0xff00000000000000000000000000000000000064")]
     pub parent_gateway: Address,
 
     /// IPC registry of the parent;  20 byte Ethereum address in 0x prefixed hex format
-    #[arg(long, value_parser = parse_eth_address)]
+    #[arg(long, value_parser = parse_eth_address, default_value = "0xff00000000000000000000000000000000000065")]
     pub parent_registry: Address,
 
     /// Network version, governs which set of built-in actors to use.

--- a/fendermint/app/options/src/parse.rs
+++ b/fendermint/app/options/src/parse.rs
@@ -94,3 +94,10 @@ pub fn parse_network(s: &str) -> Result<Network, String> {
         }
     }
 }
+
+pub fn parse_eth_address(s: &str) -> Result<Address, String> {
+    match primitives::EthAddress::from_str(&s) {
+        Ok(a) => Ok(a.into()),
+        Err(e) => Err(format!("not a valid ethereum address: {e}")),
+    }
+}

--- a/fendermint/app/options/src/parse.rs
+++ b/fendermint/app/options/src/parse.rs
@@ -96,7 +96,7 @@ pub fn parse_network(s: &str) -> Result<Network, String> {
 }
 
 pub fn parse_eth_address(s: &str) -> Result<Address, String> {
-    match primitives::EthAddress::from_str(&s) {
+    match primitives::EthAddress::from_str(s) {
         Ok(a) => Ok(a.into()),
         Err(e) => Err(format!("not a valid ethereum address: {e}")),
     }

--- a/fendermint/app/src/cmd/genesis.rs
+++ b/fendermint/app/src/cmd/genesis.rs
@@ -4,7 +4,6 @@
 use anyhow::{anyhow, Context};
 use fendermint_app::APP_VERSION;
 use fendermint_crypto::PublicKey;
-use fendermint_vm_message::conv::from_eth::to_fvm_tokens;
 use fvm_shared::address::Address;
 use ipc_provider::config::subnet::{EVMSubnet, SubnetConfig};
 use ipc_provider::IpcProvider;
@@ -303,10 +302,9 @@ async fn new_child_genesis(
 
     for v in genesis_info.validators {
         let pk = PublicKey::parse_slice(&v.metadata, None)?;
-        let c = to_fvm_tokens(&v.weight);
         genesis.validators.push(Validator {
             public_key: ValidatorKey(pk),
-            power: Collateral(c),
+            power: Collateral(v.weight),
         })
     }
 

--- a/fendermint/app/src/cmd/genesis.rs
+++ b/fendermint/app/src/cmd/genesis.rs
@@ -260,7 +260,10 @@ async fn new_child_genesis(
     let parent_provider = IpcProvider::new_with_subnet(
         None,
         ipc_provider::config::Subnet {
-            id: args.subnet_id.clone(),
+            id: args
+                .subnet_id
+                .parent()
+                .ok_or_else(|| anyhow!("subnet is not a child"))?,
             config: SubnetConfig::Fevm(EVMSubnet {
                 provider_http: args.parent_endpoint.clone(),
                 auth_token: None,

--- a/fendermint/app/src/cmd/genesis.rs
+++ b/fendermint/app/src/cmd/genesis.rs
@@ -84,8 +84,8 @@ cmd! {
     match self {
         GenesisIpcCommands::Gateway(args) =>
             set_ipc_gateway(&genesis_file, args),
-        GenesisIpcCommands::ChildGenesis(args) =>
-            new_child_genesis(&genesis_file, args).await
+        GenesisIpcCommands::FromParent(args) =>
+            new_genesis_from_parent(&genesis_file, args).await
     }
   }
 }
@@ -251,9 +251,9 @@ fn set_ipc_gateway(genesis_file: &PathBuf, args: &GenesisIpcGatewayArgs) -> anyh
     })
 }
 
-async fn new_child_genesis(
+async fn new_genesis_from_parent(
     genesis_file: &PathBuf,
-    args: &GenesisIpcChildGenesisArgs,
+    args: &GenesisFromParentArgs,
 ) -> anyhow::Result<()> {
     // provider with the parent.
     let parent_provider = IpcProvider::new_with_subnet(

--- a/fendermint/app/src/cmd/genesis.rs
+++ b/fendermint/app/src/cmd/genesis.rs
@@ -9,7 +9,6 @@ use fvm_shared::address::Address;
 use ipc_provider::config::subnet::{EVMSubnet, SubnetConfig};
 use ipc_provider::IpcProvider;
 use std::path::PathBuf;
-use std::str::FromStr;
 
 use fendermint_vm_actor_interface::eam::EthAddress;
 use fendermint_vm_core::Timestamp;
@@ -263,7 +262,7 @@ async fn new_child_genesis(
         ipc_provider::config::Subnet {
             id: args.subnet_id.clone(),
             config: SubnetConfig::Fevm(EVMSubnet {
-                provider_http: args.parent_endpoint,
+                provider_http: args.parent_endpoint.clone(),
                 auth_token: None,
                 registry_addr: args.parent_registry,
                 gateway_addr: args.parent_gateway,
@@ -284,7 +283,7 @@ async fn new_child_genesis(
             active_validators_limit: genesis_info.active_validators_limit,
         },
     };
-    let genesis = Genesis {
+    let mut genesis = Genesis {
         // We set the genesis epoch as the genesis timestamp so it can be
         // generated deterministically by all participants
         // genesis_epoch should be a positive number, we can afford panicking
@@ -304,7 +303,7 @@ async fn new_child_genesis(
         let c = to_fvm_tokens(&v.weight);
         genesis.validators.push(Validator {
             public_key: ValidatorKey(pk),
-            power: Collateral(c).into_power(genesis.power_scale),
+            power: Collateral(c),
         })
     }
 

--- a/fendermint/testing/smoke-test/scripts/init.sh
+++ b/fendermint/testing/smoke-test/scripts/init.sh
@@ -60,7 +60,6 @@ fendermint \
   genesis --genesis-file $GENESIS_FILE \
   ipc gateway \
     --subnet-id /r0 \
-    --top-down-check-period 10 \
     --bottom-up-check-period 10 \
     --min-collateral 1 \
     --msg-fee 10 \

--- a/fendermint/vm/genesis/src/arb.rs
+++ b/fendermint/vm/genesis/src/arb.rs
@@ -123,7 +123,6 @@ impl Arbitrary for ipc::GatewayParams {
             subnet_id: ArbSubnetID::arbitrary(g).0,
             // Gateway constructor would reject 0.
             bottom_up_check_period: u64::arbitrary(g).max(1),
-            top_down_check_period: u64::arbitrary(g),
             // Gateway constructor would reject 0.
             min_collateral: ArbTokenAmount::arbitrary(g)
                 .0

--- a/fendermint/vm/genesis/src/lib.rs
+++ b/fendermint/vm/genesis/src/lib.rs
@@ -209,7 +209,6 @@ pub mod ipc {
         #[serde_as(as = "IsHumanReadable")]
         pub subnet_id: SubnetID,
         pub bottom_up_check_period: u64,
-        pub top_down_check_period: u64,
         #[serde_as(as = "IsHumanReadable")]
         pub msg_fee: TokenAmount,
         pub majority_percentage: u8,

--- a/infra/scripts/node.toml
+++ b/infra/scripts/node.toml
@@ -95,7 +95,6 @@ script = """
 cwd = "./target/release"
 script = """
 ./fendermint genesis --genesis-file ${GENESIS_FILE} ipc gateway --subnet-id /r0 \
-    --top-down-check-period 10 \
     --bottom-up-check-period 10 \
     --msg-fee 10 \
     --majority-percentage 67

--- a/infra/scripts/testnet.toml
+++ b/infra/scripts/testnet.toml
@@ -156,7 +156,6 @@ done
 
 ./fendermint genesis --genesis-file $BASE_DIR/genesis.json ipc gateway \
     --subnet-id /r0 \
-    --top-down-check-period 10 \
     --bottom-up-check-period 10 \
     --msg-fee 10 \
     --majority-percentage 67 \


### PR DESCRIPTION
Closes #306 

This PR implements a new genesis command to generate the genesis file for a child subnet from the information available for the child in the parent (after it has been bootstrapped successfully). 