### PR TITLE
FIX: Do not fail if status doesn't respond in the interpreter

### DIFF
--- a/fendermint/vm/interpreter/src/fvm/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/exec.rs
@@ -141,7 +141,7 @@ where
             // Asynchronously broadcast signature, if validating.
             if let Some(ref ctx) = self.validator_ctx {
                 // Do not resend past signatures.
-                if !self.syncing().await? {
+                if !self.syncing().await {
                     // Fetch any incomplete checkpoints synchronously because the state can't be shared across threads.
                     let incomplete_checkpoints =
                         checkpoint::unsigned_checkpoints(&self.gateway, &mut state, ctx.public_key)


### PR DESCRIPTION
Follow up for https://github.com/consensus-shipyard/fendermint/pull/426

I missed this part when making that change: it still tries to connect to CometBFT in `end_block`. This change ignores any error as a synonym for catching up.