### PR TITLE
FM-377: Handle one or many JSON-RPC requests

### DIFF
--- a/fendermint/eth/api/src/handlers/http.rs
+++ b/fendermint/eth/api/src/handlers/http.rs
@@ -6,60 +6,97 @@
 
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
-use jsonrpc_v2::{Id, RequestObject as JsonRpcRequestObject};
+use jsonrpc_v2::{RequestObject, ResponseObjects};
+use serde::Deserialize;
 
-use crate::{apis, AppState, JsonRpcServer};
+use crate::{apis, AppState};
+
+type ResponseHeaders = [(&'static str, &'static str); 1];
+
+const RESPONSE_HEADERS: ResponseHeaders = [("content-type", "application/json-rpc;charset=utf-8")];
+
+/// The Ethereum API implementations accept `{}` or `[{}, {}, ...]` as requests,
+/// with the expectation of as many responses.
+///
+/// `jsonrpc_v2` has a type named `RequestKind` but it's not `Deserialize`.
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub enum RequestKind {
+    One(RequestObject),
+    Many(Vec<RequestObject>),
+}
 
 /// Handle JSON-RPC calls.
 pub async fn handle(
     _headers: HeaderMap,
     axum::extract::State(state): axum::extract::State<AppState>,
-    axum::Json(request): axum::Json<JsonRpcRequestObject>,
+    axum::Json(request): axum::Json<RequestKind>,
 ) -> impl IntoResponse {
-    let response_headers = [("content-type", "application/json-rpc;charset=utf-8")];
-
     // NOTE: Any authorization can come here.
+    let response = match request {
+        RequestKind::One(request) => {
+            if let Err(response) = check_request(&request) {
+                return response;
+            }
+            state.rpc_server.handle(request).await
+        }
+        RequestKind::Many(requests) => {
+            for request in requests.iter() {
+                if let Err(response) = check_request(request) {
+                    return response;
+                }
+            }
+            state.rpc_server.handle(requests).await
+        }
+    };
+    debug_response(&response);
+    json_response(&response)
+}
 
-    tracing::debug!("RPC request: {request:?}");
+fn debug_response(response: &ResponseObjects) {
+    let debug = |r| {
+        tracing::debug!(
+            response = serde_json::to_string(r).unwrap_or_else(|e| e.to_string()),
+            "RPC response"
+        );
+    };
+    match response {
+        ResponseObjects::Empty => {}
+        ResponseObjects::One(r) => {
+            debug(r);
+        }
+        ResponseObjects::Many(rs) => {
+            for r in rs {
+                debug(r);
+            }
+        }
+    }
+}
 
-    let id = request.id_ref().map(id_to_string).unwrap_or_default();
+fn json_response(response: &ResponseObjects) -> (StatusCode, ResponseHeaders, std::string::String) {
+    match serde_json::to_string(response) {
+        Ok(json) => (StatusCode::OK, RESPONSE_HEADERS, json),
+        Err(err) => {
+            let msg = err.to_string();
+            tracing::error!(error = msg, "RPC to JSON failure");
+            (StatusCode::INTERNAL_SERVER_ERROR, RESPONSE_HEADERS, msg)
+        }
+    }
+}
+
+fn check_request(
+    request: &RequestObject,
+) -> Result<(), (StatusCode, ResponseHeaders, std::string::String)> {
+    tracing::debug!(?request, "RPC request");
     let method = request.method_ref().to_owned();
 
     if apis::is_streaming_method(&method) {
-        return (
+        Err((
             StatusCode::BAD_REQUEST,
-            response_headers,
+            RESPONSE_HEADERS,
             format!("'{method}' is only available through WebSocket"),
-        );
+        ))
+    } else {
+        Ok(())
     }
-
-    match call_rpc_str(&state.rpc_server, request).await {
-        Ok(result) => {
-            tracing::debug!(method, id, result, "RPC call success");
-
-            (StatusCode::OK, response_headers, result)
-        }
-        Err(err) => {
-            let msg = err.to_string();
-            tracing::error!(method, id, msg, "RPC call failure");
-            (StatusCode::INTERNAL_SERVER_ERROR, response_headers, msg)
-        }
-    }
-}
-
-fn id_to_string(id: &jsonrpc_v2::Id) -> String {
-    match id {
-        Id::Null => "null".to_owned(),
-        Id::Str(s) => (**s).to_owned(),
-        Id::Num(n) => n.to_string(),
-    }
-}
-
-// Calls an RPC method and returns the full response as a string.
-async fn call_rpc_str(
-    server: &JsonRpcServer,
-    request: jsonrpc_v2::RequestObject,
-) -> anyhow::Result<String> {
-    let response = server.handle(request).await;
-    Ok(serde_json::to_string(&response)?)
 }


### PR DESCRIPTION
Fixes [#377](https://github.com/consensus-shipyard/ipc/issues/377)

Changes the HTTP server to accept a single JSON object or an array of objects as request, expecting that the latter are a batch of requests. The `jsonrpc_v2` server implementation actually handles this, I just didn't know it was part of the Ethereum API spec. 

I did not change the websocket implementation, that still expects results to arrive as single messages.