### PR TITLE
FIX: Add an extra 2 rounds of delay before proposing a topdown finality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ build: | protoc
 	cargo build --release
 
 install:
-	cargo install --path fendermint/app
+	cargo install --locked --path fendermint/app
 
 # Using --release for testing because wasm can otherwise be slow.
 test: $(IPC_ACTORS_ABI) $(BUILTIN_ACTORS_BUNDLE) $(BUILTIN_ACTORS_DIR)

--- a/docker/builder.ci.Dockerfile
+++ b/docker/builder.ci.Dockerfile
@@ -84,4 +84,4 @@ RUN set -eux; \
   amd64) ARCH='x86_64'  ;; \
   arm64) ARCH='aarch64' ;; \
   esac; \
-  cargo install --root output --path fendermint/app --target ${ARCH}-unknown-linux-gnu
+  cargo install --locked --root output --path fendermint/app --target ${ARCH}-unknown-linux-gnu

--- a/docker/builder.local.Dockerfile
+++ b/docker/builder.local.Dockerfile
@@ -17,4 +17,4 @@ COPY . .
 RUN --mount=type=cache,target=target \
   --mount=type=cache,target=$RUSTUP_HOME,from=rust,source=$RUSTUP_HOME \
   --mount=type=cache,target=$CARGO_HOME,from=rust,source=$CARGO_HOME \
-  cargo install --root output --path fendermint/app
+  cargo install --locked --root output --path fendermint/app

--- a/docs/demos/milestone-1/fendermint-demo.sh
+++ b/docs/demos/milestone-1/fendermint-demo.sh
@@ -1,5 +1,5 @@
 #0
-cargo install --path fendermint/app
+cargo install --locked --path fendermint/app
 
 #1
 

--- a/fendermint/app/settings/src/lib.rs
+++ b/fendermint/app/settings/src/lib.rs
@@ -112,6 +112,10 @@ pub struct TopDownConfig {
     /// conservative and avoid other from rejecting the proposal because they don't see the
     /// height as final yet.
     pub chain_head_delay: BlockHeight,
+    /// The number of blocks on top of `chain_head_delay` to wait before proposing a height
+    /// as final on the parent chain, to avoid slight disagreements between validators whether
+    /// a block is final, or not just yet.
+    pub proposal_delay: BlockHeight,
     /// Parent syncing cron period, in seconds
     #[serde_as(as = "DurationSeconds<u64>")]
     pub polling_interval: Duration,

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -164,6 +164,7 @@ async fn run(settings: Settings) -> anyhow::Result<()> {
         let topdown_config = settings.ipc.topdown_config()?;
         let config = fendermint_vm_topdown::Config {
             chain_head_delay: topdown_config.chain_head_delay,
+            proposal_delay: topdown_config.proposal_delay,
             polling_interval: topdown_config.polling_interval,
             exponential_back_off: topdown_config.exponential_back_off,
             exponential_retry_limit: topdown_config.exponential_retry_limit,

--- a/fendermint/vm/topdown/src/finality/fetch.rs
+++ b/fendermint/vm/topdown/src/finality/fetch.rs
@@ -190,7 +190,7 @@ impl<T> CachedFinalityProvider<T> {
         committed_finality: Option<IPCParentFinality>,
         parent_client: Arc<T>,
     ) -> Self {
-        let inner = FinalityWithNull::new(genesis_epoch, committed_finality);
+        let inner = FinalityWithNull::new(genesis_epoch, config.proposal_delay, committed_finality);
         Self {
             inner,
             config,

--- a/fendermint/vm/topdown/src/finality/mod.rs
+++ b/fendermint/vm/topdown/src/finality/mod.rs
@@ -107,6 +107,7 @@ mod tests {
     fn new_provider() -> CachedFinalityProvider<MockedParentQuery> {
         let config = Config {
             chain_head_delay: 20,
+            proposal_delay: 0,
             polling_interval: Duration::from_secs(10),
             exponential_back_off: Duration::from_secs(10),
             exponential_retry_limit: 10,
@@ -277,6 +278,7 @@ mod tests {
     async fn test_top_down_msgs_works() {
         let config = Config {
             chain_head_delay: 2,
+            proposal_delay: 0,
             polling_interval: Duration::from_secs(10),
             exponential_back_off: Duration::from_secs(10),
             exponential_retry_limit: 10,

--- a/fendermint/vm/topdown/src/lib.rs
+++ b/fendermint/vm/topdown/src/lib.rs
@@ -39,6 +39,9 @@ pub struct Config {
     /// conservative and avoid other from rejecting the proposal because they don't see the
     /// height as final yet.
     pub chain_head_delay: BlockHeight,
+    /// Extra delay on top of `chain_head_delay` before proposing a height as final on the parent chain,
+    /// to avoid validator disagreeing by 1 height whether something is final or not just yet.
+    pub proposal_delay: BlockHeight,
     /// Parent syncing cron period, in seconds
     pub polling_interval: Duration,
     /// Top down exponential back off retry base

--- a/infra/Makefile.toml
+++ b/infra/Makefile.toml
@@ -37,6 +37,7 @@ PARENT_GATEWAY = { value = "0x56948d2CFaa2EF355B8C08Ac925202db212146D1", conditi
 PARENT_REGISTRY = { value = "0x6A4884D2B6A597792dC68014D4B7C117cca5668e", condition = { env_not_set = ["PARENT_REGISTRY"] } }
 FM_NETWORK = { value = "test", condition = { env_not_set = ["FM_NETWORK"] } }
 TOPDOWN_CHAIN_HEAD_DELAY = { value = "10", condition = { env_not_set = ["TOPDOWN_CHAIN_HEAD_DELAY"] } }
+TOPDOWN_PROPOSAL_DELAY = { value = "2", condition = { env_not_set = ["TOPDOWN_PROPOSAL_DELAY"] } }
 # Comma-separated list of bootstrap nodes to be used by the CometBFT node.
 BOOTSTRAPS = { value = "", condition = { env_not_set = ["BOOTSTRAPS"] } }
 PRIVATE_KEY_PATH = { value = "", condition = { env_not_set = ["PRIVATE_KEY_PATH"] } }

--- a/infra/scripts/fendermint.toml
+++ b/infra/scripts/fendermint.toml
@@ -3,7 +3,9 @@ extend = "fendermint-run"
 env = { "ENTRY" = "fendermint", "CMD" = "run", "FLAGS" = "-d" }
 
 [tasks.fendermint-pull]
-condition = { env_not_set = ["FM_PULL_SKIP"], fail_message = "Skipped pulling fendermint Docker image." }
+condition = { env_not_set = [
+  "FM_PULL_SKIP",
+], fail_message = "Skipped pulling fendermint Docker image." }
 script = """
   docker pull ghcr.io/consensus-shipyard/fendermint:${FM_DOCKER_TAG}
   docker tag ghcr.io/consensus-shipyard/fendermint:${FM_DOCKER_TAG} fendermint:${FM_DOCKER_TAG}
@@ -51,6 +53,7 @@ docker run \
   --env FM_CHAIN_NAME=${NETWORK_NAME} \
   --env FM_IPC__SUBNET_ID=${SUBNET_ID} \
   --env FM_IPC__TOPDOWN__CHAIN_HEAD_DELAY=${TOPDOWN_CHAIN_HEAD_DELAY} \
+  --env FM_IPC__TOPDOWN__PROPOSAL_DELAY=${TOPDOWN_PROPOSAL_DELAY} \
   --env FM_IPC__TOPDOWN__PARENT_HTTP_ENDPOINT=${PARENT_ENDPOINT} \
   --env FM_IPC__TOPDOWN__PARENT_REGISTRY=${PARENT_REGISTRY} \
   --env FM_IPC__TOPDOWN__PARENT_GATEWAY=${PARENT_GATEWAY} \
@@ -92,6 +95,7 @@ docker run \
   --env FM_CHAIN_NAME=${NETWORK_NAME} \
   --env FM_IPC__SUBNET_ID=${SUBNET_ID} \
   --env FM_IPC__TOPDOWN__CHAIN_HEAD_DELAY=${TOPDOWN_CHAIN_HEAD_DELAY} \
+  --env FM_IPC__TOPDOWN__PROPOSAL_DELAY=${TOPDOWN_PROPOSAL_DELAY} \
   --env FM_IPC__TOPDOWN__PARENT_HTTP_ENDPOINT=${PARENT_ENDPOINT} \
   --env FM_IPC__TOPDOWN__PARENT_REGISTRY=${PARENT_REGISTRY} \
   --env FM_IPC__TOPDOWN__PARENT_GATEWAY=${PARENT_GATEWAY} \


### PR DESCRIPTION
Adds an `FM_IPC__TOPDOWN__PROPOSAL_DELAY` env var with a value of 2 set by the docker container scripts as an example (I think this doesn't appear in `default.toml`), with the effect that blocks are proposed when they are `FM_IPC__TOPDOWN__CHAIN_HEAD_DELAY + FM_IPC__TOPDOWN__PROPOSAL_DELAY` deep, but accepted if they are `FM_IPC__TOPDOWN__CHAIN_HEAD_DELAY` deep, so there is an extra minute for parents to sync with each other, which might help avoid lost rounds in the subnet.