### PR TITLE
FIX: Rename eth-to-fendermint and export .pk and .addr

### DIFF
--- a/fendermint/app/options/src/key.rs
+++ b/fendermint/app/options/src/key.rs
@@ -18,7 +18,7 @@ pub enum KeyCommands {
     /// Converts a hex encoded Ethereum private key into a Base64 encoded Fendermint keypair.
     #[clap(alias = "eth-to-fendermint")]
     FromEth(KeyFromEthArgs),
-    /// Converts a Base64 encoded Fendermint private key in a hex encoded Ethereum secret key and address.
+    /// Converts a Base64 encoded Fendermint private key into a hex encoded Ethereum secret key, public key and address (20 bytes).
     IntoEth(KeyIntoEthArgs),
 }
 

--- a/fendermint/app/options/src/key.rs
+++ b/fendermint/app/options/src/key.rs
@@ -16,9 +16,10 @@ pub enum KeyCommands {
     /// Get the peer ID corresponding to a node ID and its network address and print it to a local file.
     AddPeer(AddPeer),
     /// Converts a hex encoded Ethereum private key into a Base64 encoded Fendermint keypair.
-    EthToFendermint(EthToFendermintArgs),
+    #[clap(alias = "eth-to-fendermint")]
+    FromEth(KeyFromEthArgs),
     /// Converts a Base64 encoded Fendermint private key in a hex encoded Ethereum secret key and address.
-    FendermintToEth(FendermintToEthArgs),
+    IntoEth(KeyIntoEthArgs),
 }
 
 #[derive(Args, Debug)]
@@ -53,7 +54,7 @@ pub struct KeyGenArgs {
 }
 
 #[derive(Args, Debug)]
-pub struct EthToFendermintArgs {
+pub struct KeyFromEthArgs {
     /// Path to the file that stores the private key (hex format)
     #[arg(long, short)]
     pub secret_key: PathBuf,
@@ -66,7 +67,7 @@ pub struct EthToFendermintArgs {
 }
 
 #[derive(Args, Debug)]
-pub struct FendermintToEthArgs {
+pub struct KeyIntoEthArgs {
     /// Path to the file that stores the private key (base64 format)
     #[arg(long, short)]
     pub secret_key: PathBuf,

--- a/fendermint/app/src/cmd/key.rs
+++ b/fendermint/app/src/cmd/key.rs
@@ -50,7 +50,8 @@ cmd! {
         let pk = sk.public_key();
 
         export(&self.out_dir, &self.name, "sk", &hex::encode(sk.serialize()))?;
-        export(&self.out_dir, &self.name, "pk", &hex::encode(EthAddress::from(pk).0))?;
+        export(&self.out_dir, &self.name, "pk", &hex::encode(pk.serialize()))?;
+        export(&self.out_dir, &self.name, "addr", &hex::encode(EthAddress::from(pk).0))?;
 
         Ok(())
     }

--- a/fendermint/app/src/cmd/key.rs
+++ b/fendermint/app/src/cmd/key.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use anyhow::{anyhow, Context};
-use fendermint_app_options::key::FendermintToEthArgs;
 use fendermint_crypto::{PublicKey, SecretKey};
 use fendermint_vm_actor_interface::eam::EthAddress;
 use fvm_shared::address::Address;
@@ -15,7 +14,7 @@ use super::{from_b64, to_b64};
 use crate::{
     cmd,
     options::key::{
-        AddPeer, EthToFendermintArgs, KeyAddressArgs, KeyArgs, KeyCommands, KeyGenArgs,
+        AddPeer, KeyAddressArgs, KeyArgs, KeyCommands, KeyFromEthArgs, KeyGenArgs, KeyIntoEthArgs,
         KeyIntoTendermintArgs,
     },
 };
@@ -27,14 +26,14 @@ cmd! {
             KeyCommands::IntoTendermint(args) => args.exec(()).await,
             KeyCommands::AddPeer(args) => args.exec(()).await,
             KeyCommands::Address(args) => args.exec(()).await,
-            KeyCommands::EthToFendermint(args) => args.exec(()).await,
-            KeyCommands::FendermintToEth(args) => args.exec(()).await,
+            KeyCommands::FromEth(args) => args.exec(()).await,
+            KeyCommands::IntoEth(args) => args.exec(()).await,
         }
     }
 }
 
 cmd! {
-    EthToFendermintArgs(self) {
+    KeyFromEthArgs(self) {
         let sk = read_secret_key_hex(&self.secret_key)?;
         let pk = sk.public_key();
 
@@ -46,7 +45,7 @@ cmd! {
 }
 
 cmd! {
-    FendermintToEthArgs(self) {
+    KeyIntoEthArgs(self) {
         let sk = read_secret_key(&self.secret_key)?;
         let pk = sk.public_key();
 


### PR DESCRIPTION
Follow up for https://github.com/consensus-shipyard/fendermint/pull/393 

```console
❯ cargo run  -p fendermint_app --release -- key --help
Subcommands related to the construction of signing keys

Usage: fendermint key <COMMAND>

Commands:
  gen              Generate a new Secp256k1 key pair and export them to files in base64 format
  into-tendermint  Convert a secret key file from base64 into the format expected by Tendermint
  address          Convert a public key file from base64 into an f1 Address format an print it to STDOUT
  add-peer         Get the peer ID corresponding to a node ID and its network address and print it to a local file
  from-eth         Converts a hex encoded Ethereum private key into a Base64 encoded Fendermint keypair
  into-eth         Converts a Base64 encoded Fendermint private key in a hex encoded Ethereum secret key and address
  help             Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help

❯ cargo run  -p fendermint_app --release -- key eth-to-fendermint --help
Converts a hex encoded Ethereum private key into a Base64 encoded Fendermint keypair

Usage: fendermint key from-eth [OPTIONS] --secret-key <SECRET_KEY> --name <NAME>

Options:
  -s, --secret-key <SECRET_KEY>  Path to the file that stores the private key (hex format)
  -n, --name <NAME>              Name used to distinguish the files from other exported keys
  -o, --out-dir <OUT_DIR>        Directory to export the key files to; it must exist [default: .]
  -h, --help                     Print help
```