### PR TITLE
CONFIG: Set subscription limits

### DIFF
--- a/fendermint/testing/smoke-test/Makefile.toml
+++ b/fendermint/testing/smoke-test/Makefile.toml
@@ -133,6 +133,8 @@ docker run \
   --volume ${TEST_DATA_DIR}/cometbft:/cometbft \
   --env CMT_PROXY_APP=tcp://${FM_CONTAINER_NAME}:26658 \
   --env CMT_PEX=false \
+  --env CMT_MAX_SUBSCRIPTION_CLIENTS=10 \
+  --env CMT_MAX_SUBSCRIPTIONS_PER_CLIENT=1000 \
   ${CMT_DOCKER_IMAGE} \
   ${CMD}
 """

--- a/infra/scripts/cometbft.toml
+++ b/infra/scripts/cometbft.toml
@@ -26,6 +26,8 @@ docker run \
   --volume ${CMT_DIR}:/cometbft \
   --env CMT_PROXY_APP=tcp://${FM_CONTAINER_NAME}:26658 \
   --env CMT_PEX=false \
+  --env CMT_MAX_SUBSCRIPTION_CLIENTS=10 \
+  --env CMT_MAX_SUBSCRIPTIONS_PER_CLIENT=1000 \
   ${CMT_DOCKER_IMAGE} \
   ${CMD}
 """
@@ -35,7 +37,7 @@ dependencies = ["cometbft-pull", "docker-network-create"]
 script_runner = "@rust"
 description = "This script resolve the external IP and sets NODE_EXTERNAL_IP variable using rust-env plugin"
 plugin = "rust-env"
-script="""
+script = """
 //! ```cargo
 //! [dependencies]
 //! reqwest = { version = "0.11", features = ["blocking"] }
@@ -174,12 +176,12 @@ extend = "docker-logs"
 env = { "CONTAINER_NAME" = "${CMT_CONTAINER_NAME}" }
 
 [tasks.seed-enable]
-script="""
+script = """
 sed -i'' -e "s|seed_mode = false|seed_mode = true|" ${CMT_DIR}/config/config.toml
 """
 
 [tasks.addr-book-enable]
-script="""
+script = """
 sed -i'' -e "s|addr_book_strict = false|addr_book_strict = true|" ${CMT_DIR}/config/config.toml
 """
 


### PR DESCRIPTION
Sets some non-default CometBFT subscription limits, because in our case the `ethapi` container subscribes on behalf of users, and turning Ethereum filters into CometBFT transactions is prone to a combinatorial explosion [here](https://github.com/consensus-shipyard/fendermint/blob/2f02238ec355422f31845031ee39e61fbd903c1a/fendermint/eth/api/src/filters.rs#L93), as demonstrated by [this test](https://github.com/consensus-shipyard/fendermint/blob/2f02238ec355422f31845031ee39e61fbd903c1a/fendermint/eth/api/src/filters.rs#L776). 

Even the [FEVM test suite](https://github.com/consensus-shipyard/fevm-contract-tests/blob/main/test/ethers.js/ERC20.js#L94-L173) subscribes to more than the default limits.