### PR TITLE
FIX: Do not go to CometBFT during end_block for the power table

### DIFF
--- a/fendermint/vm/interpreter/src/fvm/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/exec.rs
@@ -134,8 +134,7 @@ where
 
     async fn end(&self, mut state: Self::State) -> anyhow::Result<(Self::State, Self::EndOutput)> {
         let updates = if let Some((checkpoint, updates)) =
-            checkpoint::maybe_create_checkpoint(&self.client, &self.gateway, &mut state)
-                .await
+            checkpoint::maybe_create_checkpoint(&self.gateway, &mut state)
                 .context("failed to create checkpoint")?
         {
             // Asynchronously broadcast signature, if validating.


### PR DESCRIPTION
Changes the `end_block` processing so that it doesn't try to fetch the power table from CometBFT, which may not respond to requests yet, for example (maybe) because it's trying to replay the last block it failed on. 

The asynchronous `broadcast_incomplete_signatures` method still gets the power table from CometBFT because that's the only place where the history is preserved, but if that fails, at least it will be retried later.