### PR TITLE
FM-355: Snapshot manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,6 +3221,8 @@ dependencies = [
  "anyhow",
  "async-stm",
  "fendermint_vm_interpreter",
+ "fvm_ipld_blockstore",
+ "tempfile",
  "tendermint 0.31.1",
  "tendermint-rpc",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3215,6 +3215,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fendermint_vm_snapshot"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-stm",
+ "fendermint_vm_interpreter",
+ "tendermint 0.31.1",
+ "tendermint-rpc",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "fendermint_vm_topdown"
 version = "0.1.0"
 dependencies = [

--- a/fendermint/vm/interpreter/src/fvm/state/mod.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/mod.rs
@@ -7,7 +7,7 @@ pub mod fevm;
 mod genesis;
 pub mod ipc;
 mod query;
-mod snapshot;
+pub mod snapshot;
 
 use std::sync::Arc;
 
@@ -15,7 +15,6 @@ pub use check::FvmCheckState;
 pub use exec::{BlockHash, FvmExecState, FvmStateParams, FvmUpdatableParams};
 pub use genesis::{empty_state_tree, FvmGenesisState};
 pub use query::FvmQueryState;
-pub use snapshot::{Snapshot, V1Snapshot};
 
 use super::store::ReadOnlyBlockstore;
 

--- a/fendermint/vm/interpreter/src/fvm/state/snapshot.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/snapshot.rs
@@ -39,7 +39,7 @@ type SnapshotStreamer = Box<dyn Send + Unpin + Stream<Item = (Cid, Vec<u8>)>>;
 
 impl<BS> Snapshot<BS>
 where
-    BS: Blockstore + Clone + 'static + Send,
+    BS: Blockstore + 'static + Send,
 {
     pub fn new(
         store: BS,
@@ -135,7 +135,7 @@ pub type BlockStateParams = (FvmStateParams, BlockHeight);
 
 impl<BS> V1Snapshot<BS>
 where
-    BS: Blockstore + Clone + 'static + Send,
+    BS: Blockstore + 'static + Send,
 {
     /// Creates a new V2Snapshot struct. Caller ensure store
     pub fn new(

--- a/fendermint/vm/interpreter/src/fvm/state/snapshot.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/snapshot.rs
@@ -131,7 +131,7 @@ pub struct V1Snapshot<BS> {
     block_height: BlockHeight,
 }
 
-type BlockStateParams = (FvmStateParams, BlockHeight);
+pub type BlockStateParams = (FvmStateParams, BlockHeight);
 
 impl<BS> V1Snapshot<BS>
 where
@@ -263,8 +263,8 @@ fn derive_cid<T: Serialize>(t: &T) -> anyhow::Result<(Cid, Vec<u8>)> {
 
 #[cfg(test)]
 mod tests {
-    use crate::fvm::state::snapshot::StateTreeStreamer;
-    use crate::fvm::state::{FvmStateParams, Snapshot};
+    use crate::fvm::state::snapshot::{Snapshot, StateTreeStreamer};
+    use crate::fvm::state::FvmStateParams;
     use crate::fvm::store::memory::MemoryBlockstore;
     use crate::fvm::store::ReadOnlyBlockstore;
     use cid::Cid;

--- a/fendermint/vm/snapshot/Cargo.toml
+++ b/fendermint/vm/snapshot/Cargo.toml
@@ -11,10 +11,13 @@ license.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-stm = { workspace = true }
+tempfile = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 
 tendermint = { workspace = true }
 tendermint-rpc = { workspace = true }
+
+fvm_ipld_blockstore = { workspace = true }
 
 fendermint_vm_interpreter = { path = "../interpreter" }

--- a/fendermint/vm/snapshot/Cargo.toml
+++ b/fendermint/vm/snapshot/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "fendermint_vm_snapshot"
+description = "Produce and consume ledger snapshots"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = { workspace = true }
+async-stm = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+
+tendermint = { workspace = true }
+tendermint-rpc = { workspace = true }
+
+fendermint_vm_interpreter = { path = "../interpreter" }

--- a/fendermint/vm/snapshot/src/lib.rs
+++ b/fendermint/vm/snapshot/src/lib.rs
@@ -1,0 +1,3 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+pub mod manager;

--- a/fendermint/vm/snapshot/src/manager.rs
+++ b/fendermint/vm/snapshot/src/manager.rs
@@ -1,0 +1,148 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use async_stm::{atomically, retry, TVar};
+use fendermint_vm_interpreter::fvm::state::snapshot::{BlockHeight, BlockStateParams};
+use fendermint_vm_interpreter::fvm::state::FvmStateParams;
+use tendermint_rpc::Client;
+
+const SYNC_POLL_INTERVAL: Duration = Duration::from_secs(60);
+
+/// State of snapshots, including the list of available completed ones
+/// and the next eligible height.
+#[derive(Clone)]
+struct SnapshotState {
+    /// Snapshotted heights are a multiple of the interval.
+    ///
+    /// The manager is free to skip heights if it's busy.
+    snapshot_interval: BlockHeight,
+    /// Location to store completed snapshots.
+    _snapshot_dir: PathBuf,
+    /// The latest state parameters at a snapshottable height.
+    latest_params: TVar<Option<BlockStateParams>>,
+}
+
+/// Interface to snapshot state for the application.
+#[derive(Clone)]
+pub struct SnapshotClient {
+    snapshot_state: SnapshotState,
+}
+
+impl SnapshotClient {
+    /// Set the latest block state parameters and notify the manager.
+    pub async fn on_commit(&self, block_height: BlockHeight, params: FvmStateParams) {
+        if block_height % self.snapshot_state.snapshot_interval == 0 {
+            atomically(|| {
+                self.snapshot_state
+                    .latest_params
+                    .write(Some((params.clone(), block_height)))
+            })
+            .await;
+        }
+    }
+}
+
+/// Create snapshots at regular block intervals.
+pub struct SnapshotManager {
+    /// Shared state of snapshots.
+    snapshot_state: SnapshotState,
+    /// Indicate whether CometBFT has finished syncing with the chain,
+    /// so that we can skip snapshotting old states while catching up.
+    is_syncing: TVar<bool>,
+}
+
+impl SnapshotManager {
+    /// Create a new manager.
+    pub fn new(snapshot_interval: BlockHeight, snapshot_dir: PathBuf) -> Self {
+        Self {
+            snapshot_state: SnapshotState {
+                snapshot_interval,
+                _snapshot_dir: snapshot_dir,
+                // Start with nothing to snapshot until we are notified about a new height.
+                // We could also look back to find the latest height we should have snapshotted.
+                latest_params: TVar::new(None),
+            },
+            // Assume we are syncing until we can determine otherwise.
+            is_syncing: TVar::new(true),
+        }
+    }
+
+    /// Create a client to talk to this manager.
+    pub fn snapshot_client(&self) -> SnapshotClient {
+        SnapshotClient {
+            snapshot_state: self.snapshot_state.clone(),
+        }
+    }
+
+    /// Produce snapshots.
+    pub async fn run<C>(self, client: C)
+    where
+        C: Client + Send + Sync + 'static,
+    {
+        // Start a background poll to CometBFT.
+        // We could just do this once and await here, but this way ostensibly CometBFT could be
+        // restarted without Fendermint and go through another catch up.
+        {
+            let is_syncing = self.is_syncing.clone();
+            tokio::spawn(async {
+                poll_sync_status(client, is_syncing).await;
+            });
+        }
+
+        let mut last_params = None;
+        loop {
+            let new_params = atomically(|| {
+                // Check the current sync status. We could just query the API, but then we wouldn't
+                // be notified when we finally reach the end, and we'd only snapshot the next height,
+                // not the last one as soon as the chain is caught up.
+                if *self.is_syncing.read()? {
+                    retry()?;
+                }
+
+                match self.snapshot_state.latest_params.read()?.as_ref() {
+                    None => retry()?,
+                    unchanged if *unchanged == last_params => retry()?,
+                    Some(new_params) => Ok(new_params.clone()),
+                }
+            })
+            .await;
+
+            last_params = Some(new_params.clone());
+
+            self.create_snapshot(new_params).await;
+        }
+    }
+
+    async fn create_snapshot(&self, (_params, _height): BlockStateParams) {
+        todo!()
+    }
+}
+
+/// Periodically ask CometBFT if it has caught up with the chain.
+async fn poll_sync_status<C>(client: C, is_syncing: TVar<bool>)
+where
+    C: Client + Send + Sync + 'static,
+{
+    loop {
+        match client.status().await {
+            Ok(status) => {
+                let catching_up = status.sync_info.catching_up;
+
+                atomically(|| {
+                    if *is_syncing.read()? != catching_up {
+                        is_syncing.write(catching_up)?;
+                    }
+                    Ok(())
+                })
+                .await;
+            }
+            Err(e) => {
+                tracing::warn!(error =? e, "failed to poll CometBFT sync status");
+            }
+        }
+        tokio::time::sleep(SYNC_POLL_INTERVAL).await;
+    }
+}


### PR DESCRIPTION
Closes #355 
Closes #358 

This is just a skeleton for a snapshot manager. It listens to notifications about new heights where snapshots should be taken and exports the data to a CAR file. It's not wired in, and doesn't implement all the functions which are covered by upcoming tasks, such as removing old files, listing available snapshots, etc.