### PR TITLE
FIX: end block no exec state

### DIFF
--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use std::future::Future;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
@@ -165,7 +165,7 @@ where
     /// The parent finality provider for top down checkpoint
     parent_finality_provider: TopDownFinalityProvider,
     /// State accumulating changes during block execution.
-    exec_state: Arc<Mutex<Option<FvmExecState<SS>>>>,
+    exec_state: Arc<tokio::sync::Mutex<Option<FvmExecState<SS>>>>,
     /// Projected (partial) state accumulating during transaction checks.
     check_state: CheckStateRef<SS>,
     /// How much history to keep.
@@ -203,7 +203,7 @@ where
             interpreter: Arc::new(interpreter),
             resolve_pool,
             parent_finality_provider,
-            exec_state: Arc::new(Mutex::new(None)),
+            exec_state: Arc::new(tokio::sync::Mutex::new(None)),
             check_state: Arc::new(tokio::sync::Mutex::new(None)),
         };
         app.init_committed_state()?;
@@ -292,25 +292,16 @@ where
     }
 
     /// Put the execution state during block execution. Has to be empty.
-    fn put_exec_state(&self, state: FvmExecState<SS>) {
-        let mut guard = self.exec_state.lock().expect("mutex poisoned");
+    async fn put_exec_state(&self, state: FvmExecState<SS>) {
+        let mut guard = self.exec_state.lock().await;
         assert!(guard.is_none(), "exec state not empty");
         *guard = Some(state);
     }
 
     /// Take the execution state during block execution. Has to be non-empty.
-    fn take_exec_state(&self) -> FvmExecState<SS> {
-        let mut guard = self.exec_state.lock().expect("mutex poisoned");
+    async fn take_exec_state(&self) -> FvmExecState<SS> {
+        let mut guard = self.exec_state.lock().await;
         guard.take().expect("exec state empty")
-    }
-
-    /// Apply a function on the state, if it exists.
-    fn map_exec_state<T, F>(&self, f: F) -> Option<T>
-    where
-        F: FnOnce(&FvmExecState<SS>) -> T,
-    {
-        let guard = self.exec_state.lock().expect("mutex poisoned");
-        guard.as_ref().map(f)
     }
 
     /// Take the execution state, update it, put it back, return the output.
@@ -324,14 +315,18 @@ where
             )>,
         >,
     {
-        let state = self.take_exec_state();
+        let mut guard = self.exec_state.lock().await;
+        let state = guard.take().expect("exec state empty");
+
         let ((_pool, _provider, state), ret) = f((
             self.resolve_pool.clone(),
             self.parent_finality_provider.clone(),
             state,
         ))
         .await?;
-        self.put_exec_state(state);
+
+        *guard = Some(state);
+
         Ok(ret)
     }
 
@@ -682,7 +677,7 @@ where
 
         tracing::debug!("initialized exec state");
 
-        self.put_exec_state(state);
+        self.put_exec_state(state).await;
 
         let ret = self
             .modify_exec_state(|s| self.interpreter.begin(s))
@@ -694,19 +689,19 @@ where
 
     /// Apply a transaction to the application's state.
     async fn deliver_tx(&self, request: request::DeliverTx) -> AbciResult<response::DeliverTx> {
+        tracing::info!("deliver_tx");
         let msg = request.tx.to_vec();
-        let result = self
+        let (result, block_hash) = self
             .modify_exec_state(|s| async {
-                let res = self.interpreter.deliver(s, msg).await;
+                let ((pool, provider, state), res) = self.interpreter.deliver(s, msg).await?;
+                let block_hash = state.block_hash();
                 tracing::info!("sleeping...");
                 tokio::time::sleep(Duration::from_secs(60)).await;
                 tracing::info!("sleep over");
-                res
+                Ok(((pool, provider, state), (res, block_hash)))
             })
             .await
             .context("deliver failed")?;
-
-        let block_hash = self.map_exec_state(|s| s.block_hash()).flatten();
 
         let response = match result {
             Err(e) => invalid_deliver_tx(AppError::InvalidEncoding, e.description),
@@ -734,7 +729,7 @@ where
 
     /// Signals the end of a block.
     async fn end_block(&self, request: request::EndBlock) -> AbciResult<response::EndBlock> {
-        tracing::debug!(height = request.height, "end block");
+        tracing::info!(height = request.height, "end block");
 
         // TODO: Return events from epoch transitions.
         let ret = self
@@ -747,7 +742,7 @@ where
 
     /// Commit the current state at the current height.
     async fn commit(&self) -> AbciResult<response::Commit> {
-        let exec_state = self.take_exec_state();
+        let exec_state = self.take_exec_state().await;
 
         // Commit the execution state to the datastore.
         let mut state = self.committed_state()?;

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -3,7 +3,6 @@
 use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -695,9 +694,6 @@ where
             .modify_exec_state(|s| async {
                 let ((pool, provider, state), res) = self.interpreter.deliver(s, msg).await?;
                 let block_hash = state.block_hash();
-                tracing::info!("sleeping...");
-                tokio::time::sleep(Duration::from_secs(60)).await;
-                tracing::info!("sleep over");
                 Ok(((pool, provider, state), (res, block_hash)))
             })
             .await
@@ -729,7 +725,7 @@ where
 
     /// Signals the end of a block.
     async fn end_block(&self, request: request::EndBlock) -> AbciResult<response::EndBlock> {
-        tracing::info!(height = request.height, "end block");
+        tracing::debug!(height = request.height, "end block");
 
         // TODO: Return events from epoch transitions.
         let ret = self

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -688,7 +688,6 @@ where
 
     /// Apply a transaction to the application's state.
     async fn deliver_tx(&self, request: request::DeliverTx) -> AbciResult<response::DeliverTx> {
-        tracing::info!("deliver_tx");
         let msg = request.tx.to_vec();
         let (result, block_hash) = self
             .modify_exec_state(|s| async {

--- a/fendermint/testing/smoke-test/Makefile.toml
+++ b/fendermint/testing/smoke-test/Makefile.toml
@@ -157,6 +157,7 @@ docker run \
   --network ${NETWORK_NAME} \
   --volume ${TEST_DATA_DIR}:/data \
   --volume ${TEST_SCRIPTS_DIR}:/scripts \
+  --env RUST_BACKTRACE=1 \
   --env FM_DATA_DIR=/data/fendermint/data \
   --env FM_CHAIN_NAME=${NETWORK_NAME} \
   --env TENDERMINT_RPC_URL=http://${CMT_CONTAINER_NAME}:26657 \


### PR DESCRIPTION
Trying to replicate `end_block` panicking due to `exec state empty`. 

Steps to replicate:
1. Add a long sleep in `deliver_tx` while the interpreter is owning the state.
2. `make docker-build`
3. `cd fendermint/testing/smoke-tests`
4. `cargo make setup`
5. `cargo make simplecoin-example`
6. `docker logs -f smoke-fendermint`
7. `cargo make teardown`

The logs show that:
```console
2023-11-10T15:00:34.099374Z  INFO fendermint_vm_interpreter::fvm::exec: tx delivered height=17 from="f1kigdcls46syhfzfrmorydy2wdgvunw7alzk2pca" to="f010" method_num=4 exit_code=0
2023-11-10T15:00:34.099445Z  INFO fendermint_app::app: sleeping...
thread 'tokio-runtime-worker' panicked at /app/fendermint/app/src/app.rs:304:22:
exec state empty
stack backtrace:
   0: rust_begin_unwind
             at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/std/src/panicking.rs:595:5
   1: core::panicking::panic_fmt
             at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/core/src/panicking.rs:67:14
   2: core::panicking::panic_display
             at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/core/src/panicking.rs:150:5
   3: core::panicking::panic_str
             at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/core/src/panicking.rs:134:5
   4: core::option::expect_failed
             at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/core/src/option.rs:1988:5
   5: fendermint_app::app::App<DB,SS,S,I>::take_exec_state
   6: <fendermint_app::app::App<DB,SS,S,I> as fendermint_abci::application::Application>::end_block::{{closure}}
   7: <fendermint_abci::application::ApplicationService<A> as tower_service::Service<tendermint::v0_37::abci::request::Request>>::call::{{closure}}

```

Adding a bit more logging shows that there is virtually no timeout before the `end_block` is called:
```console
2023-11-10T15:12:38.254063Z  INFO fendermint_app::app: deliver_tx
2023-11-10T15:12:38.257502Z  INFO fendermint_vm_interpreter::fvm::exec: tx delivered height=209 from="f1sypvu5lgn6f7vyyz74vgw2nuuw3qtvlkccw4xyq" to="f010" method_num=4 exit_code=0
2023-11-10T15:12:38.257566Z  INFO fendermint_app::app: sleeping...
2023-11-10T15:12:38.257661Z  INFO fendermint_app::app: end block height=209
```

### Action

So my assumption about CometBFT not calling the next step in the ABCI lifecyle until the previous one is finished was wrong, perhaps it calls them in a pipeline. We have the `[abci.bound]` setting for the number of concurrent requests, but it's set to 1 - nevertheless it's possible that it's the `tower-abci` service (or my adapter on it) that does this. 

I'm changing the `Mutex` around the execution state to be from `tokio` and I'm going to hold it while processing the transaction.

With that change the panic is gone:
```
2023-11-10T15:36:05.941889Z  INFO fendermint_vm_interpreter::fvm::check: check transaction exit_code=0 from="f1lwxsaxecucemgoguobkkr44ybhxlnsvhv2ih2ui" to="f010" method_num=4 info=""
2023-11-10T15:36:06.260050Z  INFO fendermint_app::app: deliver_tx
2023-11-10T15:36:06.261358Z  INFO fendermint_vm_interpreter::fvm::exec: tx delivered height=16 from="f1lwxsaxecucemgoguobkkr44ybhxlnsvhv2ih2ui" to="f010" method_num=4 exit_code=0
2023-11-10T15:36:06.261382Z  INFO fendermint_app::app: sleeping...
2023-11-10T15:36:06.261409Z  INFO fendermint_app::app: end block height=16
2023-11-10T15:37:06.262721Z  INFO fendermint_app::app: sleep over
2023-11-10T15:37:06.377209Z  INFO fendermint_app::app: end block height=17

```