### PR TITLE
FM-350: eth_getTransactionCount should return 0 for nonexistent senders

### DIFF
--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -323,6 +323,12 @@ where
     )?;
 
     request(
+        "eth_getBalance (non-existent)",
+        provider.get_balance(Address::default(), None).await,
+        |b| b.is_zero(),
+    )?;
+
+    request(
         "eth_getUncleCountByBlockHash",
         provider
             .get_uncle_count(BlockId::Hash(H256([0u8; 32])))
@@ -361,6 +367,14 @@ where
             .get_transaction_count(from.eth_addr, Some(BlockId::Number(BlockNumber::Earliest)))
             .await,
         |u| u.is_zero(),
+    )?;
+
+    request(
+        "eth_getTransactionCount (non-existent)",
+        provider
+            .get_transaction_count(Address::default(), None)
+            .await,
+        |b| b.is_zero(),
     )?;
 
     // Get a block without transactions

--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -360,23 +360,6 @@ where
         |u| u.is_none(),
     )?;
 
-    // Querying at genesis, so the transaction count should be zero.
-    request(
-        "eth_getTransactionCount",
-        provider
-            .get_transaction_count(from.eth_addr, Some(BlockId::Number(BlockNumber::Earliest)))
-            .await,
-        |u| u.is_zero(),
-    )?;
-
-    request(
-        "eth_getTransactionCount (non-existent)",
-        provider
-            .get_transaction_count(Address::default(), None)
-            .await,
-        |b| b.is_zero(),
-    )?;
-
     // Get a block without transactions
     let b = request(
         "eth_getBlockByNumber w/o txns",
@@ -431,6 +414,21 @@ where
         TxHash::from(ethers_core::utils::keccak256(rlp))
     };
     assert_eq!(tx_hash, expected_hash, "Ethereum hash should match");
+
+    // Querying at latest, so the transaction count should be non-zero.
+    request(
+        "eth_getTransactionCount",
+        provider.get_transaction_count(from.eth_addr, None).await,
+        |u| !u.is_zero(),
+    )?;
+
+    request(
+        "eth_getTransactionCount (non-existent)",
+        provider
+            .get_transaction_count(Address::default(), None)
+            .await,
+        |b| b.is_zero(),
+    )?;
 
     // Get a block with transactions by number.
     let block = request(

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -450,7 +450,7 @@ where
             let nonce = state.sequence;
             Ok(et::U64::from(nonce))
         }
-        None => error(ExitCode::USR_NOT_FOUND, format!("actor {addr} not found")),
+        None => Ok(et::U64::zero()),
     }
 }
 

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -310,7 +310,7 @@ where
 
     match res.value {
         Some((_, state)) => Ok(to_eth_tokens(&state.balance)?),
-        None => error(ExitCode::USR_NOT_FOUND, format!("actor {addr} not found")),
+        None => Ok(et::U256::zero()),
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/consensus-shipyard/fendermint/issues/350

Consistent with Lotus https://github.com/filecoin-project/lotus/blob/master/node/impl/full/eth.go#L360