### PR TITLE
FM-220: Remove tx.hash from the filter, index block.hash

### DIFF
--- a/fendermint/eth/api/src/conv/from_tm.rs
+++ b/fendermint/eth/api/src/conv/from_tm.rs
@@ -461,20 +461,20 @@ fn message_hash(tx: &[u8]) -> tendermint::Hash {
     tendermint::Hash::Sha256(hash)
 }
 
-/// Best effort to find and parse any `eco.hash` attribute emitted among the events.
-fn find_eth_hash(events: &[abci::Event]) -> Option<et::TxHash> {
+/// Best effort to find and parse any `<kind>.hash` attribute emitted among the events.
+pub fn find_hash_event(kind: &str, events: &[abci::Event]) -> Option<et::H256> {
     events
         .iter()
-        .find(|e| e.kind == "eth")
+        .find(|e| e.kind == kind)
         .and_then(|e| e.attributes.iter().find(|a| a.key == "hash"))
         .and_then(|a| hex::decode(&a.value).ok())
         .filter(|bz| bz.len() == 32)
-        .map(|bz| et::TxHash::from_slice(&bz))
+        .map(|bz| et::H256::from_slice(&bz))
 }
 
 // Calculate some kind of hash for the message, preferrably one the tools expect.
 pub fn msg_hash(events: &[Event], tx: &[u8]) -> et::TxHash {
-    if let Some(h) = find_eth_hash(events) {
+    if let Some(h) = find_hash_event("eth", events) {
         h
     } else {
         // Return the default hash, at least there is something

--- a/fendermint/eth/api/src/filters.rs
+++ b/fendermint/eth/api/src/filters.rs
@@ -27,7 +27,7 @@ use tokio::sync::{
 };
 
 use crate::{
-    conv::from_tm::{self, map_rpc_block_txs, msg_hash},
+    conv::from_tm::{self, find_hash_event, map_rpc_block_txs, msg_hash},
     error::JsonRpcError,
     handlers::ws::{MethodNotification, Notification},
     state::{enrich_block, WebSocketSender},
@@ -298,10 +298,13 @@ where
                 //     })
                 // }
 
-                // TODO: There is no easy way here to tell the block hash. Maybe it has been given in a preceding event,
+                // There is no easy way here to tell the block hash. Maybe it has been given in a preceding event,
                 // but other than that our only option is to query the Tendermint API. If we do that we should have caching,
                 // otherwise all the transactions in a block hammering the node will act like a DoS attack.
-                let block_hash = et::H256::default();
+                // Or we can add it to the indexed fields.
+                let block_hash =
+                    find_hash_event("block", &tx_result.result.events).unwrap_or_default();
+
                 let block_number = et::U64::from(tx_result.height);
 
                 let transaction_hash = msg_hash(&tx_result.result.events, &tx_result.tx);

--- a/fendermint/eth/api/src/filters.rs
+++ b/fendermint/eth/api/src/filters.rs
@@ -104,9 +104,12 @@ impl FilterKind {
                     Query::from(EventType::Tx)
                 };
 
-                if let Some(block_hash) = filter.get_block_hash() {
-                    // TODO #220: This looks wrong, tx.hash is the transaction hash, not the block.
-                    query = query.and_eq("tx.hash", hex::encode(block_hash.0));
+                if let Some(_block_hash) = filter.get_block_hash() {
+                    // Currently we only use these filters for subscribing to future events,
+                    // we don't go back to retireve past ones (although I think Lotus does that).
+                    // As such, it is impossible to subscribe to future block hashes, they are unknown.
+                    // We could add a `block.hash` to the index, but there are other ways to find transactions
+                    // in a block, so it would be storing data for little reason.
                 }
                 if let Some(from_block) = filter.get_from_block() {
                     query = query.and_gte("tx.height", from_block.as_u64());

--- a/fendermint/vm/interpreter/src/fvm/state/mod.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/mod.rs
@@ -12,7 +12,7 @@ mod snapshot;
 use std::sync::Arc;
 
 pub use check::FvmCheckState;
-pub use exec::{FvmExecState, FvmStateParams, FvmUpdatableParams};
+pub use exec::{BlockHash, FvmExecState, FvmStateParams, FvmUpdatableParams};
 pub use genesis::{empty_state_tree, FvmGenesisState};
 pub use query::FvmQueryState;
 pub use snapshot::{Snapshot, V1Snapshot};


### PR DESCRIPTION
Closes #220  

Initially I wanted to add `block.hash` to the indexes but decided against it, and just removed the incorrect filtering of `tx.hash`. 

Then I realised that we can use an index on `block.hash` in filters, where it didn't use to be available, but Ethereum clients expect it.