### PR TITLE
Look ahead limit use finalized height

### DIFF
--- a/fendermint/vm/topdown/src/error.rs
+++ b/fendermint/vm/topdown/src/error.rs
@@ -15,6 +15,8 @@ pub enum Error {
     ParentChainReorgDetected,
     #[error("Cannot query parent at height {1}: {0}")]
     CannotQueryParent(String, BlockHeight),
+    /// This error happens when querying top down messages, the block ahead are all null rounds.
+    /// See `parent_views_at_height` for detailed explanation
     #[error("Look ahead limit reached from {0}: {1}")]
     LookAheadLimitReached(BlockHeight, BlockHeight),
 }

--- a/fendermint/vm/topdown/src/sync.rs
+++ b/fendermint/vm/topdown/src/sync.rs
@@ -447,7 +447,16 @@ async fn parent_views_in_block_range(
     Ok(updates)
 }
 
-/// Obtain the new parent views for the target height
+/// Obtain the new parent views for the target height.
+///
+/// For `look_ahead_limit`, the explanation is as follows:
+/// Say the current height is h and we need to fetch the top down messages. For `lotus`, the state
+/// at height h is only finalized at h + 1. The block hash at height h will return empty top down
+/// messages. In this case, we need to get the block hash at height h + 1 to query the top down messages.
+/// Sadly, the height h + 1 could be null block, we need to continuously look ahead until we found
+/// a height that is not null. But we cannot go all the way to the block head as it's not considered
+/// final yet. So we need to use a `look_ahead_limit` that restricts how far as head we should go.
+/// If we still cannot find a height that is non-null, maybe we should try later
 async fn parent_views_at_height(
     parent_proxy: &Arc<IPCProviderProxy>,
     previous_hash: &BlockHash,


### PR DESCRIPTION
Fix look ahead null block error. 

This is a tricky edge case, say the current height is 100 and chain head is 1000 and our block fetching limit is 100. So we will be fetching from height 100 to 200 in this batch. Now, when in the loop we queried till block 199 and we need to fetch the top down messages. Because we need the block hash at block 200, so we query block 200 first  to get the block hash. But sadly block 200 is a null block which throws an error. We should fetch block 201. As a safety precaution, if 201 is a null block ,we need to fetch 202 and so on. Theoretically, we can go all the way to block head. But block head is not considered finalised, so we put a `look_ahead_limit`. 

According to the old logic, the `look_ahead_limit` is just the end block height of the current batch, which is 200 in the above example. So if block 200 is a null block, an error will be thrown as we reached look ahead limit. That's why the fetching parent is stuck. We change the `look_ahead_limit` to `finalised_height`, i.e. the height x blocks away from the chain head that we considered final. If 200 is the finalised height, it will throw an error, but as chain head progresses, the `finalised_height` will move beyond 200 and we should not get stuck.