### PR TITLE
FIX: Pretend there is a block 0

### DIFF
--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -35,7 +35,7 @@ use tendermint_rpc::{
 };
 
 use crate::conv::from_eth::to_fvm_message;
-use crate::conv::from_tm::{self, msg_hash, to_chain_message, to_cumulative};
+use crate::conv::from_tm::{self, msg_hash, to_chain_message, to_cumulative, to_eth_block_zero};
 use crate::error::error_with_data;
 use crate::filters::{matches_topics, FilterId, FilterKind, FilterRecords};
 use crate::{
@@ -323,7 +323,7 @@ where
     C: Client + Sync + Send,
 {
     match data.block_by_hash_opt(block_hash).await? {
-        Some(block) if from_tm::is_block_zero(&block) => Ok(Some(data.zero_block(block)?)),
+        Some(block) if from_tm::is_block_zero(&block) => Ok(Some(to_eth_block_zero(block)?)),
         Some(block) => data.enrich_block(block, full_tx).await.map(Some),
         None => Ok(None),
     }
@@ -341,7 +341,7 @@ where
         block if block.header().height.value() > 0 => {
             data.enrich_block(block, full_tx).await.map(Some)
         }
-        block if from_tm::is_block_zero(&block) => Ok(Some(data.zero_block(block)?)),
+        block if from_tm::is_block_zero(&block) => Ok(Some(to_eth_block_zero(block)?)),
         _ => Ok(None),
     }
 }

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -323,6 +323,7 @@ where
     C: Client + Sync + Send,
 {
     match data.block_by_hash_opt(block_hash).await? {
+        Some(block) if from_tm::is_block_zero(&block) => Ok(Some(data.zero_block(block)?)),
         Some(block) => data.enrich_block(block, full_tx).await.map(Some),
         None => Ok(None),
     }
@@ -340,6 +341,7 @@ where
         block if block.header().height.value() > 0 => {
             data.enrich_block(block, full_tx).await.map(Some)
         }
+        block if from_tm::is_block_zero(&block) => Ok(Some(data.zero_block(block)?)),
         _ => Ok(None),
     }
 }
@@ -500,6 +502,9 @@ where
     C: Client + Sync + Send,
 {
     let block = data.block_by_height(block_number).await?;
+    if from_tm::is_block_zero(&block) {
+        return Ok(Vec::new());
+    }
     let height = block.header.height;
     let state_params = data
         .client

--- a/fendermint/eth/api/src/conv/from_tm.rs
+++ b/fendermint/eth/api/src/conv/from_tm.rs
@@ -65,7 +65,7 @@ fn block_zero() -> tendermint::Block {
 
     let header = tendermint::block::Header {
         version: tendermint::block::header::Version { block: 0, app: 0 },
-        chain_id: tendermint::chain::Id::try_from("n/a").unwrap(),
+        chain_id: tendermint::chain::Id::try_from("UNSPECIFIED").expect("invalid chainid"),
         height: tendermint::block::Height::try_from(0u64).unwrap(),
         time: tendermint::time::Time::unix_epoch(),
         last_block_id: None,
@@ -563,4 +563,16 @@ pub fn collect_emitters(events: &[abci::Event]) -> HashSet<Address> {
         }
     }
     emitters
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::conv::from_tm::is_block_zero;
+
+    use super::BLOCK_ZERO;
+
+    #[test]
+    fn block_zero_can_be_created() {
+        assert!(is_block_zero(&BLOCK_ZERO))
+    }
 }

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -16,7 +16,6 @@ use fendermint_vm_message::query::FvmQueryHeight;
 use fendermint_vm_message::signed::DomainHash;
 use fendermint_vm_message::{chain::ChainMessage, conv::from_eth::to_fvm_address};
 use fvm_ipld_encoding::{de::DeserializeOwned, RawBytes};
-use fvm_shared::bigint::Zero;
 use fvm_shared::{chainid::ChainID, econ::TokenAmount, error::ExitCode, message::Message};
 use rand::Rng;
 use tendermint::block::Height;
@@ -273,29 +272,6 @@ where
                 .context("failed to convert hash to JSON")?
         };
 
-        Ok(block)
-    }
-
-    /// Artificial block-zero.
-    pub fn zero_block(
-        &self,
-        block: tendermint::Block,
-    ) -> JsonRpcResult<et::Block<serde_json::Value>>
-    where
-        C: Client + Sync + Send,
-    {
-        let block_results = tendermint_rpc::endpoint::block_results::Response {
-            height: block.header.height,
-            txs_results: None,
-            begin_block_events: None,
-            end_block_events: None,
-            validator_updates: Vec::new(),
-            consensus_param_updates: None,
-        };
-        let block = to_eth_block(block, block_results, TokenAmount::zero(), ChainID::from(0))
-            .context("failed to map block zero to eth")?;
-        let block =
-            map_rpc_block_txs(block, serde_json::to_value).context("failed to convert to JSON")?;
         Ok(block)
     }
 


### PR DESCRIPTION
Creates a `BLOCK_ZERO` which is returned when the client is looking for one at height 0 or when it's looking for the `BLOCK_ZERO_HASH`. 

Testing through `ethers.rs` example.