### PR TITLE
FIX: Set transaction_type to 2

### DIFF
--- a/fendermint/eth/api/src/conv/from_tm.rs
+++ b/fendermint/eth/api/src/conv/from_tm.rs
@@ -174,7 +174,7 @@ pub fn to_eth_transaction(
         v: et::U64::from(sig.v),
         r: sig.r,
         s: sig.s,
-        transaction_type: None,
+        transaction_type: Some(2u64.into()),
         access_list: None,
         other: Default::default(),
     };

--- a/fendermint/eth/api/src/conv/from_tm.rs
+++ b/fendermint/eth/api/src/conv/from_tm.rs
@@ -168,7 +168,9 @@ pub fn to_eth_transaction(
         gas: et::U256::from(msg.gas_limit),
         max_fee_per_gas: Some(to_eth_tokens(&msg.gas_fee_cap)?),
         max_priority_fee_per_gas: Some(to_eth_tokens(&msg.gas_premium)?),
-        gas_price: None,
+        // Strictly speaking a "Type 2" transaction should not need to set this, but we do because Blockscout
+        // has a database constraint that if a transaction is included in a block this can't be null.
+        gas_price: Some(to_eth_tokens(&msg.gas_fee_cap)? + to_eth_tokens(&msg.gas_premium)?),
         input: et::Bytes::from(msg.params.bytes().to_vec()),
         chain_id: Some(et::U256::from(u64::from(chain_id))),
         v: et::U64::from(sig.v),

--- a/fendermint/vm/message/src/conv/from_fvm.rs
+++ b/fendermint/vm/message/src/conv/from_fvm.rs
@@ -94,7 +94,11 @@ pub fn to_eth_signature(sig: &FvmSignature, normalized: bool) -> anyhow::Result<
     Ok(sig)
 }
 
-pub fn to_eth_transaction(msg: &Message, chain_id: &ChainID) -> anyhow::Result<TypedTransaction> {
+/// Turn an FVM `Message` back into an Ethereum transaction request, mainly for signature checking.
+pub fn to_eth_typed_transaction(
+    msg: &Message,
+    chain_id: &ChainID,
+) -> anyhow::Result<TypedTransaction> {
     let chain_id: u64 = (*chain_id).into();
 
     let Message {
@@ -154,7 +158,7 @@ pub mod tests {
         tests::{EthMessage, KeyPair},
     };
 
-    use super::{to_eth_signature, to_eth_tokens, to_eth_transaction};
+    use super::{to_eth_signature, to_eth_tokens, to_eth_typed_transaction};
 
     #[quickcheck]
     fn prop_to_eth_tokens(tokens: ArbTokenAmount) -> bool {
@@ -207,7 +211,7 @@ pub mod tests {
     fn prop_to_and_from_eth_transaction(msg: EthMessage, chain_id: u64) {
         let chain_id = ChainID::from(chain_id);
         let msg0 = msg.0;
-        let tx = to_eth_transaction(&msg0, &chain_id).expect("to_eth_transaction failed");
+        let tx = to_eth_typed_transaction(&msg0, &chain_id).expect("to_eth_transaction failed");
         let tx = tx.as_eip1559_ref().expect("not an eip1559 transaction");
         let msg1 = to_fvm_message(tx).expect("to_fvm_message failed");
 
@@ -222,7 +226,7 @@ pub mod tests {
 
         let chain_id = ChainID::from(chain_id);
         let msg0 = msg.0;
-        let tx = to_eth_transaction(&msg0, &chain_id).expect("to_eth_transaction failed");
+        let tx = to_eth_typed_transaction(&msg0, &chain_id).expect("to_eth_transaction failed");
 
         let wallet: Wallet<SigningKey> = Wallet::from_bytes(key_pair.sk.serialize().as_ref())
             .expect("failed to create wallet")

--- a/fendermint/vm/message/src/signed.rs
+++ b/fendermint/vm/message/src/signed.rs
@@ -104,7 +104,7 @@ impl SignedMessage {
         // work with regular accounts.
         match maybe_eth_address(&message.from) {
             Some(addr) => {
-                let tx = from_fvm::to_eth_transaction(message, chain_id)
+                let tx = from_fvm::to_eth_typed_transaction(message, chain_id)
                     .map_err(SignedMessageError::Ethereum)?;
 
                 Ok(Signable::Ethereum((tx.sighash(), addr)))
@@ -155,7 +155,7 @@ impl SignedMessage {
         chain_id: &ChainID,
     ) -> Result<Option<DomainHash>, SignedMessageError> {
         if maybe_eth_address(&self.message.from).is_some() {
-            let tx = from_fvm::to_eth_transaction(self.message(), chain_id)
+            let tx = from_fvm::to_eth_typed_transaction(self.message(), chain_id)
                 .map_err(SignedMessageError::Ethereum)?;
 
             let sig = from_fvm::to_eth_signature(self.signature(), true)


### PR DESCRIPTION
Sets the `transaction_type` fields on the `ethers::core::type::Transaction` return values in the API to 2, which should signal that `gas_price` will not be set.