### PR TITLE
FIX: to_eth_transaction set wrong input bytes

### DIFF
--- a/fendermint/testing/smoke-test/Makefile.toml
+++ b/fendermint/testing/smoke-test/Makefile.toml
@@ -20,6 +20,14 @@ env_files = [
   { path = "../scripts/ci.env", profile = "ci" },
 ]
 
+[tasks.test-data-env]
+script = """
+cat << EOF > ${TEST_DATA_DIR}/.env
+CMT_P2P_MAX_NUM_OUTBOUND_PEERS=0
+CMT_CONSENSUS_TIMEOUT_COMMIT=1s
+EOF
+"""
+
 [tasks.test]
 clear = true
 dependencies = ["simplecoin-example", "ethapi-example"]

--- a/fendermint/vm/message/src/conv/from_fvm.rs
+++ b/fendermint/vm/message/src/conv/from_fvm.rs
@@ -211,7 +211,8 @@ pub mod tests {
     fn prop_to_and_from_eth_transaction(msg: EthMessage, chain_id: u64) {
         let chain_id = ChainID::from(chain_id);
         let msg0 = msg.0;
-        let tx = to_eth_typed_transaction(&msg0, &chain_id).expect("to_eth_transaction failed");
+        let tx =
+            to_eth_typed_transaction(&msg0, &chain_id).expect("to_eth_typed_transaction failed");
         let tx = tx.as_eip1559_ref().expect("not an eip1559 transaction");
         let msg1 = to_fvm_message(tx).expect("to_fvm_message failed");
 
@@ -226,7 +227,8 @@ pub mod tests {
 
         let chain_id = ChainID::from(chain_id);
         let msg0 = msg.0;
-        let tx = to_eth_typed_transaction(&msg0, &chain_id).expect("to_eth_transaction failed");
+        let tx =
+            to_eth_typed_transaction(&msg0, &chain_id).expect("to_eth_typed_transaction failed");
 
         let wallet: Wallet<SigningKey> = Wallet::from_bytes(key_pair.sk.serialize().as_ref())
             .expect("failed to create wallet")

--- a/fendermint/vm/message/src/conv/from_fvm.rs
+++ b/fendermint/vm/message/src/conv/from_fvm.rs
@@ -7,7 +7,6 @@ use std::str::FromStr;
 
 use anyhow::anyhow;
 use ethers_core::types as et;
-use ethers_core::types::transaction::eip2718::TypedTransaction;
 use fendermint_crypto::{RecoveryId, Signature};
 use fendermint_vm_actor_interface::eam::EthAddress;
 use fendermint_vm_actor_interface::eam::EAM_ACTOR_ID;
@@ -94,11 +93,11 @@ pub fn to_eth_signature(sig: &FvmSignature, normalized: bool) -> anyhow::Result<
     Ok(sig)
 }
 
-/// Turn an FVM `Message` back into an Ethereum transaction request, mainly for signature checking.
-pub fn to_eth_typed_transaction(
+/// Turn an FVM `Message` back into an Ethereum transaction request.
+pub fn to_eth_transaction_request(
     msg: &Message,
     chain_id: &ChainID,
-) -> anyhow::Result<TypedTransaction> {
+) -> anyhow::Result<et::Eip1559TransactionRequest> {
     let chain_id: u64 = (*chain_id).into();
 
     let Message {
@@ -134,7 +133,7 @@ pub fn to_eth_typed_transaction(
         tx.value = Some(to_eth_tokens(value)?);
     }
 
-    Ok(tx.into())
+    Ok(tx)
 }
 
 #[cfg(test)]
@@ -158,7 +157,7 @@ pub mod tests {
         tests::{EthMessage, KeyPair},
     };
 
-    use super::{to_eth_signature, to_eth_tokens, to_eth_typed_transaction};
+    use super::{to_eth_signature, to_eth_tokens, to_eth_transaction_request};
 
     #[quickcheck]
     fn prop_to_eth_tokens(tokens: ArbTokenAmount) -> bool {
@@ -211,10 +210,9 @@ pub mod tests {
     fn prop_to_and_from_eth_transaction(msg: EthMessage, chain_id: u64) {
         let chain_id = ChainID::from(chain_id);
         let msg0 = msg.0;
-        let tx =
-            to_eth_typed_transaction(&msg0, &chain_id).expect("to_eth_typed_transaction failed");
-        let tx = tx.as_eip1559_ref().expect("not an eip1559 transaction");
-        let msg1 = to_fvm_message(tx).expect("to_fvm_message failed");
+        let tx = to_eth_transaction_request(&msg0, &chain_id)
+            .expect("to_eth_transaction_request failed");
+        let msg1 = to_fvm_message(&tx).expect("to_fvm_message failed");
 
         assert_eq!(msg1, msg0)
     }
@@ -227,8 +225,9 @@ pub mod tests {
 
         let chain_id = ChainID::from(chain_id);
         let msg0 = msg.0;
-        let tx =
-            to_eth_typed_transaction(&msg0, &chain_id).expect("to_eth_typed_transaction failed");
+        let tx: TypedTransaction = to_eth_transaction_request(&msg0, &chain_id)
+            .expect("to_eth_transaction_request failed")
+            .into();
 
         let wallet: Wallet<SigningKey> = Wallet::from_bytes(key_pair.sk.serialize().as_ref())
             .expect("failed to create wallet")

--- a/fendermint/vm/message/src/signed.rs
+++ b/fendermint/vm/message/src/signed.rs
@@ -158,8 +158,10 @@ impl SignedMessage {
         chain_id: &ChainID,
     ) -> Result<Option<DomainHash>, SignedMessageError> {
         if maybe_eth_address(&self.message.from).is_some() {
-            let tx = from_fvm::to_eth_transaction_request(self.message(), chain_id)
-                .map_err(SignedMessageError::Ethereum)?;
+            let tx: TypedTransaction =
+                from_fvm::to_eth_transaction_request(self.message(), chain_id)
+                    .map_err(SignedMessageError::Ethereum)?
+                    .into();
 
             let sig = from_fvm::to_eth_signature(self.signature(), true)
                 .map_err(SignedMessageError::Ethereum)?;

--- a/fendermint/vm/message/src/signed.rs
+++ b/fendermint/vm/message/src/signed.rs
@@ -6,6 +6,7 @@ use anyhow::anyhow;
 use cid::multihash::MultihashDigest;
 use cid::Cid;
 use ethers_core::types as et;
+use ethers_core::types::transaction::eip2718::TypedTransaction;
 use fendermint_crypto::SecretKey;
 use fendermint_vm_actor_interface::{eam, evm};
 use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
@@ -41,6 +42,7 @@ pub enum SignedMessageError {
 /// which use a different algorithm than Ethereum.
 ///
 /// We can potentially extend this list to include CID based indexing.
+#[derive(Debug, Clone)]
 pub enum DomainHash {
     Eth([u8; 32]),
 }
@@ -104,8 +106,9 @@ impl SignedMessage {
         // work with regular accounts.
         match maybe_eth_address(&message.from) {
             Some(addr) => {
-                let tx = from_fvm::to_eth_typed_transaction(message, chain_id)
-                    .map_err(SignedMessageError::Ethereum)?;
+                let tx: TypedTransaction = from_fvm::to_eth_transaction_request(message, chain_id)
+                    .map_err(SignedMessageError::Ethereum)?
+                    .into();
 
                 Ok(Signable::Ethereum((tx.sighash(), addr)))
             }
@@ -155,7 +158,7 @@ impl SignedMessage {
         chain_id: &ChainID,
     ) -> Result<Option<DomainHash>, SignedMessageError> {
         if maybe_eth_address(&self.message.from).is_some() {
-            let tx = from_fvm::to_eth_typed_transaction(self.message(), chain_id)
+            let tx = from_fvm::to_eth_transaction_request(self.message(), chain_id)
                 .map_err(SignedMessageError::Ethereum)?;
 
             let sig = from_fvm::to_eth_signature(self.signature(), true)


### PR DESCRIPTION
Fixes https://github.com/consensus-shipyard/fendermint/issues/351

The `RawBytes` type from `fvm_ipld_encoding` strikes again. Unlike in `to_eth_typed_transaction`, in `to_eth_transaction` I forgot that `Message::params` contains IPLD bytes that have to be decoded to get rid of the length prefix. The result was that the `Transaction::input` field returned from the Ethereum API did not match the `Eip1559TranasctionRequest::data` field the client sent, it was wrapped as an IPLD byte vector. This gets me every time :disappointed: 