### PR TITLE
FM-361: Serve snapshot chunks

### DIFF
--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -864,4 +864,28 @@ where
             Ok(Default::default())
         }
     }
+
+    /// Used during state sync to retrieve chunks of snapshots from peers.
+    async fn load_snapshot_chunk(
+        &self,
+        request: request::LoadSnapshotChunk,
+    ) -> AbciResult<response::LoadSnapshotChunk> {
+        if let Some(ref client) = self.snapshots {
+            if let Some(snapshot) =
+                atomically(|| client.find_snapshot(request.height.value(), request.format)).await
+            {
+                match snapshot.load_chunk(request.chunk as usize) {
+                    Ok(chunk) => {
+                        return Ok(response::LoadSnapshotChunk {
+                            chunk: chunk.into(),
+                        });
+                    }
+                    Err(e) => {
+                        tracing::warn!("failed to load chunk: {e:#}");
+                    }
+                }
+            }
+        }
+        Ok(Default::default())
+    }
 }

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -872,7 +872,7 @@ where
     ) -> AbciResult<response::LoadSnapshotChunk> {
         if let Some(ref client) = self.snapshots {
             if let Some(snapshot) =
-                atomically(|| client.find_snapshot(request.height.value(), request.format)).await
+                atomically(|| client.access_snapshot(request.height.value(), request.format)).await
             {
                 match snapshot.load_chunk(request.chunk as usize) {
                     Ok(chunk) => {

--- a/fendermint/vm/snapshot/src/manager.rs
+++ b/fendermint/vm/snapshot/src/manager.rs
@@ -304,10 +304,7 @@ where
         std::fs::remove_file(snapshot_dir.join(SNAPSHOT_FILE_NAME))
             .context("failed to remove CAR file")?;
 
-        Ok(SnapshotItem {
-            snapshot_dir,
-            manifest,
-        })
+        Ok(SnapshotItem::new(snapshot_dir, manifest))
     }
 }
 


### PR DESCRIPTION
Closes #361 

Implements the `load_snapshot_chunk` ABCI method. It looks for the snapshot requested; if it exists it tries to load it from the disk. 

### Notes

I did not build in any protection against the snapshot not being deleted between the time we find the record in memory and when we try to read it. I don't want to read it inside the STM transaction because that wouldn't guarantee that the pruning task doesn't commit while this one is running, so it's the same from that perspective, but its worse because it can re-read files if the transaction gets retried. 

What would solve it if we updated the snapshot item with a timestamp of when it was last requested and did not delete if it was recent, but I'm not sure if it can't be abused. 

Another option is to just mark it as being read right now, and update it again to release it when done. 

I'm not sure if we tried to read the file while the directory is being deleted, then the delete would leave this and only this file in the directory, and we'd have a partial subnet that would cause problems further down the line. Will have to try.