### PR TITLE
FM-407: Insert 0x00..00 for system account

### DIFF
--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -490,6 +490,8 @@ where
     // Calling with 0 nonce so the node figures out the latest value.
     let mut probe_tx = transfer.clone();
     probe_tx.set_nonce(0);
+    // Calling with 0x00..00 address so we see if it world work for calls by clients that set nothing.
+    probe_tx.set_from(Address::default());
     let probe_height = BlockId::Number(BlockNumber::Number(bn));
 
     request(

--- a/fendermint/vm/actor_interface/src/eam.rs
+++ b/fendermint/vm/actor_interface/src/eam.rs
@@ -30,7 +30,7 @@ pub enum Method {
 
 // TODO: We could re-export `fil_evm_actor_shared::address::EvmAddress`.
 #[derive(
-    serde::Deserialize, serde::Serialize, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord,
+    serde::Deserialize, serde::Serialize, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default,
 )]
 pub struct EthAddress(#[serde(with = "strict_bytes")] pub [u8; 20]);
 

--- a/fendermint/vm/actor_interface/src/init.rs
+++ b/fendermint/vm/actor_interface/src/init.rs
@@ -11,7 +11,7 @@ use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_hamt::Hamt;
 use fvm_shared::{address::Address, ActorID, HAMT_BIT_WIDTH};
 
-use crate::eam::EthAddress;
+use crate::{eam::EthAddress, system};
 
 /// Defines first available ID address after builtin actors
 pub const FIRST_NON_SINGLETON_ADDR: ActorID = 100;
@@ -112,6 +112,15 @@ impl State {
                 .context("cannot set ID of eth address")?;
             next_id += 1;
         }
+
+        // Insert the null-Ethereum address to equal the system actor,
+        // so the system actor can be identified by 0xff00..00 as well as 0x00..00
+        address_map
+            .set(
+                Address::from(EthAddress::default()).to_bytes().into(),
+                system::SYSTEM_ACTOR_ID,
+            )
+            .context("cannot set ID of null eth address")?;
 
         #[cfg(feature = "m2-native")]
         let installed_actors = store.put_cbor(&Vec::<Cid>::new(), Code::Blake2b256)?;

--- a/fendermint/vm/message/src/conv/from_eth.rs
+++ b/fendermint/vm/message/src/conv/from_eth.rs
@@ -6,7 +6,7 @@
 use ethers_core::types::{Eip1559TransactionRequest, NameOrAddress, H160, U256};
 use fendermint_vm_actor_interface::{
     eam::{self, EthAddress},
-    evm, system,
+    evm,
 };
 use fvm_ipld_encoding::{BytesSer, RawBytes};
 use fvm_shared::{
@@ -35,10 +35,10 @@ pub fn to_fvm_message(tx: &Eip1559TransactionRequest) -> anyhow::Result<Message>
     };
 
     // The `from` of the transaction is inferred from the signature.
-    // As long as the client and the server use the same hashing scheme,
-    // this should be usable as a delegated address.
-    // If none, use SYSTEM_ACTOR_ADDR. This is similar to https://github.com/filecoin-project/lotus/blob/master/node/impl/full/eth_utils.go#L124
-    let from = tx.from.map_or(system::SYSTEM_ACTOR_ADDR, to_fvm_address);
+    // As long as the client and the server use the same hashing scheme, this should be usable as a delegated address.
+    // If none, use the 0x00..00 null ethereum address, which in the node will be replaced with the SYSTEM_ACTOR_ADDR;
+    // This is similar to https://github.com/filecoin-project/lotus/blob/master/node/impl/full/eth_utils.go#L124
+    let from = to_fvm_address(tx.from.unwrap_or_default());
 
     // Wrap calldata in IPLD byte format.
     let calldata = tx.data.clone().unwrap_or_default().to_vec();


### PR DESCRIPTION
Fixes #407 

Inserts into the `Init` actor an association from the "null" `f410` address `0x00..00` to the `SYSTEM_ACTOR_ID`. This way calls that do not set a `from` will continue to work with implicit semantics FWIW.