### PR TITLE
FM-347: get child subnet genesis balance from parent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4638,7 +4638,7 @@ dependencies = [
 [[package]]
 name = "ipc-identity"
 version = "0.1.0"
-source = "git+https://github.com/consensus-shipyard/ipc.git?branch=dev#65e92a324e4c3818ceeee90f1416d10d8ad9a107"
+source = "git+https://github.com/consensus-shipyard/ipc.git?branch=dev#67156c4ddf84fa6c96d52cf430def8776840af54"
 dependencies = [
  "ahash 0.8.6",
  "anyhow",
@@ -4665,7 +4665,7 @@ dependencies = [
 [[package]]
 name = "ipc-provider"
 version = "0.1.0"
-source = "git+https://github.com/consensus-shipyard/ipc.git?branch=dev#65e92a324e4c3818ceeee90f1416d10d8ad9a107"
+source = "git+https://github.com/consensus-shipyard/ipc.git?branch=dev#67156c4ddf84fa6c96d52cf430def8776840af54"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4705,7 +4705,7 @@ dependencies = [
 [[package]]
 name = "ipc-sdk"
 version = "0.1.0"
-source = "git+https://github.com/consensus-shipyard/ipc.git?branch=dev#65e92a324e4c3818ceeee90f1416d10d8ad9a107"
+source = "git+https://github.com/consensus-shipyard/ipc.git?branch=dev#67156c4ddf84fa6c96d52cf430def8776840af54"
 dependencies = [
  "anyhow",
  "cid",
@@ -4729,7 +4729,7 @@ dependencies = [
 [[package]]
 name = "ipc_actors_abis"
 version = "0.1.0"
-source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=dev#469bd60bc61820f83624306f9e06d33993a4c13d"
+source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=dev#cec4e7ede1e16589b86da91b18d197601c90d14b"
 dependencies = [
  "anyhow",
  "ethers",

--- a/fendermint/app/src/cmd/genesis.rs
+++ b/fendermint/app/src/cmd/genesis.rs
@@ -312,6 +312,17 @@ async fn new_genesis_from_parent(
         })
     }
 
+    for (a, b) in genesis_info.genesis_balances {
+        let meta = ActorMeta::Account(Account {
+            owner: SignerAddr(a),
+        });
+        let actor = Actor {
+            meta,
+            balance: b.clone(),
+        };
+        genesis.accounts.push(actor);
+    }
+
     let json = serde_json::to_string_pretty(&genesis)?;
     std::fs::write(genesis_file, json)?;
 


### PR DESCRIPTION
Depends on https://github.com/consensus-shipyard/ipc/pull/361

This PR modifies the child subnet genesis generation to also pull information from the parent about the genesis balances to be initialized in genesis in the subnet.