### PR TITLE
FIX: Change checkpoint broadcast mode to sync

### DIFF
--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -42,6 +42,8 @@ state_hist_size = 0
 max_retries = 5
 # Tome to wait between retries, in seconds. It should roughly correspond to the block interval.
 retry_delay = 2
+# Any over-estimation to apply on top of the estimate returned by the API.
+gas_overestimation_rate = 2
 
 # FVM configuration
 [fvm]

--- a/fendermint/app/settings/src/lib.rs
+++ b/fendermint/app/settings/src/lib.rs
@@ -100,6 +100,8 @@ pub struct BroadcastSettings {
     /// Time to wait between retries. This should roughly correspond to the block interval.
     #[serde_as(as = "DurationSeconds<u64>")]
     pub retry_delay: Duration,
+    /// Any over-estimation to apply on top of the estimate returned by the API.
+    pub gas_overestimation_rate: f64,
 }
 
 #[serde_as]

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -97,6 +97,7 @@ async fn run(settings: Settings) -> anyhow::Result<()> {
             sk.clone(),
             settings.fvm.gas_fee_cap.clone(),
             settings.fvm.gas_premium.clone(),
+            settings.fvm.gas_overestimation_rate,
         )
         .with_max_retries(settings.broadcast.max_retries)
         .with_retry_delay(settings.broadcast.retry_delay);

--- a/fendermint/vm/interpreter/src/fvm/broadcast.rs
+++ b/fendermint/vm/interpreter/src/fvm/broadcast.rs
@@ -103,7 +103,7 @@ where
 
     /// Send a transaction to the chain and return is hash.
     ///
-    /// It currently doesn't wait for the execution only, only that it has successfully been added to the mempool,
+    /// It currently doesn't wait for the execution, only that it has successfully been added to the mempool,
     /// or if not then an error is returned. The reason for not waiting for the commit is that the Tendermint
     /// client seems to time out if the check fails, waiting for the inclusion which will never come, instead of
     /// returning the result with no `deliver_tx` and a failed `check_tx`. We can add our own mechanism to wait

--- a/fendermint/vm/interpreter/src/fvm/checkpoint.rs
+++ b/fendermint/vm/interpreter/src/fvm/checkpoint.rs
@@ -284,10 +284,13 @@ where
         .add_checkpoint_signature_calldata(checkpoint, &power_table.0, validator, secret_key)
         .context("failed to produce checkpoint signature calldata")?;
 
-    broadcaster
+    let tx_hash = broadcaster
         .fevm_invoke(Address::from(gateway.addr()), calldata, chain_id)
         .await
         .context("failed to broadcast signature")?;
+
+    // The transaction should be in the mempool now.
+    tracing::info!(tx_hash = tx_hash.to_string(), "broadcasted signature");
 
     Ok(())
 }


### PR DESCRIPTION
Changes the mode of broadcasting checkpoint signatures from `TxCommit` to `TxSync`, that is, instead of waiting for `deliver_tx` it only waits for `check_tx`. 

The reason is that looking at the logs, the `broadcast_tx_commit` of the CometBFT API doesn't work the way I thought it did. I thought that it will wait for the commit (`deliver_tx`) of the transaction, but also return early if `check_tx` fails, since the response has the results for both. Instead what we see is that it times out waiting for delivery:

```console
2023-11-13T10:00:20.556795Z  INFO fendermint_vm_interpreter::fvm::query: query actor state height=40862 pending=true addr="t410frbdnwklaitcjsqe7swjwp5naple6vthq4woyfry" found=true
2023-11-13T10:00:20.557981Z  INFO fendermint_vm_interpreter::fvm::query: query estimate gas height=40862 pending=false to="t410fo6vebmifqq3sqcemaezoip6eineiqhnidng7rxi" from="t410frbdnwklaitcjsqe7swjwp5naple6vthq4woyfry" method_num=3844450837
2023-11-13T10:00:20.617176Z  INFO fendermint_vm_interpreter::fvm::check: check transaction exit_code=0 from="t410frbdnwklaitcjsqe7swjwp5naple6vthq4woyfry" to="t410fo6vebmifqq3sqcemaezoip6eineiqhnidng7rxi" method_num=3844450837 info=""
2023-11-13T10:00:21.398207Z  INFO fendermint_vm_interpreter::fvm::check: check transaction exit_code=33 from="t410frbdnwklaitcjsqe7swjwp5naple6vthq4woyfry" to="t410fo6vebmifqq3sqcemaezoip6eineiqhnidng7rxi" method_num=3844450837 info="message failed with backtrace:\n00: t064 (method 3844450837) -- contract reverted (33)\n01: t064 (method 6) -- out of gas (7)\n"
2023-11-13T10:00:30.618450Z ERROR fendermint_vm_interpreter::fvm::exec: error broadcasting checkpoint signature error=failed to broadcast checkpoint signature
Caused by:
  0: failed to broadcast signature
  1: failed to invoke contract
  2: response error
    
    Caused by:
      Internal error: timed out waiting for tx to be included in a block (code: -32603)
    
    Location:
      /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/flex-error-0.4.4/src/tracer_impl/eyre.rs:10:9
  3: response error
  4: Internal error: timed out waiting for tx to be included in a block (code: -32603)
Stack backtrace:
  0: <fendermint_rpc::client::BoundFendermintClient<C> as fendermint_rpc::tx::TxClient>::perform::{{closure}}
  1: fendermint_rpc::tx::TxClient::fevm_invoke::{{closure}}
  2: fendermint_vm_interpreter::fvm::checkpoint::broadcast_incomplete_signatures::{{closure}}
  3: fendermint_vm_interpreter::fvm::exec::<impl fendermint_vm_interpreter::ExecInterpreter for fendermint_vm_interpreter::fvm::FvmMessageInterpreter<DB,TC>>::end::{{closure}}::{{closure}}
  4: tokio::runtime::task::core::Core<T,S>::poll
  5: tokio::runtime::task::harness::Harness<T,S>::poll
  6: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
  7: tokio::runtime::scheduler::multi_thread::worker::run
  8: tokio::runtime::task::core::Core<T,S>::poll
  9: tokio::runtime::task::harness::Harness<T,S>::poll
 10: std::sys_common::backtrace::__rust_begin_short_backtrace
 11: core::ops::function::FnOnce::call_once{{vtable.shim}}
 12: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
       at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/alloc/src/boxed.rs:2007:9
   <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
       at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/alloc/src/boxed.rs:2007:9
   std::sys::unix::thread::thread::new::thread_start
       at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/std/src/sys/unix/thread.rs:108:17
 13: <unknown>
 14: clone height=40860
```

The problem is that this prevented the `retry!` mechanism I put in place because the [error case analysis](https://filecoinproject.slack.com/archives/C04JR5R1UL8/p1699876861338349?thread_ts=1699874787.947719&cid=C04JR5R1UL8) is circumvented by the unexpected error. We can't say what to do with a timeout so the best it can do is retry after the next checkpoint, if the checkpoint is still pending. The retry only works if there is an exit code, and a timeout is not it.

What I thought was happening was that a validator tries to submit their signature but because they are the first one they get a gas estimation that is below what it will be once it actually hits the chain and it's no longer alone in the epoch. Or it might just under estimate for some reason. 

Maybe I'll put it some over estimation on top of the estimation.


### Did it crash?

No, Fendermint didn't crash, the above is still just an error log. It just failed to send a checkpoint signature in a spawned background task, which is annoying. It will retry next time, but the estimates can keep being off the mark.


### What does CometBFT say?

Looking at the logs of https://docs.cometbft.com/v0.37/rpc/#/Tx/broadcast_tx_commit making this change is the right thing to do:

> IMPORTANT: use only for testing and development. In production, use BroadcastTxSync or BroadcastTxAsync. You can subscribe for the transaction result using JSONRPC via a websocket. 

However, I still don't understand the error behaviour:

> CONTRACT: only returns error if mempool.CheckTx() errs or if we timeout waiting for tx to commit.
> If CheckTx or DeliverTx fail, no error will be returned, but the returned result will contain a non-OK ABCI code.

It should not have returned an error, but a regular response with codes to look at :shrug: 

