### PR TITLE
FIX: pass settings to run bottom-up checkpoints in validator infra

### DIFF
--- a/infra/scripts/fendermint.toml
+++ b/infra/scripts/fendermint.toml
@@ -56,6 +56,8 @@ docker run \
   --env FM_ABCI__LISTEN__HOST=0.0.0.0 \
   --env FM_ETH__LISTEN__HOST=0.0.0.0 \
   --env FM_TENDERMINT_RPC_URL=http://${CMT_CONTAINER_NAME}:26657 \
+  --env FM_VALIDATOR_KEY__PATH=/data/${NODE_NAME}/${PRIV_KEY_PATH} \
+  --env FM_VALIDATOR_KEY__KIND=ethereum \
   --env TENDERMINT_RPC_URL=http://${CMT_CONTAINER_NAME}:26657 \
   --env LOG_LEVEL=info \
   --env RUST_BACKTRACE=1 \


### PR DESCRIPTION
While testing the end-to-end I realized that no bottom-up checkpoints were being signed in the child subnet. It ended up being because I wasn't passing the `ValidatorContext` settings required for the validator to be able to sign and commit checkpoint signatures. This PR passes the settings to the validator infra scripts as env variables.