### PR TITLE
FIX: Remove EthAddress::into_non_masked

### DIFF
--- a/fendermint/testing/contract-test/src/ipc/registry.rs
+++ b/fendermint/testing/contract-test/src/ipc/registry.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Context;
 use fendermint_vm_actor_interface::eam::EthAddress;
+use fendermint_vm_actor_interface::init::builtin_actor_eth_addr;
 use fendermint_vm_actor_interface::ipc::SUBNETREGISTRY_ACTOR_ID;
 use fendermint_vm_interpreter::fvm::state::fevm::{ContractCaller, MockProvider, NoRevert};
 use fendermint_vm_interpreter::fvm::state::FvmExecState;
@@ -33,9 +34,9 @@ impl<DB> Default for RegistryCaller<DB> {
 
 impl<DB> RegistryCaller<DB> {
     pub fn new(actor_id: ActorID) -> Self {
-        let addr = EthAddress::from_id(actor_id);
+        let addr = builtin_actor_eth_addr(actor_id);
         Self {
-            addr: addr.into_non_masked(),
+            addr,
             registry: ContractCaller::new(addr, SubnetRegistry::new),
             _getter: ContractCaller::new(addr, SubnetActorGetterFacet::new),
             _manager: ContractCaller::new(addr, SubnetActorManagerFacet::new),

--- a/fendermint/vm/actor_interface/src/eam.rs
+++ b/fendermint/vm/actor_interface/src/eam.rs
@@ -60,16 +60,6 @@ impl EthAddress {
     pub fn is_masked_id(&self) -> bool {
         self.0[0] == 0xff && self.0[1..].starts_with(&[0u8; 11])
     }
-
-    pub fn into_non_masked(self) -> EthAddress {
-        if !self.is_masked_id() {
-            return self;
-        }
-        // Based on `hash20` in the EAM actor.
-        let eth_addr = cid::multihash::Code::Keccak256.digest(&self.0);
-        let eth_addr: [u8; 20] = eth_addr.digest()[12..32].try_into().unwrap();
-        Self(eth_addr)
-    }
 }
 
 impl Display for EthAddress {

--- a/fendermint/vm/actor_interface/src/init.rs
+++ b/fendermint/vm/actor_interface/src/init.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use anyhow::Context;
+use cid::multihash::MultihashDigest;
 use cid::Cid;
 use fendermint_vm_genesis::{Actor, ActorMeta};
 use fvm_ipld_blockstore::Blockstore;
@@ -20,9 +21,22 @@ define_singleton!(INIT { id: 1, code_id: 2 });
 pub type AddressMap = HashMap<Address, ActorID>;
 
 /// Delegated address of an Ethereum built-in actor.
-fn eth_builtin_deleg_addr(id: ActorID) -> Address {
+///
+/// This is based to what seems to be going on in the `CREATE_EXTERNAL` method
+/// of the EAM actor when it determines a robust address for an account ID,
+/// in that we take something known (a public key, or in this case the ID),
+/// hash it and truncate the results to 20 bytes.
+///
+/// But it's not a general rule of turning actor IDs into Ethereum addresses!
+/// It's just something we do to assign an address that looks like an Ethereum one.
+pub fn builtin_actor_eth_addr(id: ActorID) -> EthAddress {
     // The EVM actor would reject a delegated address that looks like an ID address, so let's hash it.
-    Address::from(EthAddress::from_id(id).into_non_masked())
+    // Based on `hash20` in the EAM actor:
+    // https://github.com/filecoin-project/builtin-actors/blob/v11.0.0/actors/eam/src/lib.rs#L213-L216
+    let eth_addr = EthAddress::from_id(id);
+    let eth_addr = cid::multihash::Code::Keccak256.digest(&eth_addr.0);
+    let eth_addr: [u8; 20] = eth_addr.digest()[12..32].try_into().unwrap();
+    EthAddress(eth_addr)
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
@@ -84,7 +98,7 @@ impl State {
 
         // Insert top-level EVM contracts which have fixed IDs.
         for id in eth_builtin_ids {
-            let addr = eth_builtin_deleg_addr(*id);
+            let addr = Address::from(builtin_actor_eth_addr(*id));
             address_map
                 .set(addr.to_bytes().into(), *id)
                 .context("cannot set ID of eth address")?;
@@ -92,7 +106,7 @@ impl State {
 
         // Insert dynamic EVM library contracts.
         for _ in 0..eth_library_count {
-            let addr = eth_builtin_deleg_addr(next_id);
+            let addr = Address::from(builtin_actor_eth_addr(next_id));
             address_map
                 .set(addr.to_bytes().into(), next_id)
                 .context("cannot set ID of eth address")?;

--- a/fendermint/vm/actor_interface/src/init.rs
+++ b/fendermint/vm/actor_interface/src/init.rs
@@ -22,7 +22,7 @@ pub type AddressMap = HashMap<Address, ActorID>;
 
 /// Delegated address of an Ethereum built-in actor.
 ///
-/// This is based to what seems to be going on in the `CREATE_EXTERNAL` method
+/// This is based on what seems to be going on in the `CREATE_EXTERNAL` method
 /// of the EAM actor when it determines a robust address for an account ID,
 /// in that we take something known (a public key, or in this case the ID),
 /// hash it and truncate the results to 20 bytes.

--- a/fendermint/vm/interpreter/src/fvm/state/genesis.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/genesis.rs
@@ -10,7 +10,8 @@ use fendermint_vm_actor_interface::{
     account::{self, ACCOUNT_ACTOR_CODE_ID},
     eam::{self, EthAddress},
     ethaccount::ETHACCOUNT_ACTOR_CODE_ID,
-    evm, init,
+    evm,
+    init::{self, builtin_actor_eth_addr},
     multisig::{self, MULTISIG_ACTOR_CODE_ID},
     system, EMPTY_ARR,
 };
@@ -298,7 +299,7 @@ where
         // When a contract is constructed the EVM actor verifies that it has an Ethereum delegated address.
         // This has been inserted into the Init actor state as well.
         let f0_addr = Address::new_id(id);
-        let f4_addr = Address::from(EthAddress::from_id(id).into_non_masked());
+        let f4_addr = Address::from(builtin_actor_eth_addr(id));
 
         let msg = Message {
             version: 0,

--- a/fendermint/vm/interpreter/src/fvm/state/ipc.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/ipc.rs
@@ -11,6 +11,7 @@ use fvm_shared::ActorID;
 use fendermint_crypto::SecretKey;
 use fendermint_vm_actor_interface::{
     eam::EthAddress,
+    init::builtin_actor_eth_addr,
     ipc::{AbiHash, ValidatorMerkleTree, GATEWAY_ACTOR_ID},
 };
 use fendermint_vm_genesis::{Power, Validator};
@@ -48,10 +49,10 @@ impl<DB> GatewayCaller<DB> {
     pub fn new(actor_id: ActorID) -> Self {
         // A masked ID works for invoking the contract, but internally the EVM uses a different
         // ID and if we used this address for anything like validating that the sender is the gateway,
-        // we'll face bitter disappointment. For that we have to use the hashed version.
-        let addr = EthAddress::from_id(actor_id);
+        // we'll face bitter disappointment. For that we have to use the delegated address we have in genesis.
+        let addr = builtin_actor_eth_addr(actor_id);
         Self {
-            addr: addr.into_non_masked(),
+            addr,
             getter: ContractCaller::new(addr, GatewayGetterFacet::new),
             router: ContractCaller::new(addr, GatewayRouterFacet::new),
         }


### PR DESCRIPTION
A discussion about how masked IDs should be avoided inside the EVM led to the realisation that adding `EthAddress::into_non_masked` in https://github.com/consensus-shipyard/fendermint/pull/319 as a convenience method was ill-advised because this is not a rule for this type, it's only one made up when I was working on the genesis process for the builtin Ethereum actor IDs, nothing else. They work because the association is manually inserted into the `Init` actor's state, but wouldn't work for any other actor ID which was created through the EAM actor.