### PR TITLE
FM-219: Filter duplicate transactions in subscriptions

### DIFF
--- a/fendermint/eth/api/src/conv/from_tm.rs
+++ b/fendermint/eth/api/src/conv/from_tm.rs
@@ -455,7 +455,7 @@ pub fn to_chain_message(tx: &[u8]) -> anyhow::Result<ChainMessage> {
 ///
 /// This is here for reference only and should not be returned to Ethereum tools which expect
 /// the hash to be based on RLP and Keccak256.
-fn message_hash(tx: &[u8]) -> tendermint::Hash {
+pub fn tx_hash(tx: &[u8]) -> tendermint::Hash {
     // based on how `tendermint::Header::hash` works.
     let hash = tendermint::crypto::default::Sha256::digest(tx);
     tendermint::Hash::Sha256(hash)
@@ -478,6 +478,6 @@ pub fn msg_hash(events: &[Event], tx: &[u8]) -> et::TxHash {
         h
     } else {
         // Return the default hash, at least there is something
-        et::TxHash::from_slice(message_hash(tx).as_bytes())
+        et::TxHash::from_slice(tx_hash(tx).as_bytes())
     }
 }

--- a/fendermint/eth/api/src/filters.rs
+++ b/fendermint/eth/api/src/filters.rs
@@ -15,6 +15,7 @@ use fendermint_vm_actor_interface::eam::EthAddress;
 use fendermint_vm_message::{chain::ChainMessage, query::FvmQueryHeight, signed::DomainHash};
 use futures::{Future, StreamExt};
 use fvm_shared::{address::Address, chainid::ChainID, error::ExitCode};
+use lru_time_cache::LruCache;
 use serde::Serialize;
 use tendermint_rpc::{
     event::{Event, EventData},
@@ -27,7 +28,7 @@ use tokio::sync::{
 };
 
 use crate::{
-    conv::from_tm::{self, map_rpc_block_txs, msg_hash},
+    conv::from_tm::{self, map_rpc_block_txs, msg_hash, tx_hash},
     error::JsonRpcError,
     handlers::ws::{MethodNotification, Notification},
     state::{enrich_block, WebSocketSender},
@@ -408,7 +409,24 @@ impl FilterDriver {
             .await
             .map(|state_params| ChainID::from(state_params.value.chain_id));
 
+        // Because there are multiple potentially overlapping subscriptions, we might see the same transaction twice,
+        // e.g. because we were interested in ones that emit events "A or B" we had to subscribe to "A" and also to "B",
+        // so if a transaction emits both "A" and "B" we'll get it twice. Most likely they will be at the same time,
+        // so a short time based cache should help get rid of the duplicates.
+        let mut tx_cache: LruCache<tendermint::Hash, bool> =
+            LruCache::with_expiry_duration(Duration::from_secs(60));
+
         while let Some(cmd) = self.rx.recv().await {
+            // Skip duplicate transactions. We won't see duplidate blocks because there is only 1 query for that.
+            if let FilterCommand::Update(ref event) = cmd {
+                if let EventData::Tx { ref tx_result } = event.data {
+                    let tx_hash = tx_hash(&tx_result.tx);
+                    if tx_cache.insert(tx_hash, true).is_some() {
+                        continue;
+                    }
+                }
+            }
+
             match self.state {
                 FilterState::Poll(ref mut state) => {
                     match cmd {


### PR DESCRIPTION
Closes #219 

Adds a time based LRU cache to the filter driver and skips duplicate transactions that follow each other within one minute. They should come pretty rapidly, so even that is more than enough time.