### PR TITLE
DOCKER: Pre-build and cache dependencies

### DIFF
--- a/docker/builder.ci.Dockerfile
+++ b/docker/builder.ci.Dockerfile
@@ -78,9 +78,12 @@ RUN set -eux; \
 COPY . .
 
 # ... and do the final build.
+# Using `cargo build` instead of `cargo install` because the latter doesn't seem to work with the stripper for some reason.
 RUN set -eux; \
   case "${TARGETARCH}" in \
   amd64) ARCH='x86_64'  ;; \
   arm64) ARCH='aarch64' ;; \
   esac; \
-  cargo install --root output --path fendermint/app --target ${ARCH}-unknown-linux-gnu
+  cargo build --release -p fendermint_app --target ${ARCH}-unknown-linux-gnu && \
+  mkdir -p output/bin && \
+  cp target/${ARCH}-unknown-linux-gnu/release/fendermint output/bin


### PR DESCRIPTION
Followup for #374 

The PR does some tricks to try to get more out of the Github Actions caching activated by `--cache-to=type=gha` which works on layers. 

It includes an initial `stripper` stage in the build where all the source code except the `Cargo.toml` and `Cargo.lock` files are stripped away and replaced with empty Rust files. In the `builder` stage these files are copied and built with `cargo`, which results in the download and build of all dependencies into the `target` directory. This gets cached as a Docker layer, and if the dependencies don't change then they can be reused for the next build. After this the rest of the source code is copied in as usual and another round of build produces the final executable. 

### References
* https://stackoverflow.com/questions/49939960/docker-copy-files-using-glob-pattern
* https://stackoverflow.com/questions/58473606/cache-rust-dependencies-with-docker-build/58474618#58474618