### PR TITLE
Fix Fendermint folder

### DIFF
--- a/infra/scripts/fendermint.toml
+++ b/infra/scripts/fendermint.toml
@@ -18,7 +18,7 @@ docker run \
   --user $(id -u) \
   --network ${NETWORK_NAME} \
   --volume ${BASE_DIR}:/data \
-  --env FM_DATA_DIR=/data/fendermint/data \
+  --env FM_DATA_DIR=/data/${NODE_NAME}/fendermint/data \
   --env FM_ABCI__LISTEN__HOST=0.0.0.0 \
   --env FM_ETH__LISTEN__HOST=0.0.0.0 \
   --env FM_CHAIN_NAME=${NETWORK_NAME} \
@@ -45,7 +45,7 @@ docker run \
   --user $(id -u) \
   --network ${NETWORK_NAME} \
   --volume ${BASE_DIR}:/data \
-  --env FM_DATA_DIR=/data/fendermint/data \
+  --env FM_DATA_DIR=/data/${NODE_NAME}/fendermint/data \
   --env FM_CHAIN_NAME=${NETWORK_NAME} \
   --env FM_IPC__SUBNET_ID=${SUBNET_ID} \
   --env FM_IPC__TOPDOWN__CHAIN_HEAD_DELAY=${TOPDOWN_CHAIN_HEAD_DELAY} \
@@ -85,7 +85,7 @@ docker run \
   --user $(id -u) \
   --network ${NETWORK_NAME} \
   --volume ${BASE_DIR}:/data \
-  --env FM_DATA_DIR=/data/fendermint/data \
+  --env FM_DATA_DIR=/data/${NODE_NAME}/fendermint/data \
   --env FM_CHAIN_NAME=${NETWORK_NAME} \
   --env FM_IPC__SUBNET_ID=${SUBNET_ID} \
   --env FM_IPC__TOPDOWN__CHAIN_HEAD_DELAY=${TOPDOWN_CHAIN_HEAD_DELAY} \


### PR DESCRIPTION
When you are starting validator through infra scripts - it will put cometbft data files into ~/.ipc/${SUBNET_ID}/${NODE_NAME}/cometbft, but Fendermint data will go into ~/.ipc/${SUBNET_ID}/fendermint for some reason, making it impossible to run multiple validators of the same subnet on 1 machine. This PR is intended to fix this behavior.