### PR TITLE
FIX: Rectify state and block heights

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -251,7 +251,7 @@ $ cat ~/.cometbft/config/genesis.json
 {
   "genesis_time": "2023-03-29T14:50:12Z",
   "chain_id": "test",
-  "initial_height": "0",
+  "initial_height": "1",
   "consensus_params": {
     "block": {
       "max_bytes": "22020096",

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -773,7 +773,7 @@ where
 
         let app_hash = state.app_hash();
 
-        tracing::info!(
+        tracing::debug!(
             height = state.block_height,
             state_root = state_root.to_string(),
             app_hash = app_hash.to_string(),

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -709,7 +709,11 @@ where
             tendermint::Hash::None => return Err(anyhow!("empty block hash").into()),
         };
 
-        tracing::debug!(block_height, "begin block");
+        tracing::debug!(
+            height = block_height,
+            app_hash = request.header.app_hash.to_string(),
+            "begin block"
+        );
 
         let db = self.state_store_clone();
         let state = self.committed_state()?;

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -625,6 +625,11 @@ where
         &self,
         request: request::PrepareProposal,
     ) -> AbciResult<response::PrepareProposal> {
+        tracing::debug!(
+            height = request.height.value(),
+            time = request.time.to_string(),
+            "prepare proposal"
+        );
         let txs = request.txs.into_iter().map(|tx| tx.to_vec()).collect();
 
         let txs = self
@@ -650,6 +655,11 @@ where
         &self,
         request: request::ProcessProposal,
     ) -> AbciResult<response::ProcessProposal> {
+        tracing::debug!(
+            height = request.height.value(),
+            time = request.time.to_string(),
+            "process proposal"
+        );
         let txs = request.txs.into_iter().map(|tx| tx.to_vec()).collect();
 
         let accept = self

--- a/fendermint/app/src/cmd/genesis.rs
+++ b/fendermint/app/src/cmd/genesis.rs
@@ -196,7 +196,9 @@ fn into_tendermint(genesis_file: &PathBuf, args: &GenesisIntoTendermintArgs) -> 
     let tmg = tendermint::Genesis {
         genesis_time: tendermint::time::Time::from_unix_timestamp(genesis.timestamp.as_secs(), 0)?,
         chain_id: tendermint::chain::Id::try_from(chain_id)?,
-        initial_height: 0,
+        // CometBFT chains typically start from height 1. It doesn't seem to matter if we set this to 0,
+        // the `init_chain` ABCI method will still receive 1.
+        initial_height: 1,
         // Values are based on the default produced by `tendermint init`
         consensus_params: tendermint::consensus::Params {
             block: tendermint::block::Size {


### PR DESCRIPTION
Added the block height to the `init_chain` logs so we can see what was going on. 

In the `genesis into-tendermint` command I set the `initial_height` of the CometBFT `genesis.json` file to 0, but it doesn't seem to make any difference: I get 1 for initial height in `init_chain`, and the first block it creates also has height 1. The first block also has the timestamp of genesis, so ~it's effectively a physical embodiment of it~, and perhaps the only reason for `init_chain` to exist is so we don't have to come up with transactions that achieve the same effect, but it's considered somehow part of the process. Actually the application hash resulting from `init_chain` is already visible in the header of block 1, so it's a separate step.

```console
023-11-10T12:49:24.035117Z  INFO fendermint_app::app: init chain height=1 state_root="bafy2bzaced4bao7y465haxhvakyi25wgagmkz7dxxj2ehr7n6wi2g6m2a4bhq" app_hash="0171A0E402201806E989A5503D1FAE1A21AA4C886F74EF3FBCB04F3AA629357DE859748AC952" timestamp=1680101412 chain_id=2327059176193834
2023-11-10T12:49:24.625519Z  INFO fendermint_app::app: commit state height=1 state_root="bafy2bzaced4bao7y465haxhvakyi25wgagmkz7dxxj2ehr7n6wi2g6m2a4bhq" app_hash="0171A0E402201806E989A5503D1FAE1A21AA4C886F74EF3FBCB04F3AA629357DE859748AC952" timestamp=1680101412
2023-11-10T12:49:25.169955Z  INFO fendermint_app::app: commit state height=2 state_root="bafy2bzaced4bao7y465haxhvakyi25wgagmkz7dxxj2ehr7n6wi2g6m2a4bhq" app_hash="0171A0E40220CA9638741159D186D5EA88E726A1AC85F99423EB492C99A036B5E5E1732D1C30" timestamp=1699620564
```

~I don't know if the 1st block can contain any transactions, or is it an automatic block that everyone creates on their own.~ Adding more logs shows that `prepare_proposal` is indeed called for the first block, which suggests there _could_ be transactions in it, and that one of the validators has to create this block, because the request has a `proposer_address`. 
```console
2023-11-10T13:12:45.936101Z  INFO fendermint_app::app: init chain height=1 state_root="bafy2bzacedkm4sp6hfgkcbhevfkdydx3ioe6ha54eqexshr3c4mhrhvl6bu6k" app_hash="0171A0E4022094E17BB110E40200C7AC52B0FBCB5CB1AF601B63C3D6F0B1B9F5B0EF63D8BEE8" timestamp=1680101412 chain_id=2327059176193834
2023-11-10T13:12:46.461577Z  INFO fendermint_app::app: prepare proposal height=1 time="2023-03-29T14:50:12Z"
2023-11-10T13:12:46.481255Z  INFO fendermint_app::app: process proposal height=1 time="2023-03-29T14:50:12Z"
2023-11-10T13:12:46.999894Z  INFO fendermint_app::app: prepare proposal height=2 time="2023-11-10T13:12:46.490480491Z"
2023-11-10T13:12:47.019522Z  INFO fendermint_app::app: process proposal height=2 time="2023-11-10T13:12:46.490480491Z"
```

The inadvertent effect of the heights is that we save the state at height 1 twice: in `init_chain` and in the first `commit`. 

### Note on block height

There is a slight difference between how CometBFT describes the `block_height` in ABCI queries and what fendermint does: they say it is the height of the block where the state root hash appears, that is, the effects of block N are surfaced in block N+1, so when we query height N we should see the results of block N-1. 

That is not how it works today: we save the application state after committing block N at the height N, and when querying height N we retrieve this state, so we run the queries on the post-state of the blocks, not the pre-state.

In theory we could change how things work in two different ways:
1. save the committed state with `block_height + 1` in `commit`. 
2. change the `FvmQueryHeight` constructor to subtract 1 from the input height

Both would change it so that the when querying height `N` we would only see the effects of block `N-1`, however with the 1st we would save the `init_chain` and the first block under different heights. 

So the best thing to do probably is to save the state at `block_height + 1` and then we adhere to the CometBFT rules and also keep the genesis state separate from the block 1 state.

The PR changes the slot accordingly :point_up_2: 