### PR TITLE
FM-340: Don't send duplicate signatures

### DIFF
--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -180,8 +180,7 @@ struct TestAccount {
 impl TestAccount {
     pub fn new(sk: &Path) -> anyhow::Result<Self> {
         let sk = MessageFactory::read_secret_key(sk)?;
-        let pk = sk.public_key();
-        let ea = EthAddress::new_secp256k1(&pk.serialize())?;
+        let ea = EthAddress::from(sk.public_key());
         let h = Address::from_slice(&ea.0);
 
         Ok(Self {

--- a/fendermint/testing/contract-test/tests/staking/machine.rs
+++ b/fendermint/testing/contract-test/tests/staking/machine.rs
@@ -133,7 +133,7 @@ impl StateMachine for StakingMachine {
 
         // Make all the validators join the subnet by putting down collateral according to their power.
         for v in state.child_genesis.validators.iter() {
-            let _addr = EthAddress::new_secp256k1(&v.public_key.0.serialize()).unwrap();
+            let _addr = EthAddress::from(v.public_key.0);
             eprintln!("\n> JOINING SUBNET: addr={_addr} deposit={}", v.power.0);
 
             subnet

--- a/fendermint/vm/actor_interface/Cargo.toml
+++ b/fendermint/vm/actor_interface/Cargo.toml
@@ -34,6 +34,7 @@ ipc-sdk = { workspace = true }
 # frc42_dispatch = { workspace = true }
 
 fendermint_vm_genesis = { path = "../genesis" }
+fendermint_crypto = { path = "../../crypto" }
 
 [dev-dependencies]
 ethers-core = { workspace = true }
@@ -41,5 +42,4 @@ quickcheck = { workspace = true }
 quickcheck_macros = { workspace = true }
 rand = { workspace = true }
 
-fendermint_crypto = { path = "../../crypto" }
 fendermint_vm_genesis = { path = "../genesis", features = ["arb"] }

--- a/fendermint/vm/actor_interface/src/eam.rs
+++ b/fendermint/vm/actor_interface/src/eam.rs
@@ -4,6 +4,7 @@
 use std::fmt::{Debug, Display};
 
 use cid::multihash::MultihashDigest;
+use fendermint_crypto::PublicKey;
 use fvm_ipld_encoding::{
     strict_bytes,
     tuple::{Deserialize_tuple, Serialize_tuple},
@@ -112,6 +113,12 @@ impl From<&EthAddress> for ethers::types::Address {
 impl From<ethers::types::Address> for EthAddress {
     fn from(value: ethers::types::Address) -> Self {
         Self(value.0)
+    }
+}
+
+impl From<PublicKey> for EthAddress {
+    fn from(value: PublicKey) -> Self {
+        Self::new_secp256k1(&value.serialize()).expect("length is 65")
     }
 }
 

--- a/fendermint/vm/actor_interface/src/eam.rs
+++ b/fendermint/vm/actor_interface/src/eam.rs
@@ -157,12 +157,11 @@ mod tests {
     fn prop_new_secp256k1(seed: u64) -> bool {
         let mut rng = StdRng::seed_from_u64(seed);
         let sk = SecretKey::random(&mut rng);
-        let pk = sk.public_key();
 
         let signing_key = SigningKey::from_slice(sk.serialize().as_ref()).unwrap();
         let address = ethers_core::utils::secret_key_to_address(&signing_key);
 
-        let eth_address = EthAddress::new_secp256k1(&pk.serialize()).unwrap();
+        let eth_address = EthAddress::from(sk.public_key());
 
         address.0 == eth_address.0
     }

--- a/fendermint/vm/actor_interface/src/ipc.rs
+++ b/fendermint/vm/actor_interface/src/ipc.rs
@@ -170,7 +170,7 @@ impl ValidatorMerkleTree {
 
     /// Convert a validator to what we can pass to the tree.
     fn validator_to_vec(validator: &Validator<Power>) -> anyhow::Result<Vec<String>> {
-        let addr = EthAddress::new_secp256k1(&validator.public_key.0.serialize())?;
+        let addr = EthAddress::from(validator.public_key.0);
         let addr = et::Address::from_slice(&addr.0);
         let addr = format!("{addr:?}");
 

--- a/fendermint/vm/interpreter/src/fvm/checkpoint.rs
+++ b/fendermint/vm/interpreter/src/fvm/checkpoint.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 
 use anyhow::{anyhow, Context};
 use fendermint_crypto::PublicKey;
+use fendermint_vm_actor_interface::eam::EthAddress;
 use fendermint_vm_actor_interface::ipc::AbiHash;
 use fendermint_vm_genesis::Collateral;
 use fendermint_vm_genesis::PowerScale;
@@ -136,6 +137,38 @@ where
             Ok(Some((checkpoint, power_updates)))
         }
     }
+}
+
+/// Collect incomplete signatures from the ledger which this validator hasn't signed yet.
+///
+/// It doesn't check whether the validator should have signed it, that's done inside [broadcast_incomplete_signatures] at the moment.
+/// The goal is rather to avoid double signing for those who have already done it.
+pub fn unsigned_checkpoints<DB>(
+    gateway: &GatewayCaller<DB>,
+    state: &mut FvmExecState<DB>,
+    validator_key: PublicKey,
+) -> anyhow::Result<Vec<getter::BottomUpCheckpoint>>
+where
+    DB: Blockstore + Send + Sync + 'static,
+{
+    let mut unsigned_checkpoints = Vec::new();
+    let validator_addr = EthAddress::from(validator_key);
+
+    let incomplete_checkpoints = gateway
+        .incomplete_checkpoints(state)
+        .context("failed to fetch incomplete checkpoints")?;
+
+    for cp in incomplete_checkpoints {
+        let signatories = gateway
+            .checkpoint_signatories(state, cp.block_height)
+            .context("failed to get checkpoint signatories")?;
+
+        if signatories.contains(&validator_addr) {
+            unsigned_checkpoints.push(cp);
+        }
+    }
+
+    Ok(unsigned_checkpoints)
 }
 
 /// Sign the current and any incomplete checkpoints.

--- a/fendermint/vm/interpreter/src/fvm/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/exec.rs
@@ -143,10 +143,9 @@ where
                 // Do not resend past signatures.
                 if !self.syncing().await? {
                     // Fetch any incomplete checkpoints synchronously because the state can't be shared across threads.
-                    let incomplete_checkpoints = self
-                        .gateway
-                        .incomplete_checkpoints(&mut state)
-                        .context("failed to fetch incomplete checkpoints")?;
+                    let incomplete_checkpoints =
+                        checkpoint::unsigned_checkpoints(&self.gateway, &mut state, ctx.public_key)
+                            .context("failed to fetch incomplete checkpoints")?;
 
                     debug_assert!(
                         incomplete_checkpoints

--- a/fendermint/vm/interpreter/src/fvm/state/ipc.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/ipc.rs
@@ -256,6 +256,21 @@ impl<DB: Blockstore> GatewayCaller<DB> {
             .call(state, |c| c.get_latest_parent_finality())?;
         Ok(IPCParentFinality::try_from(r)?)
     }
+
+    /// Get the Ethereum adresses of validators who signed a checkpoint.
+    pub fn checkpoint_signatories(
+        &self,
+        state: &mut FvmExecState<DB>,
+        height: u64,
+    ) -> anyhow::Result<Vec<EthAddress>> {
+        let (_, _, addrs, _) = self
+            .getter
+            .call(state, |c| c.get_signature_bundle(height))?;
+
+        let addrs = addrs.into_iter().map(|a| a.into()).collect();
+
+        Ok(addrs)
+    }
 }
 
 /// Total amount of tokens to mint as a result of top-down messages arriving at the subnet.

--- a/fendermint/vm/message/src/signed.rs
+++ b/fendermint/vm/message/src/signed.rs
@@ -340,7 +340,7 @@ mod tests {
         let KeyPair { sk, pk } = key;
 
         // Set the message to the address we are going to sign with.
-        let ea = EthAddress::new_secp256k1(&pk.serialize()).map_err(|e| e.to_string())?;
+        let ea = EthAddress::from(pk);
         let mut msg = msg.0;
         msg.from = Address::from(ea);
 


### PR DESCRIPTION
Fixes #340 

Added a `checkpoint::unsigned_signatures` method that collects incomplete signatures that the current validator hasn't signed, so that they don't try to send their signatures again. 

It turns out that they would not have incurred cost because gas estimation would have failed, as the contract rejects duplicates. But this way they would skip it altogether.