### PR TITLE
INFRA: Add IPC full-node infra recipe

### DIFF
--- a/infra/scripts/fendermint.toml
+++ b/infra/scripts/fendermint.toml
@@ -19,6 +19,8 @@ docker run \
   --network ${NETWORK_NAME} \
   --volume ${BASE_DIR}:/data \
   --env FM_DATA_DIR=/data/fendermint/data \
+  --env FM_ABCI__LISTEN__HOST=0.0.0.0 \
+  --env FM_ETH__LISTEN__HOST=0.0.0.0 \
   --env FM_CHAIN_NAME=${NETWORK_NAME} \
   --env TENDERMINT_RPC_URL=http://${CMT_CONTAINER_NAME}:26657 \
   --env LOG_LEVEL=info \
@@ -30,11 +32,11 @@ docker run \
 """
 dependencies = ["docker-network-create", "fendermint-deps"]
 
-[tasks.fendermint-start-ipc]
-extend = "fendermint-run-ipc"
+[tasks.fendermint-start-validator]
+extend = "fendermint-run-validator"
 env = { "ENTRY" = "fendermint", "CMD" = "run", "FLAGS" = "-d" }
 
-[tasks.fendermint-run-ipc]
+[tasks.fendermint-run-validator]
 script = """
 docker run \
   ${FLAGS} \

--- a/infra/scripts/subnet.toml
+++ b/infra/scripts/subnet.toml
@@ -14,20 +14,45 @@ dependencies = [
     "docker-network-create",
     "cometbft-init",
     "fendermint-deps",
-    "subnet-config",
-    "fendermint-start-ipc",
+    "validator-config",
+    "fendermint-start-validator",
     "cometbft-start",
     "cometbft-wait",
     "ethapi-start",
-    "validator-report",
+    "node-report",
+]
+
+[tasks.child-fullnode-down]
+run_task = "testnode-down"
+
+[tasks.child-fullnode]
+workspace = false
+dependencies = [
+    "testnode-down",
+    "fendermint-pull",
+    "node-init",
+    "docker-network-create",
+    "cometbft-init",
+    "fendermint-deps",
+    "subnet-config",
+    "fendermint-start",
+    "cometbft-start",
+    "cometbft-wait",
+    "ethapi-start",
+    "node-report",
 ]
 
 [tasks.subnet-config]
 dependencies = [
     "subnet-fetch-genesis",
+    "genesis-write",
+]
+
+[tasks.validator-config]
+dependencies = [
+    "subnet-config",
     "subnet-convert-eth-key",
     "testnode-export-keys",
-    "genesis-write",
 ]
 
 [tasks.subnet-convert-eth-key]
@@ -39,11 +64,11 @@ script.pre = "mkdir ${BASE_DIR}/${NODE_NAME}/${KEYS_SUBDIR}; cp ${PRIVATE_KEY_PA
 extend = "fendermint-tool"
 env = { "ENTRY" = "fendermint", "CMD" = "genesis --genesis-file /data/genesis.json ipc from-parent --subnet-id ${SUBNET_ID} -p ${PARENT_ENDPOINT}  --parent-gateway ${PARENT_GATEWAY}  --parent-registry ${PARENT_REGISTRY} --base-fee ${BASE_FEE} --power-scale ${POWER_SCALE}" }
 
-[tasks.validator-report]
+[tasks.node-report]
 script = """cat << EOF
 #################################
 #                               #
-# Subnet validator ready! 🚀    #
+# Subnet node ready! 🚀         #
 #                               #
 #################################
 


### PR DESCRIPTION
This PR includes two new commands (`child-fullnode` and `child-fullnode-down`) in the infra scripts to deploy full nodes, i.e nodes that don't participate from the consensus, but follow the chain and execute and validate new blocks in the network.

Sample execution to test: 
```
cargo make --makefile ./infra/Makefile.toml \
  -e NODE_NAME=validator-2 \
  -e SUBNET_ID=/r314159/t410fhvndv5jlebhuzkeeniowduugkadqra3aibnximy \
  -e CMT_P2P_HOST_PORT=3305 -e CMT_RPC_HOST_PORT=3306 \
  -e BOOTSTRAPS=92f41793a193e37d4b0a27ccce0ef7568b0e42a3@15.204.216.8:26650 \
  -e PARENT_REGISTRY=0x2fdf1b18907341b751B32aF7088D32f6f5a617E0 \
  -e PARENT_GATEWAY=0x5Be26735Ab7A70B057e76e31953d8811f95b05AC \
  child-fullnode
```