### PR TITLE
DOCKER: Delete untagged images after build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,3 +193,13 @@ jobs:
           export BUILDX_STORE="--push"
           export BUILDX_FLAGS="--platform linux/amd64,linux/arm64 ${BUILDX_FLAGS}"
           make docker-build
+
+      # https://github.com/Chizkiyahu/delete-untagged-ghcr-action
+      - name: Delete all containers from package without tags
+        uses: Chizkiyahu/delete-untagged-ghcr-action@v3
+        with:
+            token: ${{ secrets.GITHUB_TOKEN }}
+            owner_type: org
+            package_name: fendermint
+            untagged_only: true
+            except_untagged_multiplatform: true


### PR DESCRIPTION
It turns out that https://github.com/consensus-shipyard/fendermint/pkgs/container/fendermint/versions has images going back months now. 

I think we are safe to remove everything that has been orphaned. Hopefully this action does just that: https://github.com/Chizkiyahu/delete-untagged-ghcr-action

### Note

I left the PR as _Draft_ because there is no point in testing it, it changes nothing apart from removing stuff if executed on `main`.