### PR TITLE
FIX: Set the Tendermint RPC URL for the fendermint container

### DIFF
--- a/docker/local.Dockerfile
+++ b/docker/local.Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=$RUSTUP_HOME,from=rust,source=$RUSTUP_HOME \
 FROM debian:bookworm-slim
 
 RUN apt-get update && \
-  apt-get install -y libssl3 && \
+  apt-get install -y libssl3 ca-certificates && \
   rm -rf /var/lib/apt/lists/*
 
 ENV FM_HOME_DIR=/fendermint

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -64,9 +64,11 @@ cmd! {
 ///
 /// This method acts as our composition root.
 async fn run(settings: Settings) -> anyhow::Result<()> {
-    let client: tendermint_rpc::HttpClient =
-        tendermint_rpc::HttpClient::new(settings.tendermint_rpc_url()?)
-            .context("failed to create Tendermint client")?;
+    let tendermint_rpc_url = settings.tendermint_rpc_url()?;
+    tracing::info!("Connecting to Tendermint at {tendermint_rpc_url}");
+
+    let client: tendermint_rpc::HttpClient = tendermint_rpc::HttpClient::new(tendermint_rpc_url)
+        .context("failed to create Tendermint client")?;
 
     let validator = match settings.validator_key {
         Some(ref key) => {

--- a/fendermint/testing/smoke-test/Makefile.toml
+++ b/fendermint/testing/smoke-test/Makefile.toml
@@ -159,6 +159,7 @@ docker run \
   --volume ${TEST_SCRIPTS_DIR}:/scripts \
   --env FM_DATA_DIR=/data/fendermint/data \
   --env FM_CHAIN_NAME=${NETWORK_NAME} \
+  --env TENDERMINT_RPC_URL=http://${CMT_CONTAINER_NAME}:26657 \
   --env LOG_LEVEL=info \
   --entrypoint ${ENTRY} \
   ${FM_DOCKER_IMAGE} \

--- a/infra/Makefile.toml
+++ b/infra/Makefile.toml
@@ -60,7 +60,7 @@ ACTORS_BUNDLE = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/../builtin-actors/out
 # If this wasn't present, any wait task is skipped.
 CARGO_MAKE_WAIT_MILLISECONDS = 5000
 # This wait time seems to work locally.
-CMT_WAIT_MILLIS = 10000
+CMT_WAIT_MILLIS = 30000
 # Keep example logs to a minimum.
 VERBOSITY = ""
 

--- a/infra/scripts/fendermint.toml
+++ b/infra/scripts/fendermint.toml
@@ -21,7 +21,7 @@ docker run \
 dependencies = ["docker-network-create", "fendermint-deps"]
 
 [tasks.fendermint-start-ipc]
-extend = "fendermint-run"
+extend = "fendermint-run-ipc"
 env = { "ENTRY" = "fendermint", "CMD" = "run", "FLAGS" = "-d" }
 
 [tasks.fendermint-run-ipc]
@@ -40,9 +40,17 @@ docker run \
   --env FM_IPC__TOPDOWN__PARENT_HTTP_ENDPOINT=${PARENT_ENDPOINT} \
   --env FM_IPC__TOPDOWN__PARENT_REGISTRY=${PARENT_REGISTRY} \
   --env FM_IPC__TOPDOWN__PARENT_GATEWAY=${PARENT_GATEWAY} \
+  --env FM_IPC__TOPDOWN__EXPONENTIAL_BACK_OFF=5 \
+  --env FM_IPC__TOPDOWN__EXPONENTIAL_RETRY_LIMIT=5 \
+  --env FM_IPC__TOPDOWN__POLLING_INTERVAL=10 \
+  --env FM_ABCI__LISTEN__HOST=0.0.0.0 \
+  --env FM_ETH__LISTEN__HOST=0.0.0.0 \
+  --env FM_TENDERMINT_RPC_URL=http://${CMT_CONTAINER_NAME}:26657 \
+  --env TENDERMINT_RPC_URL=http://${CMT_CONTAINER_NAME}:26657 \
   --env LOG_LEVEL=info \
   --entrypoint ${ENTRY} \
   ${FM_DOCKER_IMAGE} \
+  --network=${NETWORK_TYPE} \ 
   ${CMD}
 """
 dependencies = ["docker-network-create", "fendermint-deps"]

--- a/infra/scripts/fendermint.toml
+++ b/infra/scripts/fendermint.toml
@@ -13,6 +13,7 @@ docker run \
   --volume ${BASE_DIR}:/data \
   --env FM_DATA_DIR=/data/fendermint/data \
   --env FM_CHAIN_NAME=${NETWORK_NAME} \
+  --env TENDERMINT_RPC_URL=http://${CMT_CONTAINER_NAME}:26657 \
   --env LOG_LEVEL=info \
   --entrypoint ${ENTRY} \
   ${FM_DOCKER_IMAGE} \

--- a/infra/scripts/fendermint.toml
+++ b/infra/scripts/fendermint.toml
@@ -51,7 +51,7 @@ docker run \
   --env LOG_LEVEL=info \
   --entrypoint ${ENTRY} \
   ${FM_DOCKER_IMAGE} \
-  --network=${NETWORK_TYPE} \ 
+  --network=${NETWORK_TYPE} \
   ${CMD}
 """
 dependencies = ["docker-network-create", "fendermint-deps"]


### PR DESCRIPTION
@adlrocha has some trouble configuring his fendermint container to connect to the cometbft one. 

This PR adds an example of configuring the URL in the smoke tests. They aren't used in the smoke tests, but we should see them printed in the logs.

The URL can be configure either as:
1. `TENDERMINT_RPC_URL`, because the `fendermint rpc` and `fendermint eth` commands take it in this format - I thought it might be something people dealing with CometBFT (Tendermint Core at the time) might have. 
2. `FM_TENDERMINT_RPC_URL`, because it's part of the config files and everything there can be overwritten with `FM_` prefix