### PR TITLE
DEBUG: Gas logging and a tweak to set prices to 0 for initial estimation

### DIFF
--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -599,6 +599,7 @@ where
 
     let sighash = tx.sighash();
     let msghash = et::TxHash::from(ethers_core::utils::keccak256(rlp.as_raw()));
+    tracing::debug!(?sighash, eth_hash = ?msghash, ?tx, "received raw transaction");
 
     let msg = to_fvm_message(tx, false)?;
     let msg = SignedMessage {
@@ -607,10 +608,10 @@ where
     };
     let msg = ChainMessage::Signed(msg);
     let bz: Vec<u8> = MessageFactory::serialize(&msg)?;
+
     // Use the broadcast version which waits for basic checks to complete,
     // but not the execution results - those will have to be polled with get_transaction_receipt.
     let res: tx_sync::Response = data.tm().broadcast_tx_sync(bz).await?;
-    tracing::debug!(?sighash, eth_hash = ?msghash, tm_hash = ?res.hash, "received raw transaction");
     if res.code.is_ok() {
         // The following hash would be okay for ethers-rs,and we could use it to look up the TX with Tendermint,
         // but ethers.js would reject it because it doesn't match what Ethereum would use.

--- a/fendermint/testing/smoke-test/scripts/init.sh
+++ b/fendermint/testing/smoke-test/scripts/init.sh
@@ -43,6 +43,7 @@ fendermint \
 # Create some Ethereum accounts
 for NAME in emily eric; do
   fendermint key gen --out-dir $KEYS_DIR --name $NAME;
+  fendermint key into-eth --out-dir $KEYS_DIR --secret-key $KEYS_DIR/$NAME.sk --name $NAME-eth;
   fendermint \
     genesis --genesis-file $GENESIS_FILE \
     add-account --public-key $KEYS_DIR/$NAME.pk \

--- a/fendermint/vm/interpreter/src/fvm/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/exec.rs
@@ -117,6 +117,7 @@ where
             to = to.to_string(),
             method_num = method_num,
             exit_code = apply_ret.msg_receipt.exit_code.value(),
+            gas_used = apply_ret.msg_receipt.gas_used,
             "tx delivered"
         );
 


### PR DESCRIPTION
The initial estimation sets the gas limit to `BLOCK_GAS_LIMIT` which could result in "insufficient funds". This PR changes it to zero for the duration of `estimate_gassed_msg` and then restores it at the end.