### PR TITLE
FIX: Use bookworm with libssl3

### DIFF
--- a/docker/local.Dockerfile
+++ b/docker/local.Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1
 
 # Builder
-FROM rust:1.73 as builder
+FROM rust:bookworm as builder
 
 RUN apt-get update && \
-  apt-get install -y build-essential clang cmake protobuf-compiler && \
+  apt-get install -y build-essential clang cmake protobuf-compiler libssl3 && \
   rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -18,7 +18,11 @@ RUN --mount=type=cache,target=$RUSTUP_HOME,from=rust,source=$RUSTUP_HOME \
 
 
 # Runner
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+  apt-get install -y libssl3 && \
+  rm -rf /var/lib/apt/lists/*
 
 ENV FM_HOME_DIR=/fendermint
 ENV HOME=$FM_HOME_DIR


### PR DESCRIPTION
Fixes `local.Dockerimage` to use Debian `bookworm` and install `libssl3` in both the builder and the runner to avoid this error when _running_ the `fendermint` image (e.g. using `make e2e`):

```
fendermint: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory
```

The reason for the change is because the latest (1.73) rust builder image switched to bookworm.

https://stackoverflow.com/questions/76508361/getting-error-while-loading-shared-libraries-libssl-so-1-1-when-running-docke