### PR TITLE
FM-365: Commit snapshot

### DIFF
--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -958,6 +958,15 @@ where
                         state.block_height = snapshot.manifest.block_height;
                         state.state_params = snapshot.manifest.state_params;
                         self.set_committed_state(state)?;
+
+                        // TODO: We can remove the `current_download` from the STM
+                        // state here which would cause it to get dropped from /tmp,
+                        // but for now let's keep it just in case we need to investigate
+                        // some problem.
+
+                        // We could also move the files into our own snapshot directory
+                        // so that we can offer it to others, but again let's hold on
+                        // until we have done more robust validation.
                     }
                     return Ok(response::ApplySnapshotChunk {
                         result: response::ApplySnapshotChunkResult::Accept,

--- a/fendermint/vm/interpreter/src/fvm/state/snapshot.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/snapshot.rs
@@ -193,6 +193,14 @@ where
 
         Ok((root_cid, streamer))
     }
+
+    pub fn block_height(&self) -> BlockHeight {
+        self.block_height
+    }
+
+    pub fn state_params(&self) -> &FvmStateParams {
+        &self.state_params
+    }
 }
 
 #[pin_project::pin_project]

--- a/fendermint/vm/interpreter/src/fvm/state/snapshot.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/snapshot.rs
@@ -9,7 +9,7 @@ use cid::Cid;
 use futures_core::Stream;
 use fvm::state_tree::StateTree;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_car::{load_car_unchecked, CarHeader};
+use fvm_ipld_car::{load_car, load_car_unchecked, CarHeader};
 use fvm_ipld_encoding::{from_slice, CborStore, DAG_CBOR};
 use libipld::Ipld;
 use serde::{Deserialize, Serialize};
@@ -61,10 +61,19 @@ where
     }
 
     /// Read the snapshot from file and load all the data into the store
-    pub async fn read_car(path: impl AsRef<Path>, store: BS) -> anyhow::Result<Self> {
+    pub async fn read_car(
+        path: impl AsRef<Path>,
+        store: BS,
+        validate: bool,
+    ) -> anyhow::Result<Self> {
         let file = tokio::fs::File::open(path).await?;
 
-        let roots = load_car_unchecked(&store, file.compat()).await?;
+        let roots = if validate {
+            load_car(&store, file.compat()).await?
+        } else {
+            load_car_unchecked(&store, file.compat()).await?
+        };
+
         if roots.len() != 1 {
             return Err(anyhow!("invalid snapshot, should have 1 root cid"));
         }
@@ -377,7 +386,7 @@ mod tests {
         assert!(r.is_ok());
 
         let new_store = MemoryBlockstore::new();
-        let Snapshot::V1(loaded_snapshot) = Snapshot::read_car(tmp_file.path(), new_store)
+        let Snapshot::V1(loaded_snapshot) = Snapshot::read_car(tmp_file.path(), new_store, true)
             .await
             .unwrap();
 

--- a/fendermint/vm/snapshot/src/client.rs
+++ b/fendermint/vm/snapshot/src/client.rs
@@ -1,7 +1,7 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::{sync::Arc, time::SystemTime};
+use std::{path::PathBuf, sync::Arc, time::SystemTime};
 
 use async_stm::{abort, Stm, StmResult, TVar};
 use fendermint_vm_interpreter::fvm::state::{
@@ -74,19 +74,20 @@ impl SnapshotClient {
 
     /// If the offered snapshot is accepted, we create a temporary directory to hold the chunks
     /// and remember it as our current snapshot being downloaded.
-    pub fn offer_snapshot(&self, manifest: SnapshotManifest) -> StmResult<(), SnapshotError> {
+    pub fn offer_snapshot(&self, manifest: SnapshotManifest) -> StmResult<PathBuf, SnapshotError> {
         if manifest.version != 1 {
             abort(SnapshotError::IncompatibleVersion(manifest.version))
         } else {
             match tempdir() {
                 Ok(dir) => {
+                    let download_path = dir.path().into();
                     let download = SnapshotDownload {
                         manifest,
                         download_dir: Arc::new(dir),
                         next_index: TVar::new(0),
                     };
                     self.state.current_download.write(Some(download))?;
-                    Ok(())
+                    Ok(download_path)
                 }
                 Err(e) => abort(SnapshotError::from(e))?,
             }
@@ -95,8 +96,15 @@ impl SnapshotClient {
 
     /// Take a chunk sent to us by a remote peer. This is our chance to validate chunks on the fly.
     ///
-    /// Return a flag indicating whether all the chunks have been received and loaded to the blockstore.
-    pub fn apply_chunk(&self, index: u32, contents: Vec<u8>) -> StmResult<bool, SnapshotError> {
+    /// Returns `None` while there are more chunks to download and  `Some` [SnapshotItem] when all
+    /// the chunks have been received and basic file integrity validated.
+    ///
+    /// Then we can call `import_snapshot` to actually load the snapshot into the blockstore.
+    pub fn save_chunk(
+        &self,
+        index: u32,
+        contents: Vec<u8>,
+    ) -> StmResult<Option<SnapshotItem>, SnapshotError> {
         if let Some(cd) = self.state.current_download.read()?.as_ref() {
             let next_index = cd.next_index.read_clone()?;
             if index != next_index {
@@ -119,8 +127,11 @@ impl SnapshotClient {
                             match manifest::parts_checksum(cd.download_dir.as_ref()) {
                                 Ok(checksum) => {
                                     if checksum == cd.manifest.checksum {
-                                        // TODO: Import Snapshot.
-                                        Ok(true)
+                                        let item = SnapshotItem::new(
+                                            cd.download_dir.path().into(),
+                                            cd.manifest.clone(),
+                                        );
+                                        Ok(Some(item))
                                     } else {
                                         abort(SnapshotError::WrongChecksum(
                                             cd.manifest.checksum,
@@ -134,7 +145,7 @@ impl SnapshotClient {
                                 ))),
                             }
                         } else {
-                            Ok(false)
+                            Ok(None)
                         }
                     }
                     Err(e) => {

--- a/fendermint/vm/snapshot/src/lib.rs
+++ b/fendermint/vm/snapshot/src/lib.rs
@@ -7,6 +7,15 @@ mod manager;
 mod manifest;
 mod state;
 
+/// The file name to export the CAR to.
+const SNAPSHOT_FILE_NAME: &str = "snapshot.car";
+
+/// The file name in snapshot directories that contains the manifest.
+const MANIFEST_FILE_NAME: &str = "manifest.json";
+
+/// Name of the subdirectory where `{idx}.part` files are stored within a snapshot.
+const PARTS_DIR_NAME: &str = "parts";
+
 pub use client::SnapshotClient;
 pub use error::SnapshotError;
 pub use manager::SnapshotManager;

--- a/fendermint/vm/snapshot/src/state.rs
+++ b/fendermint/vm/snapshot/src/state.rs
@@ -101,6 +101,33 @@ impl SnapshotItem {
         // 3. Remove the restored file.
         std::fs::remove_file(&car_path).context("failed to remove CAR file")?;
 
+        // If the import failed, or it fails to validate, it will leave unwanted data in the blockstore.
+        //
+        // We could do the import into a namespace which is separate from the state store, and move the data
+        // if everything we see what successful, but it would need more database API exposed that we don't
+        // currently have access to. At the moment our best bet to remove the data is to implement garbage
+        // collection - if the CIDs are unreachable through state roots, they will be removed.
+        //
+        // Another thing worth noting is that the `Snapshot` imports synthetic records into the blockstore
+        // that did not exist in the original: the metadata, an some technical constructs that point at
+        // the real data and store application state (which is verfied below). It's not easy to get rid
+        // of these: the `Blockstore` doesn't allow us to delete CIDs, and the `Snapshot` doesn't readily
+        // expose what the CIDs of the extra records were. Our other option would be to load the data
+        // into a staging area (see above) and then walk the DAG and only load what is reachable from
+        // the state root.
+        //
+        // Inserting CIDs into the state store which did not exist in the original seem like a vector
+        // of attack that could be used to cause consensus failure: if the attacker deployed a contract
+        // that looked up a CID that validators who imported a snapshot have, but others don't, that
+        // would cause a fork. However,  his is why the FVM doesn't currently allow the deployment of
+        // user defined Wasm actors: the FEVM actors do not allow the lookup of arbitrary CIDs, so they
+        // are safe, while Wasm actors with direct access to the IPLD SDK methods would be vulnerable.
+        // Once the FVM implements the "reachability analysis" feature, it won't matter if we have an
+        // extra record or not.
+        //
+        // Actually a very similar situation arises with garbage collection: since the length of history
+        // is configurable, whether some CIDs are (still) present or not depends on how the validator
+        // configured their nodes, and cannot be allowed to cause a failure.
         let snapshot = result.context("failed to import the snapshot into the blockstore")?;
 
         // 4. See if we actually imported what we thought we would.

--- a/fendermint/vm/snapshot/src/state.rs
+++ b/fendermint/vm/snapshot/src/state.rs
@@ -96,7 +96,7 @@ impl SnapshotItem {
         }
 
         // 2. Import the contents.
-        let result = Snapshot::read_car(&car_path, store).await;
+        let result = Snapshot::read_car(&car_path, store, validate).await;
 
         // 3. Remove the restored file.
         std::fs::remove_file(&car_path).context("failed to remove CAR file")?;


### PR DESCRIPTION
Closes #365 

* When the last chunk is saved we return a `SnapshotItem`
* The `SnapshotItem::import` is used to load the data into a blockstore and validate that the imported metadata matches.
* If successful the `App` state is updated to the manifest. 

Doesn't contain: 
* Tests, deferred to https://github.com/consensus-shipyard/fendermint/issues/363
* The clearing of the `/tmp` directory - we can still investigate the snapshot contents after we're done
* The offering of the imported snapshot for others - we'll offer the next snapshot we make, but not this, although we could if we copied the contents from `/tmp` to the persistent place
* Anything clever like importing the CAR file into a temporary namespace in RocksDB, or trying to _not_ import the artificial metadata field. This is a security vulnerability because we allow potentially bogus CIDs to enter the state store, which could lead to consensus failure if some smart contract computation depends on whether something is present or not.