### PR TITLE
FM-322: Index message.to and message.from

### DIFF
--- a/fendermint/app/src/tmconv.rs
+++ b/fendermint/app/src/tmconv.rs
@@ -64,7 +64,7 @@ pub fn to_deliver_tx(ret: FvmApplyRet, domain_hash: Option<DomainHash>) -> respo
     let gas_used: i64 = receipt.gas_used.try_into().unwrap_or(i64::MAX);
 
     let data: bytes::Bytes = receipt.return_data.to_vec().into();
-    let mut events = to_events("message", ret.apply_ret.events, ret.emitters);
+    let mut events = to_events("event", ret.apply_ret.events, ret.emitters);
 
     // Emit an event which causes Tendermint to index our transaction with a custom hash.
     if let Some(h) = domain_hash {
@@ -118,7 +118,7 @@ pub fn to_end_block(power_table: Vec<Validator<Power>>) -> anyhow::Result<respon
 
 /// Map the return values from cron operations.
 pub fn to_begin_block(ret: FvmApplyRet) -> response::BeginBlock {
-    let events = to_events("begin", ret.apply_ret.events, ret.emitters);
+    let events = to_events("event", ret.apply_ret.events, ret.emitters);
 
     response::BeginBlock { events }
 }

--- a/fendermint/app/src/tmconv.rs
+++ b/fendermint/app/src/tmconv.rs
@@ -72,7 +72,7 @@ pub fn to_deliver_tx(ret: FvmApplyRet, domain_hash: Option<DomainHash>) -> respo
     }
 
     // Emit general message metadata.
-    events.push(to_meta_event(ret.from, ret.to));
+    events.push(to_message_event(ret.from, ret.to));
 
     response::DeliverTx {
         code: to_code(receipt.exit_code),
@@ -124,7 +124,6 @@ pub fn to_begin_block(ret: FvmApplyRet) -> response::BeginBlock {
 }
 
 /// Convert events to key-value pairs.
-///
 ///
 /// Fot the EVM, they are returned like so:
 ///
@@ -196,13 +195,17 @@ pub fn to_domain_hash_event(domain_hash: &DomainHash) -> Event {
     )
 }
 
-pub fn to_meta_event(from: Address, to: Address) -> Event {
+/// Event about the message itself.
+pub fn to_message_event(from: Address, to: Address) -> Event {
     let attr = |k: &str, v: Address| EventAttribute {
         key: k.to_string(),
         value: v.to_string(),
         index: true,
     };
-    Event::new("tx".to_string(), vec![attr("from", from), attr("to", to)])
+    Event::new(
+        "message".to_string(),
+        vec![attr("from", from), attr("to", to)],
+    )
 }
 
 /// Map to query results.

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -860,8 +860,14 @@ where
                         _ => continue,
                     };
 
+                    let emitters = from_tm::collect_emitters(&tx_result.events);
+
                     // Filter by address.
-                    if !addrs.is_empty() && !addrs.contains(&msg.message().from) {
+                    if !addrs.is_empty()
+                        && !addrs.contains(&msg.message().from)
+                        && !addrs.contains(&msg.message().to)
+                        && addrs.intersection(&emitters).next().is_none()
+                    {
                         continue;
                     }
 

--- a/fendermint/eth/api/src/conv/from_tm.rs
+++ b/fendermint/eth/api/src/conv/from_tm.rs
@@ -370,7 +370,7 @@ pub fn to_logs(
     log_index_start: usize,
 ) -> anyhow::Result<Vec<et::Log>> {
     let mut logs = Vec::new();
-    for (idx, event) in events.iter().filter(|e| e.kind == "message").enumerate() {
+    for (idx, event) in events.iter().filter(|e| e.kind == "event").enumerate() {
         // Lotus looks up an Ethereum address based on the actor ID:
         // https://github.com/filecoin-project/lotus/blob/6cc506f5cf751215be6badc94a960251c6453202/node/impl/full/eth.go#L1987
 

--- a/fendermint/eth/api/src/conv/from_tm.rs
+++ b/fendermint/eth/api/src/conv/from_tm.rs
@@ -499,10 +499,11 @@ pub fn collect_emitters(events: &[abci::Event]) -> HashSet<Address> {
                 .find(|a| a.key == "emitter.id")
                 .and_then(|a| a.value.parse::<u64>().ok())
                 .map(Address::new_id),
-        ] {
-            if let Some(addr) = addr {
-                emitters.insert(addr);
-            }
+        ]
+        .into_iter()
+        .flatten()
+        {
+            emitters.insert(addr);
         }
     }
     emitters

--- a/fendermint/eth/api/src/filters.rs
+++ b/fendermint/eth/api/src/filters.rs
@@ -137,9 +137,9 @@ impl FilterKind {
                             queries.iter().map(|q| {
                                 if let Ok(id) = addr.id() {
                                     // If it was a masked ID.
-                                    q.clone().and_eq("message.emitter.id", id.to_string())
+                                    q.clone().and_eq("event.emitter.id", id.to_string())
                                 } else {
-                                    q.clone().and_eq("message.emitter.deleg", addr.to_string())
+                                    q.clone().and_eq("event.emitter.deleg", addr.to_string())
                                 }
                             })
                         })
@@ -154,7 +154,7 @@ impl FilterKind {
                             _ => vec![],
                         };
                         if !topics.is_empty() {
-                            let key = format!("message.t{}", i + 1);
+                            let key = format!("event.t{}", i + 1);
                             queries = topics
                                 .into_iter()
                                 .flat_map(|t| {
@@ -269,7 +269,7 @@ where
                 //                 gas_used: Some("5151233"),
                 //                 events: [
                 //                     Event {
-                //                         kind: "message",
+                //                         kind: "event",
                 //                         attributes: [
                 //                             EventAttribute { key: "emitter.id", value: "108", index: true },
                 //                             EventAttribute { key: "t1", value: "dd...b3ef", index: true },
@@ -284,11 +284,11 @@ where
                 //     },
                 //     events: Some(
                 //     {
-                //         "message.d": ["00...0064"],
-                //         "message.emitter.id": ["108"],
-                //         "message.t1": ["dd...b3ef"],
-                //         "message.t2": ["00...362f"],
-                //         "message.t3": ["00...44eb"],
+                //         "event.d": ["00...0064"],
+                //         "event.emitter.id": ["108"],
+                //         "event.t1": ["dd...b3ef"],
+                //         "event.t2": ["00...362f"],
+                //         "event.t3": ["00...44eb"],
                 //         "tm.event": ["Tx"],
                 //         "tx.hash": ["FA7339B4D9F6AF80AEDB03FC4BFBC1FDD9A62F97632EF8B79C98AAD7044C5BDB"],
                 //         "tx.height": ["1088"]
@@ -739,7 +739,7 @@ mod tests {
         .enumerate()
         {
             let q = queries[i].to_string();
-            let e = format!("tx.height >= 1234 AND message.emitter.id = '100' AND message.t1 = '{}' AND message.t2 = '{}' AND message.t3 = '{}'", hash_hex(t1), hash_hex("Alice"), hash_hex(t3));
+            let e = format!("tx.height >= 1234 AND event.emitter.id = '100' AND event.t1 = '{}' AND event.t2 = '{}' AND event.t3 = '{}'", hash_hex(t1), hash_hex("Alice"), hash_hex(t3));
             assert_eq!(q, e, "combination {i}");
         }
     }


### PR DESCRIPTION
Closes #322 

* Renames the current `message.*` events to `event.*` event, which are the events/logs emitted by contracts
* Adds `message.from` and `message.to` to the index
* Subscribes to all combinations of filters with `message.from` and `message.to` as well, just in case that's what the account is meant to match.
* `eth::get_log` matches emitters as well as `from` and `to` against any addresses in the filter.

I though about `tx.from` and `tx.to` but decided against it, so we leave these Tendermint provided `tx` values alone, and because we call them `message` in the FVM anyway, which `from` and `to` are part of, but `tx.hash` and `tx.height` aren't. 

I just noticed that all keys can accept a list of values, so instead of `eth.hash` we could have stuck to `tx.hash` and have two values both identify the same transaction. But then we couldn't tell which one to present to Ethereum clients, so that's no good.