### PR TITLE
FIX: Add reconnection to Ethereum API startup

### DIFF
--- a/fendermint/app/options/src/eth.rs
+++ b/fendermint/app/options/src/eth.rs
@@ -27,5 +27,13 @@ pub enum EthCommands {
         /// Tendermint node's RPC endpoint.
         #[arg(long)]
         proxy_url: Option<Url>,
+
+        /// Maximum number of times to try to connect to the websocket.
+        #[arg(long, short = 'r', default_value = "5")]
+        connect_max_retries: usize,
+
+        /// Seconds to wait between trying to connect to the websocket.
+        #[arg(long, short = 'd', default_value = "5")]
+        connect_retry_delay: u64,
     },
 }

--- a/fendermint/rpc/src/client.rs
+++ b/fendermint/rpc/src/client.rs
@@ -73,7 +73,11 @@ pub fn http_client(url: Url, proxy_url: Option<Url>) -> anyhow::Result<HttpClien
 pub async fn ws_client(url: Url) -> anyhow::Result<(WebSocketClient, WebSocketClientDriver)> {
     // TODO: Doesn't handle proxy.
     tracing::debug!("Using WS client to submit request to: {}", url);
-    let (client, driver) = WebSocketClient::new(url).await?;
+
+    let (client, driver) = WebSocketClient::new(url.clone())
+        .await
+        .with_context(|| format!("failed to create WS client to: {}", url))?;
+
     Ok((client, driver))
 }
 

--- a/fendermint/testing/smoke-test/Makefile.toml
+++ b/fendermint/testing/smoke-test/Makefile.toml
@@ -50,8 +50,8 @@ dependencies = [
   "fendermint-init",
   "fendermint-start",
   "cometbft-start",
-  "cometbft-wait",
   "ethapi-start",
+  "cometbft-wait",
   "fendermint-logs",
   "cometbft-logs",
   "ethapi-logs",
@@ -159,6 +159,7 @@ docker run \
   --volume ${TEST_SCRIPTS_DIR}:/scripts \
   --env FM_DATA_DIR=/data/fendermint/data \
   --env FM_CHAIN_NAME=${NETWORK_NAME} \
+  --env TENDERMINT_RPC_URL=http://${CMT_CONTAINER_NAME}:26657 \
   --env LOG_LEVEL=info \
   --entrypoint ${ENTRY} \
   ${FM_DOCKER_IMAGE} \


### PR DESCRIPTION
The Ethereum API can fail to start if CometBFT is not ready for connection, which is why the smoke tests waited 10-20s after starting `cometbft` before starting the `ethapi` container. 

This PR adds a limited number of retries to the Ethereum API to help with this, by default 5 retries with 5 second delays between them, which should take it above the 20s that worked on CI. 

The `cometbft-wait` task is still present, but it's moved down, so we see the effect of of retries in the log and don't run tests until the API is ready.