### PR TITLE
BUILD: Do not append the date to reduce the number of uploads

### DIFF
--- a/.github/actions/setup-cache/action.yaml
+++ b/.github/actions/setup-cache/action.yaml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Setup sccache
       # uses: hanabi1224/sccache-action@v1.2.0 # https://github.com/hanabi1224/sccache-action used by Forest.
-      uses: consensus-shipyard/sccache-action@no-date
+      uses: consensus-shipyard/sccache-action@fendermint
       with:
         release-name: v0.3.1
         cache-key: ${{ inputs.cache-prefix }}

--- a/.github/actions/setup-cache/action.yaml
+++ b/.github/actions/setup-cache/action.yaml
@@ -1,11 +1,12 @@
 name: Setup Cache
 description: "Setup Rust artifact caching"
 inputs:
-  cache-key:
-    description: "Caching key used for invalidation and uploading"
+  cache-prefix:
+    description: "Caching key used for matching caches"
     required: true
-  cache-update:
-    description: "Whether to overwrite existing caches"
+  cache-suffix:
+    description: "Caching suffix used to make keys unique and force uploads"
+    required: true
 
 runs:
   using: "composite"
@@ -16,10 +17,9 @@ runs:
       uses: consensus-shipyard/sccache-action@no-date
       with:
         release-name: v0.3.1
-        # Caching everything separately, in case they don't ask for the same things to be compiled.
-        cache-key: ${{ inputs.cache-key }}
-        # Not sure why we should ever update a cache that has the hash of the lock file in it.
-        # In Forest it only contains the rust-toolchain, so it makes sense to update because dependencies could have changed.
-        cache-update: ${{ inputs.cache-update }}
-        # Don't append the date to the cache.
+        cache-key: ${{ inputs.cache-prefix }}
+        cache-suffix: ${{ inputs.cache-suffix }}
+        # We should never have to update a cache as long as we use unique suffixes, it happens automatically.
+        cache-update: false
+        # Don't append the date to the cache, the unique suffix should take care of it.
         cache-date: false

--- a/.github/actions/setup-cache/action.yaml
+++ b/.github/actions/setup-cache/action.yaml
@@ -12,7 +12,8 @@ runs:
 
   steps:
     - name: Setup sccache
-      uses: hanabi1224/sccache-action@v1.2.0 # https://github.com/hanabi1224/sccache-action used by Forest.
+      # uses: hanabi1224/sccache-action@v1.2.0 # https://github.com/hanabi1224/sccache-action used by Forest.
+      uses: consensus-shipyard/sccache-action@no-date
       with:
         release-name: v0.3.1
         # Caching everything separately, in case they don't ask for the same things to be compiled.
@@ -20,3 +21,5 @@ runs:
         # Not sure why we should ever update a cache that has the hash of the lock file in it.
         # In Forest it only contains the rust-toolchain, so it makes sense to update because dependencies could have changed.
         cache-update: ${{ inputs.cache-update }}
+        # Don't append the date to the cache.
+        cache-date: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,10 +96,8 @@ jobs:
         continue-on-error: true
         with:
           # Caching everything separately, in case they don't ask for the same things to be compiled.
-          cache-key: ${{ matrix.make.name }}-${{ matrix.os }}-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain', 'rust-toolchain.toml') }}
-          # Not sure why we should ever update a cache that has the hash of the lock file in it.
-          # In Forest it only contains the rust-toolchain, so it makes sense to update because dependencies could have changed.
-          cache-update: false
+          cache-prefix: ${{ matrix.make.name }}-${{ matrix.os }}-${{ matrix.rust }}-${{ hashFiles('rust-toolchain', 'rust-toolchain.toml') }}
+          cache-suffix: ${{ hashFiles('**/Cargo.lock') }}
 
       - name: ${{ matrix.make.name }}
         run: make ${{ matrix.make.task }}
@@ -131,10 +129,11 @@ jobs:
         timeout-minutes: 5
         continue-on-error: true
         with:
-          # Very likely that the Cargo.lock file will change between PRs,
-          # but since this only runs on the main branch we can update a single cache.
-          cache-key: publish-${{ hashFiles('rust-toolchain', 'rust-toolchain.toml') }}
-          cache-update: true
+          # The Cargo.lock file is very likely to change between PRs, which would mean a cache miss.
+          # Ideally we want to download the previous cache and do an upload if something changed.
+          # That's why the Cargo.lock hash is used as a suffix, so we match on a stable one and upload if changed.
+          cache-prefix: publish-${{ hashFiles('rust-toolchain', 'rust-toolchain.toml') }}
+          cache-suffix: ${{ hashFiles('**/Cargo.lock') }}
 
       # - name: Docker Build
       #   run: make docker-build


### PR DESCRIPTION
Our [caches](https://github.com/consensus-shipyard/fendermint/actions/caches) are full of entries with the same hash but different date. I think these have the same content, but they cause other entries to be evicted, especially with repeated builds. A possible reason for why they exist may be that multiple PRs run at the same time and end up with slightly different date timestamps, with both thinking they have to push. 

The PR depends on https://github.com/consensus-shipyard/sccache-action/pull/1 to disable the date suffix and replace it with a unique hash.