### PR TITLE
FM-287: Bottom up burn decrease circ supply

### DIFF
--- a/fendermint/testing/contract-test/tests/smt_staking.rs
+++ b/fendermint/testing/contract-test/tests/smt_staking.rs
@@ -16,7 +16,7 @@ use fendermint_testing::{arb::ArbTokenAmount, smt::StateMachine, state_machine_t
 
 mod staking;
 
-use fendermint_vm_interpreter::fvm::state::ipc::abi_hash;
+use fendermint_vm_actor_interface::ipc::abi_hash;
 use fendermint_vm_message::conv::from_fvm;
 use ipc_actors_abis::subnet_actor_getter_facet;
 use staking::machine::StakingMachine;

--- a/fendermint/testing/contract-test/tests/smt_staking.rs
+++ b/fendermint/testing/contract-test/tests/smt_staking.rs
@@ -16,7 +16,7 @@ use fendermint_testing::{arb::ArbTokenAmount, smt::StateMachine, state_machine_t
 
 mod staking;
 
-use fendermint_vm_actor_interface::ipc::abi_hash;
+use fendermint_vm_actor_interface::ipc::{abi_hash, AbiHash};
 use fendermint_vm_message::conv::from_fvm;
 use ipc_actors_abis::subnet_actor_getter_facet;
 use staking::machine::StakingMachine;
@@ -82,6 +82,7 @@ fn prop_cross_msgs_hash() {
             fendermint_testing::smt::ensure_has_randomness(u)?;
 
             // It doesn't seem to actually matter whether we pass these as tuples or arrays.
+            let cross_msgs_hash = cross_msgs.clone().abi_hash();
             let cross_msgs_hash_0 = abi_hash(cross_msgs.clone());
             let cross_msgs_hash_1 = abi_hash((cross_msgs.clone(),));
             let cross_msgs_hash_2 = abi_hash(((cross_msgs.clone(),),));
@@ -91,6 +92,7 @@ fn prop_cross_msgs_hash() {
                 .cross_msgs_hash(&mut exec_state, cross_msgs)
                 .expect("failed to call cross_msgs_hash");
 
+            assert_eq!(cross_msgs_hash, hash, "impl OK");
             assert_eq!(cross_msgs_hash_0, hash, "array OK");
             assert_eq!(cross_msgs_hash_1, hash, "tuple of array OK");
             assert_ne!(cross_msgs_hash_2, hash, "tuple of tuple of array NOT OK");

--- a/fendermint/testing/contract-test/tests/staking/machine.rs
+++ b/fendermint/testing/contract-test/tests/staking/machine.rs
@@ -9,15 +9,11 @@ use fendermint_crypto::{PublicKey, SecretKey};
 use fendermint_testing::smt::StateMachine;
 use fendermint_vm_actor_interface::{
     eam::EthAddress,
-    ipc::{subnet::SubnetActorErrors, subnet_id_to_eth},
+    ipc::{abi_hash, subnet::SubnetActorErrors, subnet_id_to_eth},
 };
 use fendermint_vm_genesis::{Collateral, Validator, ValidatorKey};
 use fendermint_vm_interpreter::fvm::{
-    state::{
-        fevm::ContractResult,
-        ipc::{abi_hash, GatewayCaller},
-        FvmExecState,
-    },
+    state::{fevm::ContractResult, ipc::GatewayCaller, FvmExecState},
     store::memory::MemoryBlockstore,
 };
 use fendermint_vm_message::{conv::from_fvm, signed::sign_secp256k1};

--- a/fendermint/testing/contract-test/tests/staking/machine.rs
+++ b/fendermint/testing/contract-test/tests/staking/machine.rs
@@ -9,7 +9,7 @@ use fendermint_crypto::{PublicKey, SecretKey};
 use fendermint_testing::smt::StateMachine;
 use fendermint_vm_actor_interface::{
     eam::EthAddress,
-    ipc::{abi_hash, subnet::SubnetActorErrors, subnet_id_to_eth},
+    ipc::{subnet::SubnetActorErrors, subnet_id_to_eth, AbiHash},
 };
 use fendermint_vm_genesis::{Collateral, Validator, ValidatorKey};
 use fendermint_vm_interpreter::fvm::{
@@ -278,7 +278,7 @@ impl StateMachine for StakingMachine {
                 // What I'm mainly interested in is whether the ABI hash is calculated correctly
                 // for a vector, which we can test by trying to pass the empty vector as a tuple.
                 let cross_messages = Vec::<subnet_manager::CrossMsg>::new();
-                let cross_messages_hash = abi_hash(cross_messages);
+                let cross_messages_hash = cross_messages.abi_hash();
 
                 let (root, route) = subnet_id_to_eth(&system.subnet_id).unwrap();
 
@@ -289,10 +289,7 @@ impl StateMachine for StakingMachine {
                     next_configuration_number: *next_configuration_number,
                     cross_messages_hash,
                 };
-
-                // Checkpoint has to be a tuple to match Solidity.
-                let checkpoint_tuple = (checkpoint.clone(),);
-                let checkpoint_hash = abi_hash(checkpoint_tuple);
+                let checkpoint_hash = checkpoint.clone().abi_hash();
 
                 let mut signatures = Vec::new();
 

--- a/fendermint/vm/actor_interface/src/ipc.rs
+++ b/fendermint/vm/actor_interface/src/ipc.rs
@@ -6,7 +6,9 @@
 // Solidity contracts during genesis.
 
 use anyhow::Context;
+use ethers::core::abi::Tokenize;
 use ethers::core::types as et;
+use ethers::core::utils::keccak256;
 use fendermint_vm_genesis::{Power, Validator};
 use fvm_shared::address::Error as AddressError;
 use fvm_shared::address::Payload;
@@ -195,6 +197,15 @@ pub fn subnet_id_to_eth(subnet_id: &SubnetID) -> Result<(u64, Vec<et::Address>),
         route.push(et::H160::from(addr.0))
     }
     Ok((subnet_id.root_id(), route))
+}
+
+/// Hash some value in the same way we'd hash it in Solidity.
+///
+/// Be careful that if we have to hash a single struct,
+/// Solidity's `abi.encode` function will treat it as a tuple,
+/// so it has to be passed as a tuple in Rust. Vectors are fine.
+pub fn abi_hash<T: Tokenize>(value: T) -> [u8; 32] {
+    keccak256(ethers::abi::encode(&value.into_tokens()))
 }
 
 pub mod gateway {

--- a/fendermint/vm/interpreter/src/fvm/checkpoint.rs
+++ b/fendermint/vm/interpreter/src/fvm/checkpoint.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 
 use anyhow::{anyhow, Context};
 use fendermint_crypto::PublicKey;
+use fendermint_vm_actor_interface::ipc::AbiHash;
 use fendermint_vm_genesis::Collateral;
 use fendermint_vm_genesis::PowerScale;
 use fendermint_vm_message::conv::from_eth;
@@ -74,9 +75,13 @@ where
                 .context("failed to apply validator changes")?;
 
             // Retrieve the bottom-up messages so we can put their hash into the checkpoint.
-            let cross_messages_hash = gateway
-                .bottom_up_msgs_hash(state, height.value())
-                .context("failed to retrieve bottom-up messages hash")?;
+            let cross_msgs = gateway
+                .bottom_up_msgs(state, height.value())
+                .context("failed to retrieve bottom-up messages")?;
+
+            // TODO: circ_supply
+
+            let cross_messages_hash = cross_msgs.abi_hash();
 
             // Construct checkpoint.
             let checkpoint = BottomUpCheckpoint {

--- a/fendermint/vm/interpreter/src/fvm/checkpoint.rs
+++ b/fendermint/vm/interpreter/src/fvm/checkpoint.rs
@@ -83,7 +83,16 @@ where
             // Sum up the value leaving the subnet as part of the bottom-up messages.
             let burnt_tokens = tokens_to_burn(&cross_msgs);
 
-            // TODO: Should we actually take this from the gateway balance? Or did it already get burnt?
+            // NOTE: Unlike when we minted tokens for the gateway by modifying its balance,
+            // we don't have to burn them here, because it's already being done in
+            // https://github.com/consensus-shipyard/ipc-solidity-actors/pull/263
+            // by sending the funds to the BURNTFUNDS_ACTOR.
+            // Ostensibly we could opt _not_ to decrease the circ supply here, but rather
+            // look up the burnt funds balance at the beginning of each block and subtract
+            // it from the monotonically increasing supply, in which case it could reflect
+            // a wider range of burning activity than just IPC.
+            // It might still be inconsistent if someone uses another address for burning tokens.
+            // By decreasing here, at least `circ_supply` is consistent with IPC.
             state.update_circ_supply(|circ_supply| {
                 *circ_supply -= burnt_tokens;
             });

--- a/fendermint/vm/interpreter/src/fvm/state/ipc.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/ipc.rs
@@ -3,7 +3,6 @@
 
 use anyhow::{anyhow, Context};
 use ethers::types as et;
-use ethers::{abi::Tokenize, utils::keccak256};
 
 use fendermint_vm_message::conv::from_fvm;
 use fvm_ipld_blockstore::Blockstore;
@@ -12,7 +11,7 @@ use fvm_shared::ActorID;
 use fendermint_crypto::SecretKey;
 use fendermint_vm_actor_interface::{
     eam::EthAddress,
-    ipc::{ValidatorMerkleTree, GATEWAY_ACTOR_ID},
+    ipc::{abi_hash, ValidatorMerkleTree, GATEWAY_ACTOR_ID},
 };
 use fendermint_vm_genesis::{Power, Validator};
 use fendermint_vm_message::signed::sign_secp256k1;
@@ -268,12 +267,4 @@ impl<DB: Blockstore> GatewayCaller<DB> {
             .call(state, |c| c.get_latest_parent_finality())?;
         Ok(IPCParentFinality::try_from(r)?)
     }
-}
-
-/// Hash some value in the same way we'd hash it in Solidity.
-///
-/// Be careful that if we have to hash a single struct, Solidity's `abi.encode`
-/// function will treat it as a tuple.
-pub fn abi_hash<T: Tokenize>(value: T) -> [u8; 32] {
-    keccak256(ethers::abi::encode(&value.into_tokens()))
 }

--- a/fendermint/vm/interpreter/src/fvm/topdown.rs
+++ b/fendermint/vm/interpreter/src/fvm/topdown.rs
@@ -9,8 +9,9 @@ use crate::fvm::FvmApplyRet;
 use anyhow::Context;
 use fendermint_vm_topdown::{BlockHeight, IPCParentFinality, ParentViewProvider};
 use fvm_ipld_blockstore::Blockstore;
-use fvm_shared::econ::TokenAmount;
 use ipc_sdk::cross::CrossMsg;
+
+use super::state::ipc::tokens_to_mint;
 
 /// Commit the parent finality. Returns the height that the previous parent finality is committed and
 /// the committed finality itself. If there is no parent finality committed, genesis epoch is returned.
@@ -47,14 +48,14 @@ pub async fn execute_topdown_msgs<DB>(
 where
     DB: Blockstore + Sync + Send + 'static,
 {
-    let total_value: TokenAmount = messages.iter().map(|a| a.msg.value.clone()).sum();
+    let minted_tokens = tokens_to_mint(&messages);
 
     gateway_caller
-        .mint_to_gateway(state, total_value.clone())
+        .mint_to_gateway(state, minted_tokens.clone())
         .context("failed to mint to gateway")?;
 
     state.update_circ_supply(|circ_supply| {
-        *circ_supply += total_value;
+        *circ_supply += minted_tokens;
     });
 
     gateway_caller.apply_cross_messages(state, messages)


### PR DESCRIPTION
Closes #287 

Changes the checkpoint creation process to include the decrease of circulating supply by the values that are included in the bottom-up messages. 

Introduced some functions to help keep things consistent:
* An `AbiHash` trait is implemented for anything we want to hash in Solidity and match that hash in Rust, to take out the guesswork from tuple or no-tuple. Seemingly unrelated but since I had to retrieve all the cross messages, whereas previously I got the hash directly from the gateway caller, I didn't want to use the naked `abi_hash` function from the interpreter. 
* `tokens_to_mint` and `tokens_to_burn` to sum up the value in cross messages.

### Questions
* We ignored the `fee` during minting, so I assumed it meant that the fees will be collected in the target network. => _Changed both the minting and the release to add both fees and values_.
* Do we have to modify the balance of the gateway to burn these tokens, or did the contracts already burn the appropriate amount? => _The contract already burned, so we just modify the circulating supply to match it._

### Caveat

The circulating supply will reflect the changes from IPC, but it will not show what is truly the unburnt token amount in the subnet, because people can use any inaccessible address for burning, not just the `BURNTFUNDS_ACTOR`. 
