### PR TITLE
FIX: Set block hash and number in to_eth_block

### DIFF
--- a/fendermint/eth/api/src/conv/from_tm.rs
+++ b/fendermint/eth/api/src/conv/from_tm.rs
@@ -108,6 +108,8 @@ pub fn to_eth_block(
                 .context("failed to convert to eth transaction")?;
 
             tx.transaction_index = Some(et::U64::from(idx));
+            tx.block_hash = Some(et::H256::from_slice(block.header.hash().as_bytes()));
+            tx.block_number = Some(et::U64::from(block.header.height.value()));
 
             transactions.push(tx);
         }


### PR DESCRIPTION
Related to https://github.com/consensus-shipyard/fendermint/issues/399#issuecomment-1798758781 in #399 

Sets the `blockHash` and `blockNumber` on the transactions when they are embedded in a block. They are obvious, which is why I thought they don't need to be set in this context, but apparently that is not the case. They are probably optional for the sake of transactions that aren't included in any block.