### PR TITLE
FM-408: Debug any hidden revert data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3003,6 +3003,7 @@ dependencies = [
  "lazy_static",
  "prost",
  "serde",
+ "serde_json",
  "tendermint 0.31.1",
  "tendermint-proto 0.31.1",
  "tendermint-rpc",

--- a/fendermint/app/src/cmd/rpc.rs
+++ b/fendermint/app/src/cmd/rpc.rs
@@ -174,7 +174,7 @@ async fn transaction(
                     .await
             })
         },
-        |data| serde_json::Value::String(hex::encode(data)),
+        |data| serde_json::Value::String(hex::encode(data.bytes())),
     )
     .await
 }

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -684,11 +684,19 @@ where
 
     let estimate = response.value;
 
-    // Based on Lotus, we should return the data from the receipt.
     if !estimate.exit_code.is_success() {
-        error(
+        // There might be some revert data encoded as ABI in the response.
+        let revert_data_hex = estimate
+            .return_data
+            .deserialize::<fvm_ipld_encoding::BytesDe>()
+            .map(|bz| bz.into_vec())
+            .map(hex::encode)
+            .unwrap_or_default();
+
+        error_with_data(
             estimate.exit_code,
             format!("failed to estimate gas: {}", estimate.info),
+            revert_data_hex,
         )
     } else {
         Ok(estimate.gas_limit.into())

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -14,7 +14,7 @@ use ethers_core::types::transaction::eip2718::TypedTransaction;
 use ethers_core::utils::rlp;
 use fendermint_rpc::message::MessageFactory;
 use fendermint_rpc::query::QueryClient;
-use fendermint_rpc::response::decode_fevm_invoke;
+use fendermint_rpc::response::{decode_fevm_invoke, decode_fevm_return_data};
 use fendermint_vm_actor_interface::eam::EthAddress;
 use fendermint_vm_actor_interface::evm;
 use fendermint_vm_message::chain::ChainMessage;
@@ -685,12 +685,7 @@ where
     if !estimate.exit_code.is_success() {
         // There might be some revert data encoded as ABI in the response.
         let msg = format!("failed to estimate gas: {}", estimate.info);
-        let (msg, data) = match estimate
-            .return_data
-            .deserialize::<fvm_ipld_encoding::BytesDe>()
-            .map(|bz| bz.into_vec())
-            .map(hex::encode)
-        {
+        let (msg, data) = match decode_fevm_return_data(estimate.return_data).map(hex::encode) {
             Ok(h) => (msg, h),
             Err(e) => (format!("{msg}\n{e:#}"), "".to_string()),
         };

--- a/fendermint/rpc/Cargo.toml
+++ b/fendermint/rpc/Cargo.toml
@@ -31,6 +31,7 @@ clap = { workspace = true }
 ethers = { workspace = true, features = ["abigen"] }
 hex = { workspace = true }
 lazy_static = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/fendermint/rpc/src/query.rs
+++ b/fendermint/rpc/src/query.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use fvm_ipld_encoding::serde::Serialize;
 use fvm_shared::message::Message;
 use prost::Message as ProstMessage;
+use tendermint::abci::response::DeliverTx;
 use tendermint::block::Height;
 use tendermint::v0_37::abci::response;
 use tendermint_rpc::endpoint::abci_query::AbciQuery;
@@ -58,21 +59,7 @@ pub trait QueryClient: Sync {
             .perform(FvmQuery::Call(Box::new(message)), height)
             .await?;
         let height = res.height;
-        let value = extract(res, |res| {
-            let bz: Vec<u8> = fvm_ipld_encoding::from_slice(&res.value)
-                .context("failed to decode IPLD as bytes")?;
-
-            let deliver_tx = tendermint_proto::abci::ResponseDeliverTx::decode(bz.as_ref())
-                .context("failed to deserialize ResponseDeliverTx from proto bytes")?;
-
-            let mut deliver_tx = tendermint::abci::response::DeliverTx::try_from(deliver_tx)
-                .context("failed to create DeliverTx from proto response")?;
-
-            // Mimic the Base64 encoding of the value that Tendermint does.
-            deliver_tx.data = encode_data(&deliver_tx.data);
-
-            Ok(deliver_tx)
-        })?;
+        let value = extract(res, parse_deliver_tx)?;
         Ok(QueryResponse { height, value })
     }
 
@@ -154,4 +141,41 @@ fn extract_actor_state(res: AbciQuery) -> anyhow::Result<Option<(ActorID, ActorS
 
 fn is_not_found(res: &AbciQuery) -> bool {
     res.code.value() == ExitCode::USR_NOT_FOUND.value()
+}
+
+fn parse_deliver_tx(res: AbciQuery) -> anyhow::Result<DeliverTx> {
+    let bz: Vec<u8> =
+        fvm_ipld_encoding::from_slice(&res.value).context("failed to decode IPLD as bytes")?;
+
+    let deliver_tx = tendermint_proto::abci::ResponseDeliverTx::decode(bz.as_ref())
+        .context("failed to deserialize ResponseDeliverTx from proto bytes")?;
+
+    let mut deliver_tx = tendermint::abci::response::DeliverTx::try_from(deliver_tx)
+        .context("failed to create DeliverTx from proto response")?;
+
+    // Mimic the Base64 encoding of the value that Tendermint does.
+    deliver_tx.data = encode_data(&deliver_tx.data);
+
+    Ok(deliver_tx)
+}
+
+#[cfg(test)]
+mod tests {
+    use tendermint_rpc::endpoint::abci_query::AbciQuery;
+
+    use crate::response::decode_fevm_invoke;
+
+    use super::parse_deliver_tx;
+
+    #[test]
+    fn parse_call_query_response() {
+        // Value extracted from a log captured in an issue.
+        let response = "{\"code\":0,\"log\":\"\",\"info\":\"\",\"index\":\"0\",\"key\":null,\"value\":\"mNwIGCESARhAGCIYVxhtGGUYcxhzGGEYZxhlGCAYZhhhGGkYbBhlGGQYIBh3GGkYdBhoGCAYYhhhGGMYaxh0GHIYYRhjGGUYOgoYMBgwGDoYIBh0GDAYMRgxGDkYIBgoGG0YZRh0GGgYbxhkGCAYMxg4GDQYNBg0GDUYMBg4GDMYNxgpGCAYLRgtGCAYYxhvGG4YdBhyGGEYYxh0GCAYchhlGHYYZRhyGHQYZRhkGCAYKBgzGDMYKQoYMBiuGK0YpAEYOhh3CgcYbRhlGHMYcxhhGGcYZRIYNgoEGGYYchhvGG0SGCwYdBg0GDEYMBhmGGEYYRhhGGEYYRhhGGEYYRhhGGEYYRhhGGEYYRhhGGEYYRhhGGEYYRhhGGEYYRhhGGEYYRhhGGEYYRhhGGEYYRhvGG4YYxg2GGkYahhpGBgBEhg0CgIYdBhvEhgsGHQYNBgxGDAYZhg3GG8YNhh3GHYYNBhtGGgYaRg2GG0YdRgzGHgYZhhpGGYYdhhmGGcYbxhyGGIYYRhtGDUYbhhwGGcYbBhpGG0YNBhkGHkYdRh2GGkYaRgYAQ==\",\"proofOps\":null,\"height\":\"6148\",\"codespace\":\"\"}";
+        let query = serde_json::from_str::<AbciQuery>(response).expect("failed to parse AbciQuery");
+        let deliver_tx = parse_deliver_tx(query).expect("failed to parse DeliverTx");
+        let return_data = decode_fevm_invoke(&deliver_tx).expect("failed to decode return data");
+        assert!(deliver_tx.code.is_err());
+        assert!(deliver_tx.info == "message failed with backtrace:\n00: t0119 (method 3844450837) -- contract reverted (33)\n");
+        assert!(return_data.is_empty(), "this error had no revert data");
+    }
 }

--- a/fendermint/rpc/src/response.rs
+++ b/fendermint/rpc/src/response.rs
@@ -4,18 +4,18 @@ use anyhow::{anyhow, Context};
 use base64::Engine;
 use bytes::Bytes;
 use fendermint_vm_actor_interface::eam::{self, CreateReturn};
-use fvm_ipld_encoding::BytesDe;
+use fvm_ipld_encoding::{BytesDe, RawBytes};
 use tendermint::abci::response::DeliverTx;
 
 /// Parse what Tendermint returns in the `data` field of [`DeliverTx`] into bytes.
 /// Somewhere along the way it replaces them with the bytes of a Base64 encoded string,
 /// and `tendermint_rpc` does not undo that wrapping.
-pub fn decode_data(data: &Bytes) -> anyhow::Result<Vec<u8>> {
+pub fn decode_data(data: &Bytes) -> anyhow::Result<RawBytes> {
     let b64 = String::from_utf8(data.to_vec()).context("error parsing data as base64 string")?;
     let data = base64::engine::general_purpose::STANDARD
         .decode(b64)
         .context("error parsing base64 to bytes")?;
-    Ok(data)
+    Ok(RawBytes::from(data))
 }
 
 /// Apply the encoding that Tendermint does to the bytes inside [`DeliverTx`].
@@ -28,7 +28,7 @@ pub fn encode_data(data: &[u8]) -> Bytes {
 /// Parse what Tendermint returns in the `data` field of [`DeliverTx`] as raw bytes.
 ///
 /// Only call this after the `code` of both [`DeliverTx`] and [`CheckTx`] have been inspected!
-pub fn decode_bytes(deliver_tx: &DeliverTx) -> anyhow::Result<Vec<u8>> {
+pub fn decode_bytes(deliver_tx: &DeliverTx) -> anyhow::Result<RawBytes> {
     decode_data(&deliver_tx.data)
 }
 
@@ -42,10 +42,14 @@ pub fn decode_fevm_create(deliver_tx: &DeliverTx) -> anyhow::Result<CreateReturn
 /// Parse what Tendermint returns in the `data` field of [`DeliverTx`] as raw ABI return value.
 pub fn decode_fevm_invoke(deliver_tx: &DeliverTx) -> anyhow::Result<Vec<u8>> {
     let data = decode_data(&deliver_tx.data)?;
+    decode_fevm_return_data(data)
+}
 
+/// Parse what is in the `return_data` field, which is `RawBytes` containing IPLD encoded bytes, into the really raw content.
+pub fn decode_fevm_return_data(data: RawBytes) -> anyhow::Result<Vec<u8>> {
     // Some calls like transfers between Ethereum accounts don't return any data.
     if data.is_empty() {
-        return Ok(data);
+        return Ok(data.into());
     }
 
     // This is the data return by the FEVM itself, not something wrapping another piece,

--- a/fendermint/rpc/src/tx.rs
+++ b/fendermint/rpc/src/tx.rs
@@ -61,7 +61,7 @@ pub trait TxClient<M: BroadcastMode = TxCommit>: BoundClient + Send + Sync {
         params: RawBytes,
         value: TokenAmount,
         gas_params: GasParams,
-    ) -> anyhow::Result<M::Response<Vec<u8>>> {
+    ) -> anyhow::Result<M::Response<RawBytes>> {
         let mf = self.message_factory_mut();
         let msg = mf.transaction(to, method_num, params, value, gas_params)?;
         let fut = self.perform(msg, decode_bytes);

--- a/fendermint/vm/interpreter/src/fvm/query.rs
+++ b/fendermint/vm/interpreter/src/fvm/query.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 use fendermint_vm_message::query::{ActorState, FvmQuery, GasEstimate, StateParams};
 use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{
     bigint::BigInt, econ::TokenAmount, error::ExitCode, message::Message, ActorID, BLOCK_GAS_LIMIT,
 };
@@ -168,6 +169,7 @@ where
                 Some(GasEstimate {
                     exit_code: ret.msg_receipt.exit_code,
                     info: ret.failure_info.map(|x| x.to_string()).unwrap_or_default(),
+                    return_data: ret.msg_receipt.return_data,
                     gas_limit: 0,
                 }),
             ));
@@ -223,6 +225,7 @@ where
                 let est = GasEstimate {
                     exit_code: ExitCode::OK,
                     info: "".to_string(),
+                    return_data: RawBytes::default(),
                     gas_limit: BLOCK_GAS_LIMIT,
                 };
                 return Ok((state, est));
@@ -254,6 +257,7 @@ where
                 .failure_info
                 .map(|x| x.to_string())
                 .unwrap_or_default(),
+            return_data: apply_ret.msg_receipt.return_data,
             gas_limit: apply_ret.msg_receipt.gas_used,
         };
 

--- a/fendermint/vm/interpreter/src/fvm/query.rs
+++ b/fendermint/vm/interpreter/src/fvm/query.rs
@@ -86,6 +86,11 @@ where
                     method_num,
                     exit_code = apply_ret.msg_receipt.exit_code.value(),
                     data = hex::encode(apply_ret.msg_receipt.return_data.bytes()),
+                    info = apply_ret
+                        .failure_info
+                        .as_ref()
+                        .map(|i| i.to_string())
+                        .unwrap_or_default(),
                     "query call"
                 );
 

--- a/fendermint/vm/message/src/query.rs
+++ b/fendermint/vm/message/src/query.rs
@@ -1,6 +1,7 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use cid::Cid;
+use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{
     address::Address, econ::TokenAmount, error::ExitCode, message::Message as FvmMessage,
     version::NetworkVersion,
@@ -109,8 +110,10 @@ pub struct ActorState {
 pub struct GasEstimate {
     /// Exit code, potentially signalling out-of-gas errors, or that the actor was not found.
     pub exit_code: ExitCode,
-    /// Any information about failed estimations.
+    /// Any information about failed estimations from `ApplyRet::failure_info`.
     pub info: String,
+    /// Potential revert data as it appreared in `ApplyRet`.
+    pub return_data: RawBytes,
     /// Gas used during the probing.
     ///
     /// Potentially contains an over-estimate, but it should be within the account balance limit.


### PR DESCRIPTION
Closes #408 

The information from the backtrace in the `ApplyFailure` has indeed been returned in the `info` field of the `DeliverTx`, and it also tries to return any potential revert-data as a hexadecimal string. Unfortunately in this case there isn't anything, as demonstrated by the unit test which parses the value seen in the log. 

Nevertheless the Eth API has been changes so that if there was an error parsing the return data, it would append it to the `message` in the error response, so that we don't have to wonder if it swallowed something.

Also changed the gas estimation query to return the `return_data` and parse it looking for potential errors.