### PR TITLE
FM-341: Delay broadcasting checkpoint sig after commit

### DIFF
--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -40,6 +40,8 @@ state_hist_size = 0
 [broadcast]
 # Maximum number of times to retry broadcasting a transaction after failure.
 max_retries = 5
+# Tome to wait between retries, in seconds. It should roughly correspond to the block interval.
+retry_delay = 2
 
 # FVM configuration
 [fvm]

--- a/fendermint/app/settings/src/lib.rs
+++ b/fendermint/app/settings/src/lib.rs
@@ -92,10 +92,14 @@ pub struct DbSettings {
 /// Settings affecting how we deal with failures in trying to send transactions to the local CometBFT node.
 /// It is not expected to be unavailable, however we might get into race conditions about the nonce which
 /// would need us to try creating a completely new transaction and try again.
+#[serde_as]
 #[derive(Debug, Deserialize, Clone)]
 pub struct BroadcastSettings {
     /// Number of times to retry broadcasting a transaction.
     pub max_retries: u8,
+    /// Time to wait between retries. This should roughly correspond to the block interval.
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub retry_delay: Duration,
 }
 
 #[serde_as]

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -95,7 +95,8 @@ async fn run(settings: Settings) -> anyhow::Result<()> {
             settings.fvm.gas_fee_cap.clone(),
             settings.fvm.gas_premium.clone(),
         )
-        .with_max_retries(settings.broadcast.max_retries);
+        .with_max_retries(settings.broadcast.max_retries)
+        .with_retry_delay(settings.broadcast.retry_delay);
 
         ValidatorContext::new(sk, broadcaster)
     });


### PR DESCRIPTION
Fixes #341 

The PR adds a step to `checkpoint::broadcast_incomplete_signatures` to call `wait_for_commit` with the highest checkpointed height +1, which should make sure that the block where the checkpoint has been added to the ledger has been executed. 

It also adds a `retry_delay` setting to the `Broadcaster` with a default 2s in the configuration file, so in case we run into an issue like this, it gives the thing a chance to at least create a block for the state to change. Previously there was no delay because I thought it's only the nonce that might be having a race condition, but this situation clearly won't resolve itself by an immediate restart.