### PR TITLE
TEST: Disable nightly tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        rust: [stable, nightly]
+        rust: [stable]
         make:
           - name: Clippy
             task: check-clippy


### PR DESCRIPTION
We run the unit tests on both `stable` and `nightly` Rust, but I think at the moment because we target `stable` the `nightly` tests don't give enough value to justify the 700MB [cache space](https://github.com/consensus-shipyard/fendermint/actions/caches) they take out of the 10GB allowance on Github Actions. We'd benefit more from leaving it for docker and other stuff.


### Note
Workflow was canceled because all I wanted to verify was that it did not want to test nightly.