### PR TITLE
Fix testnet script

### DIFF
--- a/infra/scripts/testnet.toml
+++ b/infra/scripts/testnet.toml
@@ -54,9 +54,9 @@ for i in ${nodes}
     NUMBER = set ${i}
     NODE_NAME = set "node${NUMBER}"
 
-    mkdir -p ${BASE_DIR}/${NODE_NAME}
-    mkdir -p ${BASE_DIR}/${NODE_NAME}/fendermint
-    mkdir -p ${BASE_DIR}/${NODE_NAME}/cometbft
+    mkdir ${BASE_DIR}/${NODE_NAME}
+    mkdir ${BASE_DIR}/${NODE_NAME}/fendermint
+    mkdir ${BASE_DIR}/${NODE_NAME}/cometbft
 
     set_env NODE_NAME ${NODE_NAME}
     set_env NUMBER ${NUMBER}


### PR DESCRIPTION
After applying duckscript, `testnet` was broken. The problem is that `mkdir` method does not have keys - https://github.com/sagiegurari/duckscript/blob/master/docs/sdk.md#std__fs__CreateDirectory

As a result, `-p` directory was created, and `cometbft` directories had root privileges. 