### PR TITLE
CMD: Add fendermint-to-eth command

### DIFF
--- a/fendermint/app/options/src/key.rs
+++ b/fendermint/app/options/src/key.rs
@@ -15,8 +15,10 @@ pub enum KeyCommands {
     Address(KeyAddressArgs),
     /// Get the peer ID corresponding to a node ID and its network address and print it to a local file.
     AddPeer(AddPeer),
-    /// Converts a hex encoded Ethereum private key in a Base64 encoded Fendermint keypair.
+    /// Converts a hex encoded Ethereum private key into a Base64 encoded Fendermint keypair.
     EthToFendermint(EthToFendermintArgs),
+    /// Converts a Base64 encoded Fendermint private key in a hex encoded Ethereum secret key and address.
+    FendermintToEth(FendermintToEthArgs),
 }
 
 #[derive(Args, Debug)]
@@ -53,6 +55,19 @@ pub struct KeyGenArgs {
 #[derive(Args, Debug)]
 pub struct EthToFendermintArgs {
     /// Path to the file that stores the private key (hex format)
+    #[arg(long, short)]
+    pub secret_key: PathBuf,
+    /// Name used to distinguish the files from other exported keys.
+    #[arg(long, short)]
+    pub name: String,
+    /// Directory to export the key files to; it must exist.
+    #[arg(long, short, default_value = ".")]
+    pub out_dir: PathBuf,
+}
+
+#[derive(Args, Debug)]
+pub struct FendermintToEthArgs {
+    /// Path to the file that stores the private key (base64 format)
     #[arg(long, short)]
     pub secret_key: PathBuf,
     /// Name used to distinguish the files from other exported keys.

--- a/fendermint/app/src/cmd/key.rs
+++ b/fendermint/app/src/cmd/key.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use anyhow::{anyhow, Context};
+use fendermint_app_options::key::FendermintToEthArgs;
 use fendermint_crypto::{PublicKey, SecretKey};
+use fendermint_vm_actor_interface::eam::EthAddress;
 use fvm_shared::address::Address;
 use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 use serde_json::json;
@@ -26,6 +28,7 @@ cmd! {
             KeyCommands::AddPeer(args) => args.exec(()).await,
             KeyCommands::Address(args) => args.exec(()).await,
             KeyCommands::EthToFendermint(args) => args.exec(()).await,
+            KeyCommands::FendermintToEth(args) => args.exec(()).await,
         }
     }
 }
@@ -37,6 +40,18 @@ cmd! {
 
         export(&self.out_dir, &self.name, "sk", &secret_to_b64(&sk))?;
         export(&self.out_dir, &self.name, "pk", &public_to_b64(&pk))?;
+
+        Ok(())
+    }
+}
+
+cmd! {
+    FendermintToEthArgs(self) {
+        let sk = read_secret_key(&self.secret_key)?;
+        let pk = sk.public_key();
+
+        export(&self.out_dir, &self.name, "sk", &hex::encode(sk.serialize()))?;
+        export(&self.out_dir, &self.name, "pk", &hex::encode(EthAddress::from(pk).0))?;
 
         Ok(())
     }


### PR DESCRIPTION
Mirroring https://github.com/consensus-shipyard/fendermint/pull/334 adds a command to convert Base64 keys into hex.

```console
❯ cargo run -q -p fendermint_app --release -- key fendermint-to-eth --help
Converts a Base64 encoded Fendermint private key in a hex encoded Ethereum secret key and address

Usage: fendermint key fendermint-to-eth [OPTIONS] --secret-key <SECRET_KEY> --name <NAME>

Options:
  -s, --secret-key <SECRET_KEY>  Path to the file that stores the private key (base64 format)
  -n, --name <NAME>              Name used to distinguish the files from other exported keys
  -o, --out-dir <OUT_DIR>        Directory to export the key files to; it must exist [default: .]
  -h, --help                     Print help
```