### PR TITLE
FIX: Remove unnecessary lib

### DIFF
--- a/docker/local.Dockerfile
+++ b/docker/local.Dockerfile
@@ -4,7 +4,7 @@
 FROM rust:bookworm as builder
 
 RUN apt-get update && \
-  apt-get install -y build-essential clang cmake protobuf-compiler libssl3 && \
+  apt-get install -y build-essential clang cmake protobuf-compiler && \
   rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
It was enough for the builder image to have `libssl3`. 

Follow up to https://github.com/consensus-shipyard/fendermint/pull/336