### PR TITLE
Reset provider

### DIFF
--- a/fendermint/vm/topdown/src/sync/pointers.rs
+++ b/fendermint/vm/topdown/src/sync/pointers.rs
@@ -31,6 +31,11 @@ impl SyncPointers {
     pub fn set_tail(&mut self, height: BlockHeight, hash: BlockHash) {
         self.tail = Some((height, hash));
     }
+
+    pub fn reset(&mut self, head: BlockHeight) {
+        self.tail = None;
+        self.head = head;
+    }
 }
 
 impl Display for SyncPointers {

--- a/fendermint/vm/topdown/src/sync/syncer.rs
+++ b/fendermint/vm/topdown/src/sync/syncer.rs
@@ -102,7 +102,14 @@ where
             return Ok(());
         }
 
-        self.poll_next().await?;
+        match self.poll_next().await {
+            Ok(_) => {}
+            Err(Error::ParentChainReorgDetected) => {
+                tracing::warn!("potential reorg detected, clear cache and retry");
+                self.reset().await?;
+            }
+            Err(e) => return Err(anyhow!(e)),
+        }
 
         Ok(())
     }

--- a/fendermint/vm/topdown/src/sync/tendermint.rs
+++ b/fendermint/vm/topdown/src/sync/tendermint.rs
@@ -29,6 +29,7 @@ where
     pub async fn sync(&mut self) -> anyhow::Result<()> {
         if self.is_syncing_peer().await? {
             tracing::debug!("syncing with peer, skip parent finality syncing this round");
+            self.inner.reset().await?;
             return Ok(());
         }
         self.inner.sync().await


### PR DESCRIPTION
We should reset provider, i.e. clean cache, reset last committed and polling trackers after syncing with peer and also a potential reorg.

For potential reorg, we had this for block height check but not after block hashes are different. We should reset syncer and try from scratch (what else can we do beside crashing app).

After peer syncing, we need to reset provider because with peer syncing, we might have the last committed finality way ahead of the cache polled heights. Clean cache and restart syncer will make sure syncer is up to date.