### PR TITLE
FM-357: Notify the snapshot manager about new commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2825,6 +2825,7 @@ dependencies = [
  "fendermint_vm_interpreter",
  "fendermint_vm_message",
  "fendermint_vm_resolver",
+ "fendermint_vm_snapshot",
  "fendermint_vm_topdown",
  "fvm",
  "fvm_ipld_blockstore",

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -52,6 +52,7 @@ fendermint_vm_interpreter = { path = "../vm/interpreter", features = ["bundle"] 
 fendermint_vm_message = { path = "../vm/message" }
 fendermint_vm_resolver = { path = "../vm/resolver" }
 fendermint_vm_topdown = { path = "../vm/topdown" }
+fendermint_vm_snapshot = { path = "../vm/snapshot" }
 
 fvm = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -190,6 +190,7 @@ async fn run(settings: Settings) -> anyhow::Result<()> {
         interpreter,
         resolve_pool,
         parent_finality_provider.clone(),
+        None,
     )?;
 
     if let Some((agent_proxy, config)) = ipc_tuple {


### PR DESCRIPTION
Closes #357 

Changes the `App` to notify the snapshotter about newly committed blocks. The snapshotter is a new optional constructor dependency of the `App` currently unset, so we don't end up exporting data with nothing to clean it up yet.