### PR TITLE
FM-427: HybridClient

### DIFF
--- a/fendermint/app/options/src/eth.rs
+++ b/fendermint/app/options/src/eth.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use clap::{Args, Subcommand};
-use tendermint_rpc::Url;
+use tendermint_rpc::{Url, WebSocketClientUrl};
 
 #[derive(Args, Debug)]
 pub struct EthArgs {
@@ -18,19 +18,19 @@ pub enum EthCommands {
         #[arg(
             long,
             short,
+            default_value = "http://127.0.0.1:26657",
+            env = "TENDERMINT_RPC_URL"
+        )]
+        http_url: Url,
+
+        /// The URL of the Tendermint node's WebSocket endpoint.
+        #[arg(
+            long,
+            short,
             default_value = "ws://127.0.0.1:26657/websocket",
             env = "TENDERMINT_WS_URL"
         )]
-        url: Url,
-
-        /// An optional HTTP/S proxy through which to submit requests to the
-        /// Tendermint node's RPC endpoint.
-        #[arg(long)]
-        proxy_url: Option<Url>,
-
-        /// Maximum number of times to try to connect to the websocket.
-        #[arg(long, short = 'r', default_value = "5")]
-        connect_max_retries: usize,
+        ws_url: WebSocketClientUrl,
 
         /// Seconds to wait between trying to connect to the websocket.
         #[arg(long, short = 'd', default_value = "5")]

--- a/fendermint/eth/api/Cargo.toml
+++ b/fendermint/eth/api/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 axum = { workspace = true }
 ethers-core = { workspace = true }
 erased-serde = { workspace = true }

--- a/fendermint/eth/api/src/apis/mod.rs
+++ b/fendermint/eth/api/src/apis/mod.rs
@@ -4,9 +4,9 @@
 // See https://ethereum.org/en/developers/docs/apis/json-rpc/#json-rpc-methods
 // and https://ethereum.github.io/execution-apis/api-documentation/
 
+use crate::HybridClient;
 use jsonrpc_v2::{MapRouter, ServerBuilder};
 use paste::paste;
-use tendermint_rpc::WebSocketClient;
 
 mod eth;
 mod net;
@@ -18,7 +18,7 @@ macro_rules! with_methods {
             $server
                 $(.with_method(
                     stringify!([< $module _ $method >]),
-                    $module :: [< $method:snake >] ::<WebSocketClient>
+                    $module :: [< $method:snake >] ::<HybridClient>
                 ))*
         }
     };

--- a/fendermint/eth/api/src/client.rs
+++ b/fendermint/eth/api/src/client.rs
@@ -1,0 +1,193 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::{pin::Pin, time::Duration};
+
+use anyhow::Context;
+use async_trait::async_trait;
+use fendermint_rpc::client::{http_client, ws_client};
+use futures::Future;
+use tendermint_rpc::{
+    error::ErrorDetail, query::Query, Client, Error, HttpClient, SimpleRequest, Subscription,
+    SubscriptionClient, Url, WebSocketClient, WebSocketClientDriver, WebSocketClientUrl,
+};
+
+/// A mixed HTTP and WebSocket client. Uses HTTP to perform all
+/// the JSON-RPC requests except the ones which require subscription,
+/// which go through a WebSocket client.
+///
+/// The WebSocket client is expected to lose connection with CometBFT,
+/// in which case it will be re-established in the background.
+///
+/// Existing subscriptions should receive an error and they can try
+/// re-subscribing through the Ethereum API facade, which should create
+/// new subscriptions through a fresh CometBFT client.
+#[derive(Clone)]
+pub struct HybridClient {
+    http_client: HttpClient,
+    cmd_tx: tokio::sync::mpsc::UnboundedSender<DriverCommand>,
+}
+
+pub struct HybridClientDriver {
+    ws_url: WebSocketClientUrl,
+    retry_delay: Duration,
+    cmd_rx: tokio::sync::mpsc::UnboundedReceiver<DriverCommand>,
+}
+
+enum DriverCommand {
+    Subscribe(
+        Query,
+        tokio::sync::oneshot::Sender<Result<Subscription, Error>>,
+    ),
+    Unsubscribe(Query, tokio::sync::oneshot::Sender<Result<(), Error>>),
+    Close,
+}
+
+impl HybridClient {
+    pub fn new(
+        http_url: Url,
+        ws_url: WebSocketClientUrl,
+        retry_delay: Duration,
+    ) -> anyhow::Result<(Self, HybridClientDriver)> {
+        let http_client =
+            http_client(http_url, None).context("failed to create Tendermint client")?;
+
+        let (cmd_tx, cmd_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let client = Self {
+            http_client,
+            cmd_tx,
+        };
+
+        let driver = HybridClientDriver {
+            ws_url,
+            retry_delay,
+            cmd_rx,
+        };
+
+        Ok((client, driver))
+    }
+}
+
+#[async_trait]
+impl Client for HybridClient {
+    async fn perform<R>(&self, request: R) -> Result<R::Output, Error>
+    where
+        R: SimpleRequest,
+    {
+        self.http_client.perform(request).await
+    }
+}
+
+#[async_trait]
+impl SubscriptionClient for HybridClient {
+    async fn subscribe(&self, query: Query) -> Result<Subscription, Error> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        self.cmd_tx
+            .send(DriverCommand::Subscribe(query, tx))
+            .map_err(|_| Error::channel_send())?;
+
+        rx.await
+            .map_err(|e| Error::client_internal(e.to_string()))?
+    }
+
+    async fn unsubscribe(&self, query: Query) -> Result<(), Error> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        self.cmd_tx
+            .send(DriverCommand::Unsubscribe(query, tx))
+            .map_err(|_| Error::channel_send())?;
+
+        rx.await
+            .map_err(|e| Error::client_internal(e.to_string()))?
+    }
+
+    fn close(self) -> Result<(), Error> {
+        self.cmd_tx
+            .send(DriverCommand::Close)
+            .map_err(|_| Error::channel_send())
+    }
+}
+
+impl HybridClientDriver {
+    pub async fn run(mut self) {
+        let mut client = self.ws_client().await;
+
+        while let Some(cmd) = self.cmd_rx.recv().await {
+            match cmd {
+                DriverCommand::Subscribe(query, tx) => {
+                    client = self
+                        .send_loop(client, tx, |client| {
+                            let query = query.clone();
+                            Box::pin(async move { client.subscribe(query.clone()).await })
+                        })
+                        .await;
+                }
+                DriverCommand::Unsubscribe(query, tx) => {
+                    client = self
+                        .send_loop(client, tx, |client| {
+                            let query = query.clone();
+                            Box::pin(async move { client.unsubscribe(query.clone()).await })
+                        })
+                        .await;
+                }
+                DriverCommand::Close => {
+                    break;
+                }
+            }
+        }
+        let _ = client.close();
+    }
+
+    /// Try to send something to the socket. If it fails, reconnect and send again.
+    async fn send_loop<F, T>(
+        &self,
+        mut client: WebSocketClient,
+        tx: tokio::sync::oneshot::Sender<Result<T, Error>>,
+        f: F,
+    ) -> WebSocketClient
+    where
+        F: Fn(WebSocketClient) -> Pin<Box<dyn Future<Output = Result<T, Error>> + Send>>,
+    {
+        loop {
+            match f(client.clone()).await {
+                Err(e) if matches!(e.detail(), ErrorDetail::ChannelSend(_)) => {
+                    client = self.ws_client().await;
+                }
+                res => {
+                    let _ = tx.send(res);
+                    return client;
+                }
+            }
+        }
+    }
+
+    /// Connect to the WebSocket and start the driver, returning the client.
+    async fn ws_client(&self) -> WebSocketClient {
+        let (client, driver) = self.ws_connect().await;
+        tokio::spawn(async move { driver.run().await });
+        client
+    }
+
+    /// Try connecting repeatedly until it succeeds.
+    async fn ws_connect(&self) -> (WebSocketClient, WebSocketClientDriver) {
+        let url: Url = self.ws_url.clone().into();
+        loop {
+            match ws_client(url.clone()).await {
+                Ok(cd) => {
+                    return cd;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = e.to_string(),
+                        url = url.to_string(),
+                        "failed to connect to Tendermint WebSocket; retrying in {}s...",
+                        self.retry_delay.as_secs()
+                    );
+                    tokio::time::sleep(self.retry_delay).await;
+                }
+            }
+        }
+    }
+}

--- a/fendermint/rpc/src/client.rs
+++ b/fendermint/rpc/src/client.rs
@@ -1,6 +1,7 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::fmt::Display;
 use std::marker::PhantomData;
 
 use anyhow::{anyhow, Context};
@@ -9,7 +10,7 @@ use fendermint_vm_message::chain::ChainMessage;
 use tendermint::abci::response::DeliverTx;
 use tendermint::block::Height;
 use tendermint_rpc::{endpoint::abci_query::AbciQuery, Client, HttpClient, Scheme, Url};
-use tendermint_rpc::{WebSocketClient, WebSocketClientDriver};
+use tendermint_rpc::{WebSocketClient, WebSocketClientDriver, WebSocketClientUrl};
 
 use fendermint_vm_message::query::{FvmQuery, FvmQueryHeight};
 
@@ -70,7 +71,10 @@ pub fn http_client(url: Url, proxy_url: Option<Url>) -> anyhow::Result<HttpClien
 /// Create a Tendermint WebSocket client.
 ///
 /// The caller must start the driver in a background task.
-pub async fn ws_client(url: Url) -> anyhow::Result<(WebSocketClient, WebSocketClientDriver)> {
+pub async fn ws_client<U>(url: U) -> anyhow::Result<(WebSocketClient, WebSocketClientDriver)>
+where
+    U: TryInto<WebSocketClientUrl, Error = tendermint_rpc::Error> + Display + Clone,
+{
     // TODO: Doesn't handle proxy.
     tracing::debug!("Using WS client to submit request to: {}", url);
 

--- a/fendermint/testing/smoke-test/Makefile.toml
+++ b/fendermint/testing/smoke-test/Makefile.toml
@@ -22,7 +22,7 @@ env_files = [
 
 [tasks.test]
 clear = true
-dependencies = ["simplecoin-example", "ethapi-example"]
+dependencies = ["simplecoin-example", "ethers-example"]
 
 
 [tasks.simplecoin-example]
@@ -35,7 +35,7 @@ cargo run -p fendermint_rpc --release --example simplecoin -- \
 """
 
 
-[tasks.ethapi-example]
+[tasks.ethers-example]
 script = """
 cd ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}
 cargo run -p fendermint_eth_api --release --example ethers -- \

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -44,6 +44,7 @@ services:
     image: "fendermint:latest"
     command: "eth run"
     environment:
+      - TENDERMINT_RPC_URL=http://cometbft-node${NODE_ID}:26657
       - TENDERMINT_WS_URL=ws://cometbft-node${NODE_ID}:26657/websocket
       - LOG_LEVEL=debug
       - RUST_BACKTRACE=1

--- a/infra/scripts/ethapi.toml
+++ b/infra/scripts/ethapi.toml
@@ -7,6 +7,7 @@ docker run \
   --user $(id -u) \
   --network ${NETWORK_NAME} \
   --publish ${ETHAPI_HOST_PORT}:8545 \
+  --env TENDERMINT_RPC_URL=http://${CMT_CONTAINER_NAME}:26657 \
   --env TENDERMINT_WS_URL=ws://${CMT_CONTAINER_NAME}:26657/websocket \
   --env LOG_LEVEL=${ETHAPI_LOG_LEVEL} \
   --env RUST_BACKTRACE=1 \


### PR DESCRIPTION
Fixes #427 

Replaces the use of the `WebSocketClient` in the Ethereum API facade with a new `HybridClient` that wraps it and uses a normal `HttpClient` as well as a `WebSocketClient` under the hood. The former should be more resilient as it doesn't maintain a persistent connection with CometBFT, while the latter is managed by a `HybridClientDriver` that reconnects if it encounters the `"failed to send to internal channel"` error.

With this solution the `ethapi` container should heal itself and doesn't need to be restarted. In the event of the CometBFT connection being dropped, the active WebSocket subscriptions from our own clients should get an error when they try to consume the data, resulting in those connections being closed, forcing them to re-subscribe.