### PR TITLE
FIX: script for multi-validator local deployment

### DIFF
--- a/infra/Makefile.toml
+++ b/infra/Makefile.toml
@@ -42,7 +42,7 @@ BOOTSTRAPS = { value = "", condition = { env_not_set = ["BOOTSTRAPS"] } }
 PRIVATE_KEY_PATH = { value = "", condition = { env_not_set = ["PRIVATE_KEY_PATH"] } }
 
 # Deployment-related
-BASE_DIR="${HOME}/.ipc/${NETWORK_NAME}"
+BASE_DIR="${HOME}/.ipc/${NETWORK_NAME}/${NODE_NAME}"
 FM_DIR="${BASE_DIR}/${NODE_NAME}/fendermint"
 CMT_DIR="${BASE_DIR}/${NODE_NAME}/cometbft"
 

--- a/infra/scripts/cometbft.toml
+++ b/infra/scripts/cometbft.toml
@@ -197,10 +197,18 @@ sed -i'' -e 's|^external_address = ""$|external_address = "{{PLACEHOLDER}}"|g' $
 sed -i'' -e "s/{{PLACEHOLDER}}/$CMT_EXTERNAL_ADDR/g" ${CMT_DIR}/config/config.toml
 """
 
+# This is required to run several validators locally. You may want to disable it when running
+# a real environment.
+[tasks.duplicate-ip-enable]
+script = """
+sed -i'' -e "s|allow_duplicate_ip = false|allow_duplicate_ip = true|" ${CMT_DIR}/config/config.toml
+"""
+
 [tasks.cometbft-config]
 dependencies = [
     "cometbft-init",
     "set-seeds",
     "addr-book-enable",
     "set-external-addr",
+    "duplicate-ip-enable",
 ]


### PR DESCRIPTION
Fixes a few bugs in the local infra scripts when using multi-validators where:
- The config directories for new validators where being overwritten by the new deployments. 
- If `allow_duplicate_ip` is not enabled, validators in the same network cannot connect to each other. 